### PR TITLE
feat: add module registry system for loading Ludus definitions from GitHub

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -554,12 +554,151 @@ interface EditorState {
 
 ---
 
-## 11. 次のアクション
+## 11. モジュールレジストリ設計 (GitHub連携)
+
+### 11.1 概要
+
+GitHubリポジトリをソースとしてLudusモジュール定義ファイル（Markdown）をクローン・パースし、
+プロジェクトのコンポーネントとしてアクターにアタッチできる仕組み。
+
+```
+┌────────────────────────────────────────────────────┐
+│  GitHub Repository (モジュール定義ソース)            │
+│  ├── modules/scene-manager.md                      │
+│  ├── modules/node-editor.md                        │
+│  └── modules/component-picker.md                   │
+└──────────────┬─────────────────────────────────────┘
+               │ git clone / pull
+               ▼
+┌────────────────────────────────────────────────────┐
+│  Rust Backend (Tauri Commands)                     │
+│  ├── GitCloneService    … リポジトリのclone/pull   │
+│  ├── ModuleParser       … Markdownの構造化パース    │
+│  └── ModuleRegistry     … ソース・モジュール管理    │
+├────────────────────────────────────────────────────┤
+│  ローカルキャッシュ                                  │
+│  ~/.ludas-composer/module-cache/                    │
+│  ├── github.com/user/repo/  (クローン済みリポ)     │
+│  └── registry.json          (レジストリ設定)       │
+└──────────────┬─────────────────────────────────────┘
+               │ Tauri invoke
+               ▼
+┌────────────────────────────────────────────────────┐
+│  React Frontend                                    │
+│  ├── moduleRegistryStore (Zustand)                 │
+│  │   ├── sources[]        … 登録済みリポジトリ     │
+│  │   ├── modules[]        … パース済みモジュール   │
+│  │   ├── addSource()      … ソース追加             │
+│  │   ├── syncSource()     … 同期実行               │
+│  │   └── filteredModules()… 検索・フィルタ         │
+│  ├── ModuleRegistryPanel  … ソース管理UI           │
+│  └── ComponentPicker      … モジュール→アクター    │
+│      └── moduleToComponent() でインポート          │
+└────────────────────────────────────────────────────┘
+```
+
+### 11.2 Markdownパースフォーマット
+
+plan.md セクション8のモジュール定義書フォーマットをそのまま解析対象とする:
+
+```markdown
+### {モジュール名} [モジュール定義]
+
+#### 概要
+{概要テキスト}
+
+#### カテゴリ
+{UI | Logic | System | GameObject}
+
+#### 所属ドメイン
+{ドメイン名}
+
+#### 必要なデータ
+- {データ項目1}
+- {データ項目2}
+
+#### 変数
+- {変数名}: {説明}
+- {変数名} ({型}): {説明}
+
+#### 依存
+- {依存先名1}
+- {依存先名2}
+
+#### 作業
+##### 入力
+- {入力ポート説明}
+
+##### 出力
+- {出力ポート説明}
+
+##### タスク
+- {タスク名}: {処理内容の説明}
+
+#### テスト
+- {テストケースの説明}
+```
+
+### 11.3 Tauri Commands (API)
+
+| コマンド | パラメータ | 返り値 | 説明 |
+|---------|-----------|--------|------|
+| `add_registry_source` | name, repo_url, definition_glob? | ModuleRegistrySource | GitHubリポジトリをソース登録 |
+| `remove_registry_source` | source_id | void | ソース削除 |
+| `sync_registry_source` | source_id | ModuleDefinition[] | clone/pull + パース実行 |
+| `sync_all_sources` | - | ModuleDefinition[] | 全ソース同期 |
+| `get_all_modules` | - | ModuleDefinition[] | 全モジュール取得 |
+| `get_modules_by_category` | category | ModuleDefinition[] | カテゴリフィルタ |
+| `search_modules` | query | ModuleDefinition[] | 名前・概要・ドメイン検索 |
+| `get_registry_sources` | - | ModuleRegistrySource[] | 全ソース取得 |
+| `get_module_by_id` | module_id | ModuleDefinition | ID指定取得 |
+
+### 11.4 アクターへのアタッチフロー
+
+1. **ソース登録**: ユーザーがGitHubリポジトリURLを入力し、`addSource()` でレジストリに登録
+2. **同期**: `syncSource()` でリポジトリをclone/pullし、Markdown定義ファイルをパース
+3. **モジュール選択**: ComponentPickerにレジストリのモジュール一覧が表示される
+4. **インポート**: 選択したモジュールを `moduleToComponent()` でComponentに変換
+5. **アタッチ**: 変換されたComponentをアクターの `components[]` に追加
+
+### 11.5 ファイル構成
+
+```
+src-tauri/src/
+├── models/
+│   ├── module_definition.rs   # ModuleDefinition, ModuleRegistry等
+│   └── mod.rs
+├── services/
+│   ├── git_clone.rs           # GitCloneService (git2ベース)
+│   ├── module_parser.rs       # Markdownパーサー (regexベース)
+│   ├── module_registry.rs     # ModuleRegistryService (統合管理)
+│   └── mod.rs
+├── commands/
+│   ├── module_registry.rs     # Tauriコマンド定義
+│   └── mod.rs
+├── lib.rs                     # Tauriアプリ起動・コマンド登録
+└── main.rs
+
+src/
+├── types/
+│   ├── domain.ts              # Actor, Component, moduleToComponent()
+│   ├── module-registry.ts     # ModuleDefinition, ModuleRegistrySource
+│   └── index.ts
+├── services/
+│   └── module-registry-api.ts # Tauri invoke ラッパー
+└── stores/
+    └── moduleRegistryStore.ts # Zustandストア
+```
+
+---
+
+## 12. 次のアクション
 
 この設計書の承認後、以下の順序で実装を進める：
 
 1. **Phase 0**: `create-tauri-app` でプロジェクト雛形を生成し、依存パッケージをインストール
 2. **types/domain.ts**: ドメインモデル型定義を最初に確定
 3. **stores/**: Zustandストアを先行実装 (UIなしでテスト可能)
-4. **Phase 1-4**: 各フェーズを順次実装
-5. 各フェーズ完了時にモジュール定義書のテスト項目でセルフチェック
+4. **モジュールレジストリ**: GitHubリポジトリからのモジュール定義読み込み機能（実装済み）
+5. **Phase 1-4**: 各フェーズを順次実装
+6. 各フェーズ完了時にモジュール定義書のテスト項目でセルフチェック

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ludas-composer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "2", features = [] }
+tauri-plugin-shell = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+git2 = "0.19"
+regex = "1"
+uuid = { version = "1", features = ["v4"] }
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+dirs = "6"
+walkdir = "2"
+
+[lib]
+name = "ludas_composer_lib"
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod module_registry;
+
+pub use module_registry::*;

--- a/src-tauri/src/commands/module_registry.rs
+++ b/src-tauri/src/commands/module_registry.rs
@@ -1,0 +1,160 @@
+use crate::models::*;
+use crate::services::ModuleRegistryService;
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use tauri::State;
+
+/// Tauriが管理するレジストリサービスの状態
+pub struct RegistryState(pub Mutex<ModuleRegistryService>);
+
+/// レジストリソース追加のパラメータ
+#[derive(Debug, Deserialize)]
+pub struct AddSourceParams {
+    pub name: String,
+    pub repo_url: String,
+    pub definition_glob: Option<String>,
+}
+
+/// コマンド結果
+#[derive(Debug, Serialize)]
+pub struct CommandResult<T: Serialize> {
+    pub success: bool,
+    pub data: Option<T>,
+    pub error: Option<String>,
+}
+
+impl<T: Serialize> CommandResult<T> {
+    fn ok(data: T) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    fn err(msg: String) -> Self {
+        Self {
+            success: false,
+            data: None,
+            error: Some(msg),
+        }
+    }
+}
+
+/// レジストリソース（GitHubリポジトリ）を追加
+#[tauri::command]
+pub fn add_registry_source(
+    state: State<'_, RegistryState>,
+    params: AddSourceParams,
+) -> CommandResult<ModuleRegistrySource> {
+    let mut registry = state.0.lock().unwrap();
+    let glob = params.definition_glob.unwrap_or_else(|| "**/*.md".to_string());
+
+    match registry.add_source(&params.name, &params.repo_url, &glob) {
+        Ok(source) => CommandResult::ok(source.clone()),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+/// レジストリソースを削除
+#[tauri::command]
+pub fn remove_registry_source(
+    state: State<'_, RegistryState>,
+    source_id: String,
+) -> CommandResult<()> {
+    let mut registry = state.0.lock().unwrap();
+    match registry.remove_source(&source_id) {
+        Ok(()) => CommandResult::ok(()),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+/// 指定ソースを同期（clone/pull + 定義パース）
+#[tauri::command]
+pub fn sync_registry_source(
+    state: State<'_, RegistryState>,
+    source_id: String,
+) -> CommandResult<Vec<ModuleDefinition>> {
+    let mut registry = state.0.lock().unwrap();
+    match registry.sync_source(&source_id) {
+        Ok(modules) => CommandResult::ok(modules),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+/// 全ソースを同期
+#[tauri::command]
+pub fn sync_all_sources(
+    state: State<'_, RegistryState>,
+) -> CommandResult<Vec<ModuleDefinition>> {
+    let mut registry = state.0.lock().unwrap();
+    match registry.sync_all() {
+        Ok(modules) => CommandResult::ok(modules),
+        Err(e) => CommandResult::err(e.to_string()),
+    }
+}
+
+/// 全モジュール定義を取得
+#[tauri::command]
+pub fn get_all_modules(
+    state: State<'_, RegistryState>,
+) -> CommandResult<Vec<ModuleDefinition>> {
+    let registry = state.0.lock().unwrap();
+    CommandResult::ok(registry.get_all_modules().to_vec())
+}
+
+/// カテゴリでモジュールをフィルタ
+#[tauri::command]
+pub fn get_modules_by_category(
+    state: State<'_, RegistryState>,
+    category: String,
+) -> CommandResult<Vec<ModuleDefinition>> {
+    let registry = state.0.lock().unwrap();
+    let cat = match ModuleCategory::from_str(&category) {
+        Some(c) => c,
+        None => return CommandResult::err(format!("Invalid category: {}", category)),
+    };
+    let modules: Vec<ModuleDefinition> = registry
+        .get_modules_by_category(&cat)
+        .into_iter()
+        .cloned()
+        .collect();
+    CommandResult::ok(modules)
+}
+
+/// モジュールを検索
+#[tauri::command]
+pub fn search_modules(
+    state: State<'_, RegistryState>,
+    query: String,
+) -> CommandResult<Vec<ModuleDefinition>> {
+    let registry = state.0.lock().unwrap();
+    let modules: Vec<ModuleDefinition> = registry
+        .search_modules(&query)
+        .into_iter()
+        .cloned()
+        .collect();
+    CommandResult::ok(modules)
+}
+
+/// 全ソースを取得
+#[tauri::command]
+pub fn get_registry_sources(
+    state: State<'_, RegistryState>,
+) -> CommandResult<Vec<ModuleRegistrySource>> {
+    let registry = state.0.lock().unwrap();
+    CommandResult::ok(registry.get_sources().to_vec())
+}
+
+/// IDでモジュールを取得
+#[tauri::command]
+pub fn get_module_by_id(
+    state: State<'_, RegistryState>,
+    module_id: String,
+) -> CommandResult<ModuleDefinition> {
+    let registry = state.0.lock().unwrap();
+    match registry.get_module(&module_id) {
+        Some(m) => CommandResult::ok(m.clone()),
+        None => CommandResult::err(format!("Module not found: {}", module_id)),
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,33 @@
+pub mod commands;
+pub mod models;
+pub mod services;
+
+use commands::module_registry::RegistryState;
+use services::ModuleRegistryService;
+use std::sync::Mutex;
+
+/// Tauriアプリケーションの実行
+pub fn run() {
+    let registry_service = ModuleRegistryService::with_defaults()
+        .unwrap_or_else(|_| {
+            let cache_dir = std::env::temp_dir().join("ludas-composer").join("module-cache");
+            ModuleRegistryService::new(cache_dir)
+        });
+
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .manage(RegistryState(Mutex::new(registry_service)))
+        .invoke_handler(tauri::generate_handler![
+            commands::add_registry_source,
+            commands::remove_registry_source,
+            commands::sync_registry_source,
+            commands::sync_all_sources,
+            commands::get_all_modules,
+            commands::get_modules_by_category,
+            commands::search_modules,
+            commands::get_registry_sources,
+            commands::get_module_by_id,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+// Prevents additional console window on Windows in release
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    ludas_composer_lib::run();
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod module_definition;
+
+pub use module_definition::*;

--- a/src-tauri/src/models/module_definition.rs
+++ b/src-tauri/src/models/module_definition.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+
+/// Ludusモジュール定義のカテゴリ
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ModuleCategory {
+    UI,
+    Logic,
+    System,
+    GameObject,
+}
+
+impl ModuleCategory {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.trim() {
+            "UI" => Some(Self::UI),
+            "Logic" => Some(Self::Logic),
+            "System" => Some(Self::System),
+            "GameObject" => Some(Self::GameObject),
+            _ => None,
+        }
+    }
+}
+
+/// ポート定義（タスクの入出力）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PortDefinition {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub port_type: String,
+}
+
+/// 変数定義
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VariableDefinition {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub var_type: String,
+    pub description: Option<String>,
+}
+
+/// タスク定義
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskDefinition {
+    pub name: String,
+    pub description: String,
+    pub inputs: Vec<PortDefinition>,
+    pub outputs: Vec<PortDefinition>,
+}
+
+/// テストケース定義
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestCase {
+    pub description: String,
+}
+
+/// Ludusモジュール定義（markdownから解析）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleDefinition {
+    pub id: String,
+    pub name: String,
+    pub summary: String,
+    pub category: ModuleCategory,
+    pub domain: String,
+    pub required_data: Vec<String>,
+    pub variables: Vec<VariableDefinition>,
+    pub dependencies: Vec<String>,
+    pub tasks: Vec<TaskDefinition>,
+    pub tests: Vec<TestCase>,
+    /// 定義ファイルの元パス
+    pub source_path: Option<String>,
+    /// 取得元リポジトリURL
+    pub source_repo: Option<String>,
+}
+
+/// モジュールレジストリソース（GitHubリポジトリ）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleRegistrySource {
+    pub id: String,
+    pub name: String,
+    pub repo_url: String,
+    /// ローカルにクローンされたパス
+    pub local_path: Option<String>,
+    /// 定義ファイルを探すディレクトリパターン (e.g., "modules/*.md")
+    pub definition_glob: String,
+    /// 最後に同期した日時
+    pub last_synced: Option<String>,
+}
+
+/// レジストリ全体
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleRegistry {
+    pub sources: Vec<ModuleRegistrySource>,
+    pub modules: Vec<ModuleDefinition>,
+}
+
+impl Default for ModuleRegistry {
+    fn default() -> Self {
+        Self {
+            sources: Vec::new(),
+            modules: Vec::new(),
+        }
+    }
+}

--- a/src-tauri/src/services/git_clone.rs
+++ b/src-tauri/src/services/git_clone.rs
@@ -1,0 +1,143 @@
+use git2::{FetchOptions, Repository};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GitCloneError {
+    #[error("Git operation failed: {0}")]
+    GitError(#[from] git2::Error),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Invalid repository URL: {0}")]
+    InvalidUrl(String),
+
+    #[error("Cache directory not found")]
+    CacheDirectoryNotFound,
+}
+
+/// GitHubリポジトリをローカルにクローン/プルするサービス
+pub struct GitCloneService {
+    /// クローンしたリポジトリを保存するベースディレクトリ
+    cache_dir: PathBuf,
+}
+
+impl GitCloneService {
+    /// 新しいGitCloneServiceを作成
+    /// cache_dir: リポジトリキャッシュ用ディレクトリ
+    pub fn new(cache_dir: PathBuf) -> Self {
+        Self { cache_dir }
+    }
+
+    /// デフォルトのキャッシュディレクトリを使って作成
+    /// $HOME/.ludas-composer/module-cache/
+    pub fn with_default_cache() -> Result<Self, GitCloneError> {
+        let home = dirs::data_local_dir().ok_or(GitCloneError::CacheDirectoryNotFound)?;
+        let cache_dir = home.join("ludas-composer").join("module-cache");
+        Ok(Self { cache_dir })
+    }
+
+    /// リポジトリURLからローカルパスを決定
+    /// e.g., "https://github.com/user/repo" -> "{cache_dir}/github.com/user/repo"
+    pub fn repo_local_path(&self, repo_url: &str) -> Result<PathBuf, GitCloneError> {
+        let url = repo_url
+            .trim_end_matches('/')
+            .trim_end_matches(".git");
+
+        // URLからホスト/ユーザー/リポジトリを抽出
+        let parts: Vec<&str> = url.split("://").collect();
+        let path_part = if parts.len() == 2 {
+            parts[1]
+        } else if url.starts_with("git@") {
+            // git@github.com:user/repo 形式
+            &url[4..].replace(':', "/")
+                .leak() // 簡易的な処理
+        } else {
+            return Err(GitCloneError::InvalidUrl(repo_url.to_string()));
+        };
+
+        Ok(self.cache_dir.join(path_part))
+    }
+
+    /// リポジトリをクローンまたは既存なら最新をプル
+    pub fn clone_or_pull(&self, repo_url: &str) -> Result<PathBuf, GitCloneError> {
+        let local_path = self.repo_local_path(repo_url)?;
+
+        if local_path.exists() && local_path.join(".git").exists() {
+            // 既にクローン済み → プルで最新化
+            self.pull_latest(&local_path)?;
+        } else {
+            // 新規クローン
+            self.clone_repo(repo_url, &local_path)?;
+        }
+
+        Ok(local_path)
+    }
+
+    /// リポジトリを新規クローン
+    fn clone_repo(&self, repo_url: &str, local_path: &Path) -> Result<(), GitCloneError> {
+        // 親ディレクトリを作成
+        if let Some(parent) = local_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        Repository::clone(repo_url, local_path)?;
+        Ok(())
+    }
+
+    /// 既存リポジトリのデフォルトブランチをプル
+    fn pull_latest(&self, local_path: &Path) -> Result<(), GitCloneError> {
+        let repo = Repository::open(local_path)?;
+
+        // originからfetch
+        let mut remote = repo.find_remote("origin")?;
+        let mut fetch_opts = FetchOptions::new();
+        remote.fetch(&["refs/heads/*:refs/remotes/origin/*"], Some(&mut fetch_opts), None)?;
+
+        // デフォルトブランチを検出 (main or master)
+        let default_branch = self.detect_default_branch(&repo)?;
+
+        // fast-forward merge
+        let fetch_head = repo.find_reference(&format!("refs/remotes/origin/{}", default_branch))?;
+        let fetch_commit = repo.reference_to_annotated_commit(&fetch_head)?;
+
+        let (analysis, _) = repo.merge_analysis(&[&fetch_commit])?;
+
+        if analysis.is_fast_forward() {
+            let refname = format!("refs/heads/{}", default_branch);
+            if let Ok(mut reference) = repo.find_reference(&refname) {
+                reference.set_target(fetch_commit.id(), "fast-forward pull")?;
+            }
+            repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+        }
+        // up-to-date or diverged: skip (don't force overwrite)
+
+        Ok(())
+    }
+
+    /// デフォルトブランチ名を検出
+    fn detect_default_branch(&self, repo: &Repository) -> Result<String, GitCloneError> {
+        // HEAD参照からデフォルトブランチを特定
+        if let Ok(head) = repo.head() {
+            if let Some(name) = head.shorthand() {
+                return Ok(name.to_string());
+            }
+        }
+
+        // フォールバック: main → master の順で試行
+        for branch in &["main", "master"] {
+            let refname = format!("refs/remotes/origin/{}", branch);
+            if repo.find_reference(&refname).is_ok() {
+                return Ok(branch.to_string());
+            }
+        }
+
+        Ok("main".to_string())
+    }
+
+    /// キャッシュディレクトリのパスを返す
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,0 +1,7 @@
+pub mod git_clone;
+pub mod module_parser;
+pub mod module_registry;
+
+pub use git_clone::GitCloneService;
+pub use module_parser::parse_module_markdown;
+pub use module_registry::ModuleRegistryService;

--- a/src-tauri/src/services/module_parser.rs
+++ b/src-tauri/src/services/module_parser.rs
@@ -1,0 +1,302 @@
+use crate::models::*;
+use regex::Regex;
+use uuid::Uuid;
+
+/// Ludusモジュール定義のMarkdownをパースする
+///
+/// plan.md セクション8のフォーマットに準拠:
+/// ```markdown
+/// ### モジュール名
+/// #### 概要
+/// #### カテゴリ
+/// #### 所属ドメイン
+/// #### 必要なデータ
+/// #### 変数
+/// #### 依存
+/// #### 作業
+/// ##### 入力
+/// ##### 出力
+/// ##### タスク
+/// #### テスト
+/// ```
+pub fn parse_module_markdown(content: &str, source_path: Option<&str>) -> Vec<ModuleDefinition> {
+    let mut modules = Vec::new();
+
+    // "### " で始まるセクションでモジュールを分割
+    // ただし "#### " 以上の深さは除外
+    let module_sections = split_by_module_headers(content);
+
+    for (module_name, section_content) in module_sections {
+        if let Some(module) = parse_single_module(&module_name, &section_content, source_path) {
+            modules.push(module);
+        }
+    }
+
+    modules
+}
+
+/// Markdownを "### " ヘッダーでモジュール単位に分割
+fn split_by_module_headers(content: &str) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+    let header_re = Regex::new(r"(?m)^###\s+(.+?)(?:\s+モジュール定義)?$").unwrap();
+
+    let matches: Vec<_> = header_re.find_iter(content).collect();
+    let captures: Vec<_> = header_re.captures_iter(content).collect();
+
+    for (i, cap) in captures.iter().enumerate() {
+        let name = cap[1].trim().to_string();
+        let start = matches[i].end();
+        let end = if i + 1 < matches.len() {
+            matches[i + 1].start()
+        } else {
+            content.len()
+        };
+        let section = content[start..end].to_string();
+        result.push((name, section));
+    }
+
+    result
+}
+
+/// 単一モジュールのセクションをパースしてModuleDefinitionを生成
+fn parse_single_module(
+    name: &str,
+    content: &str,
+    source_path: Option<&str>,
+) -> Option<ModuleDefinition> {
+    let summary = extract_section(content, "概要").unwrap_or_default();
+    let category_str = extract_section(content, "カテゴリ").unwrap_or_default();
+    let category = ModuleCategory::from_str(&category_str)?;
+    let domain = extract_section(content, "所属ドメイン").unwrap_or_default();
+    let required_data = extract_list_items(content, "必要なデータ");
+    let variables = parse_variables(content);
+    let dependencies = extract_list_items(content, "依存");
+    let tasks = parse_tasks(content);
+    let tests = extract_list_items(content, "テスト")
+        .into_iter()
+        .map(|desc| TestCase { description: desc })
+        .collect();
+
+    Some(ModuleDefinition {
+        id: Uuid::new_v4().to_string(),
+        name: name.to_string(),
+        summary,
+        category,
+        domain,
+        required_data,
+        variables,
+        dependencies,
+        tasks,
+        tests,
+        source_path: source_path.map(|s| s.to_string()),
+        source_repo: None,
+    })
+}
+
+/// "#### {header}" セクションのテキスト本文を抽出
+fn extract_section(content: &str, header: &str) -> Option<String> {
+    let pattern = format!(r"(?m)^####\s+{}\s*\n([\s\S]*?)(?=\n####|\n###|\z)", regex::escape(header));
+    let re = Regex::new(&pattern).ok()?;
+    let caps = re.captures(content)?;
+    let text = caps[1].trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// セクション内のリストアイテム(- で始まる行)を抽出
+fn extract_list_items(content: &str, header: &str) -> Vec<String> {
+    let section = match extract_section(content, header) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+
+    section
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+                Some(trimmed[2..].trim().to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// 変数セクションをパースして VariableDefinition のリストに変換
+fn parse_variables(content: &str) -> Vec<VariableDefinition> {
+    let items = extract_list_items(content, "変数");
+    items
+        .into_iter()
+        .filter_map(|item| {
+            // フォーマット: "変数名: 説明" または "変数名 (型): 説明"
+            let parts: Vec<&str> = item.splitn(2, ':').collect();
+            if parts.len() >= 2 {
+                let name_part = parts[0].trim();
+                let desc = parts[1].trim().to_string();
+
+                // 型情報があれば抽出 "name (type)"
+                let type_re = Regex::new(r"^(.+?)\s*\((.+?)\)$").ok()?;
+                let (name, var_type) = if let Some(caps) = type_re.captures(name_part) {
+                    (caps[1].trim().to_string(), caps[2].trim().to_string())
+                } else {
+                    (name_part.to_string(), "unknown".to_string())
+                };
+
+                Some(VariableDefinition {
+                    name,
+                    var_type,
+                    description: Some(desc),
+                })
+            } else {
+                Some(VariableDefinition {
+                    name: item,
+                    var_type: "unknown".to_string(),
+                    description: None,
+                })
+            }
+        })
+        .collect()
+}
+
+/// 作業セクション内のタスクをパース
+fn parse_tasks(content: &str) -> Vec<TaskDefinition> {
+    // "##### タスク" セクションを探す
+    let task_pattern = Regex::new(r"(?m)^#####\s+タスク\s*\n([\s\S]*?)(?=\n####|\n###|\n#####|\z)").unwrap();
+    let task_section = match task_pattern.captures(content) {
+        Some(caps) => caps[1].to_string(),
+        None => return Vec::new(),
+    };
+
+    // 入力セクションのパース
+    let inputs = parse_port_section(content, "入力");
+    // 出力セクションのパース
+    let outputs = parse_port_section(content, "出力");
+
+    // 各タスク行をパース: "- タスク名: 説明"
+    task_section
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+                let task_text = trimmed[2..].trim();
+                let parts: Vec<&str> = task_text.splitn(2, ':').collect();
+                if parts.len() >= 2 {
+                    Some(TaskDefinition {
+                        name: parts[0].trim().to_string(),
+                        description: parts[1].trim().to_string(),
+                        inputs: inputs.clone(),
+                        outputs: outputs.clone(),
+                    })
+                } else {
+                    Some(TaskDefinition {
+                        name: task_text.to_string(),
+                        description: String::new(),
+                        inputs: inputs.clone(),
+                        outputs: outputs.clone(),
+                    })
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// 入力/出力セクションからポート定義を抽出
+fn parse_port_section(content: &str, header: &str) -> Vec<PortDefinition> {
+    let pattern = format!(
+        r"(?m)^#####\s+{}\s*\n([\s\S]*?)(?=\n#####|\n####|\n###|\z)",
+        regex::escape(header)
+    );
+    let re = match Regex::new(&pattern) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+
+    let section = match re.captures(content) {
+        Some(caps) => caps[1].to_string(),
+        None => return Vec::new(),
+    };
+
+    section
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+                let port_text = trimmed[2..].trim().to_string();
+                Some(PortDefinition {
+                    name: port_text.clone(),
+                    port_type: "any".to_string(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_module_from_plan_format() {
+        let markdown = r#"
+### シーンマネージャー モジュール定義
+
+#### 概要
+プロジェクト内のシーンの作成・選択・削除・名前変更を管理する
+
+#### カテゴリ
+UI
+
+#### 所属ドメイン
+エディタ
+
+#### 必要なデータ
+- プロジェクト内のシーン一覧
+- アクティブシーンID
+
+#### 変数
+- scenes: シーンオブジェクトのMap
+- activeSceneId: 現在選択中のシーンID (null許容)
+
+#### 依存
+- ProjectStore
+
+#### 作業
+##### 入力
+- ユーザーからのシーン名入力
+- ユーザーからのシーン選択操作
+
+##### 出力
+- 更新されたシーン一覧の描画
+- アクティブシーン変更イベント
+
+##### タスク
+- シーン作成: 名前を受け取り、新規Scene + ルートActor(role=scene)を生成しストアに追加
+- シーン選択: IDを受け取り、activeSceneIdを更新
+
+#### テスト
+- シーンを作成すると、一覧に新規シーンが追加されること
+- シーンを削除すると、一覧から消えること
+"#;
+
+        let modules = parse_module_markdown(markdown, Some("test.md"));
+        assert_eq!(modules.len(), 1);
+
+        let m = &modules[0];
+        assert_eq!(m.name, "シーンマネージャー");
+        assert_eq!(m.category, ModuleCategory::UI);
+        assert_eq!(m.domain, "エディタ");
+        assert_eq!(m.required_data.len(), 2);
+        assert_eq!(m.variables.len(), 2);
+        assert_eq!(m.dependencies.len(), 1);
+        assert_eq!(m.tasks.len(), 2);
+        assert_eq!(m.tests.len(), 2);
+    }
+}

--- a/src-tauri/src/services/module_registry.rs
+++ b/src-tauri/src/services/module_registry.rs
@@ -1,0 +1,310 @@
+use crate::models::*;
+use crate::services::git_clone::GitCloneService;
+use crate::services::module_parser;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use walkdir::WalkDir;
+
+#[derive(Error, Debug)]
+pub enum RegistryError {
+    #[error("Git clone error: {0}")]
+    GitError(#[from] crate::services::git_clone::GitCloneError),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Registry file parse error: {0}")]
+    ParseError(String),
+
+    #[error("Source not found: {0}")]
+    SourceNotFound(String),
+}
+
+/// モジュールレジストリサービス
+/// GitHubリポジトリからモジュール定義を取得・管理する
+pub struct ModuleRegistryService {
+    git_service: GitCloneService,
+    registry: ModuleRegistry,
+    /// レジストリ設定の保存先パス
+    config_path: PathBuf,
+}
+
+impl ModuleRegistryService {
+    /// 新しいModuleRegistryServiceを作成
+    pub fn new(cache_dir: PathBuf) -> Self {
+        let config_path = cache_dir.join("registry.json");
+        Self {
+            git_service: GitCloneService::new(cache_dir),
+            registry: ModuleRegistry::default(),
+            config_path,
+        }
+    }
+
+    /// デフォルト設定で作成
+    pub fn with_defaults() -> Result<Self, RegistryError> {
+        let git_service = GitCloneService::with_default_cache()?;
+        let cache_dir = git_service.cache_dir().to_path_buf();
+        let config_path = cache_dir.join("registry.json");
+
+        let mut service = Self {
+            git_service,
+            registry: ModuleRegistry::default(),
+            config_path,
+        };
+
+        // 既存の設定を読み込む
+        service.load_config()?;
+
+        Ok(service)
+    }
+
+    /// レジストリソース（GitHubリポジトリ）を追加
+    pub fn add_source(
+        &mut self,
+        name: &str,
+        repo_url: &str,
+        definition_glob: &str,
+    ) -> Result<&ModuleRegistrySource, RegistryError> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let source = ModuleRegistrySource {
+            id: id.clone(),
+            name: name.to_string(),
+            repo_url: repo_url.to_string(),
+            local_path: None,
+            definition_glob: definition_glob.to_string(),
+            last_synced: None,
+        };
+        self.registry.sources.push(source);
+        self.save_config()?;
+
+        Ok(self.registry.sources.last().unwrap())
+    }
+
+    /// レジストリソースを削除
+    pub fn remove_source(&mut self, source_id: &str) -> Result<(), RegistryError> {
+        let idx = self
+            .registry
+            .sources
+            .iter()
+            .position(|s| s.id == source_id)
+            .ok_or_else(|| RegistryError::SourceNotFound(source_id.to_string()))?;
+
+        self.registry.sources.remove(idx);
+
+        // このソースからのモジュールも削除
+        self.registry
+            .modules
+            .retain(|m| m.source_repo.as_deref() != Some(source_id));
+
+        self.save_config()?;
+        Ok(())
+    }
+
+    /// 指定ソースからモジュール定義を同期（clone/pull + parse）
+    pub fn sync_source(&mut self, source_id: &str) -> Result<Vec<ModuleDefinition>, RegistryError> {
+        let source = self
+            .registry
+            .sources
+            .iter_mut()
+            .find(|s| s.id == source_id)
+            .ok_or_else(|| RegistryError::SourceNotFound(source_id.to_string()))?;
+
+        // クローンまたはプル
+        let local_path = self.git_service.clone_or_pull(&source.repo_url)?;
+        source.local_path = Some(local_path.to_string_lossy().to_string());
+        source.last_synced = Some(chrono_now());
+
+        let repo_url = source.repo_url.clone();
+        let glob_pattern = source.definition_glob.clone();
+        let source_id_owned = source_id.to_string();
+
+        // 古いモジュールを削除
+        self.registry
+            .modules
+            .retain(|m| m.source_repo.as_deref() != Some(&source_id_owned));
+
+        // 定義ファイルを検索してパース
+        let new_modules = scan_and_parse_definitions(&local_path, &glob_pattern, &repo_url)?;
+
+        let result = new_modules.clone();
+        self.registry.modules.extend(new_modules);
+        self.save_config()?;
+
+        Ok(result)
+    }
+
+    /// 全ソースを同期
+    pub fn sync_all(&mut self) -> Result<Vec<ModuleDefinition>, RegistryError> {
+        let source_ids: Vec<String> = self.registry.sources.iter().map(|s| s.id.clone()).collect();
+        let mut all_modules = Vec::new();
+
+        for source_id in source_ids {
+            match self.sync_source(&source_id) {
+                Ok(modules) => all_modules.extend(modules),
+                Err(e) => {
+                    eprintln!("Failed to sync source {}: {}", source_id, e);
+                }
+            }
+        }
+
+        Ok(all_modules)
+    }
+
+    /// 全モジュール定義を取得
+    pub fn get_all_modules(&self) -> &[ModuleDefinition] {
+        &self.registry.modules
+    }
+
+    /// カテゴリでフィルタ
+    pub fn get_modules_by_category(&self, category: &ModuleCategory) -> Vec<&ModuleDefinition> {
+        self.registry
+            .modules
+            .iter()
+            .filter(|m| &m.category == category)
+            .collect()
+    }
+
+    /// 名前で検索
+    pub fn search_modules(&self, query: &str) -> Vec<&ModuleDefinition> {
+        let query_lower = query.to_lowercase();
+        self.registry
+            .modules
+            .iter()
+            .filter(|m| {
+                m.name.to_lowercase().contains(&query_lower)
+                    || m.summary.to_lowercase().contains(&query_lower)
+                    || m.domain.to_lowercase().contains(&query_lower)
+            })
+            .collect()
+    }
+
+    /// IDでモジュールを取得
+    pub fn get_module(&self, module_id: &str) -> Option<&ModuleDefinition> {
+        self.registry.modules.iter().find(|m| m.id == module_id)
+    }
+
+    /// 全ソースを取得
+    pub fn get_sources(&self) -> &[ModuleRegistrySource] {
+        &self.registry.sources
+    }
+
+    /// レジストリを取得
+    pub fn get_registry(&self) -> &ModuleRegistry {
+        &self.registry
+    }
+
+    /// 設定を保存
+    fn save_config(&self) -> Result<(), RegistryError> {
+        if let Some(parent) = self.config_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(&self.registry)
+            .map_err(|e| RegistryError::ParseError(e.to_string()))?;
+        std::fs::write(&self.config_path, json)?;
+        Ok(())
+    }
+
+    /// 設定を読み込み
+    fn load_config(&mut self) -> Result<(), RegistryError> {
+        if self.config_path.exists() {
+            let content = std::fs::read_to_string(&self.config_path)?;
+            self.registry = serde_json::from_str(&content)
+                .map_err(|e| RegistryError::ParseError(e.to_string()))?;
+        }
+        Ok(())
+    }
+}
+
+/// ディレクトリ内のモジュール定義ファイルを検索してパース
+fn scan_and_parse_definitions(
+    base_path: &Path,
+    glob_pattern: &str,
+    repo_url: &str,
+) -> Result<Vec<ModuleDefinition>, RegistryError> {
+    let mut all_modules = Vec::new();
+
+    // globパターンからファイル拡張子を取得
+    let extension = if glob_pattern.contains("*.md") {
+        Some("md")
+    } else if glob_pattern.contains("*.json") {
+        Some("json")
+    } else {
+        None
+    };
+
+    // globパターンからサブディレクトリを取得
+    let search_dir = if let Some(dir_part) = glob_pattern.split('*').next() {
+        let dir_part = dir_part.trim_end_matches('/');
+        if dir_part.is_empty() {
+            base_path.to_path_buf()
+        } else {
+            base_path.join(dir_part)
+        }
+    } else {
+        base_path.to_path_buf()
+    };
+
+    // ディレクトリが存在しない場合はベースパスから検索
+    let search_root = if search_dir.exists() {
+        search_dir
+    } else {
+        base_path.to_path_buf()
+    };
+
+    for entry in WalkDir::new(&search_root)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+
+        // 拡張子チェック
+        let matches = match extension {
+            Some(ext) => path.extension().map_or(false, |e| e == ext),
+            None => path.extension().map_or(false, |e| e == "md"),
+        };
+
+        if !matches || !path.is_file() {
+            continue;
+        }
+
+        // .git内のファイルはスキップ
+        if path.to_string_lossy().contains("/.git/") {
+            continue;
+        }
+
+        match std::fs::read_to_string(path) {
+            Ok(content) => {
+                let relative_path = path
+                    .strip_prefix(base_path)
+                    .unwrap_or(path)
+                    .to_string_lossy()
+                    .to_string();
+
+                let mut modules =
+                    module_parser::parse_module_markdown(&content, Some(&relative_path));
+
+                // ソースリポジトリ情報を付与
+                for module in &mut modules {
+                    module.source_repo = Some(repo_url.to_string());
+                }
+
+                all_modules.extend(modules);
+            }
+            Err(e) => {
+                eprintln!("Failed to read {}: {}", path.display(), e);
+            }
+        }
+    }
+
+    Ok(all_modules)
+}
+
+/// 現在時刻を文字列で返す（簡易実装）
+fn chrono_now() -> String {
+    // std::time だけで簡易的に
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}", now.as_secs())
+}

--- a/src/services/module-registry-api.ts
+++ b/src/services/module-registry-api.ts
@@ -1,0 +1,74 @@
+/**
+ * モジュールレジストリ Tauri コマンドバインディング
+ * Rust側の commands/module_registry.rs と対応
+ */
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  AddSourceParams,
+  CommandResult,
+  ModuleDefinition,
+  ModuleRegistrySource,
+} from '../types/module-registry';
+
+/** レジストリソース（GitHubリポジトリ）を追加 */
+export async function addRegistrySource(
+  params: AddSourceParams
+): Promise<CommandResult<ModuleRegistrySource>> {
+  return invoke('add_registry_source', { params });
+}
+
+/** レジストリソースを削除 */
+export async function removeRegistrySource(
+  sourceId: string
+): Promise<CommandResult<void>> {
+  return invoke('remove_registry_source', { sourceId });
+}
+
+/** 指定ソースを同期（clone/pull + 定義パース） */
+export async function syncRegistrySource(
+  sourceId: string
+): Promise<CommandResult<ModuleDefinition[]>> {
+  return invoke('sync_registry_source', { sourceId });
+}
+
+/** 全ソースを同期 */
+export async function syncAllSources(): Promise<
+  CommandResult<ModuleDefinition[]>
+> {
+  return invoke('sync_all_sources');
+}
+
+/** 全モジュール定義を取得 */
+export async function getAllModules(): Promise<
+  CommandResult<ModuleDefinition[]>
+> {
+  return invoke('get_all_modules');
+}
+
+/** カテゴリでモジュールをフィルタ */
+export async function getModulesByCategory(
+  category: string
+): Promise<CommandResult<ModuleDefinition[]>> {
+  return invoke('get_modules_by_category', { category });
+}
+
+/** モジュールを検索 */
+export async function searchModules(
+  query: string
+): Promise<CommandResult<ModuleDefinition[]>> {
+  return invoke('search_modules', { query });
+}
+
+/** 全ソースを取得 */
+export async function getRegistrySources(): Promise<
+  CommandResult<ModuleRegistrySource[]>
+> {
+  return invoke('get_registry_sources');
+}
+
+/** IDでモジュールを取得 */
+export async function getModuleById(
+  moduleId: string
+): Promise<CommandResult<ModuleDefinition>> {
+  return invoke('get_module_by_id', { moduleId });
+}

--- a/src/stores/moduleRegistryStore.ts
+++ b/src/stores/moduleRegistryStore.ts
@@ -1,0 +1,194 @@
+/**
+ * モジュールレジストリ Zustand ストア
+ * GitHubリポジトリからのモジュール定義の取得・管理・アクターへのアタッチを担当
+ */
+import { create } from 'zustand';
+import type {
+  ModuleCategory,
+  ModuleDefinition,
+  ModuleRegistrySource,
+} from '../types/module-registry';
+import * as api from '../services/module-registry-api';
+
+interface ModuleRegistryState {
+  // === データ ===
+  sources: ModuleRegistrySource[];
+  modules: ModuleDefinition[];
+
+  // === UI状態 ===
+  isLoading: boolean;
+  isSyncing: Record<string, boolean>; // sourceId -> syncing status
+  error: string | null;
+  searchQuery: string;
+  categoryFilter: ModuleCategory | null;
+
+  // === アクション: ソース管理 ===
+  /** GitHubリポジトリをソースとして追加 */
+  addSource: (
+    name: string,
+    repoUrl: string,
+    definitionGlob?: string
+  ) => Promise<void>;
+  /** ソースを削除 */
+  removeSource: (sourceId: string) => Promise<void>;
+  /** 指定ソースを同期（clone/pull + パース） */
+  syncSource: (sourceId: string) => Promise<void>;
+  /** 全ソースを同期 */
+  syncAll: () => Promise<void>;
+
+  // === アクション: モジュール取得 ===
+  /** 初期ロード（保存済みレジストリを読み込み） */
+  loadRegistry: () => Promise<void>;
+  /** 検索クエリを設定 */
+  setSearchQuery: (query: string) => void;
+  /** カテゴリフィルタを設定 */
+  setCategoryFilter: (category: ModuleCategory | null) => void;
+
+  // === 算出値 ===
+  /** フィルタ済みモジュール一覧 */
+  filteredModules: () => ModuleDefinition[];
+}
+
+export const useModuleRegistryStore = create<ModuleRegistryState>(
+  (set, get) => ({
+    // 初期状態
+    sources: [],
+    modules: [],
+    isLoading: false,
+    isSyncing: {},
+    error: null,
+    searchQuery: '',
+    categoryFilter: null,
+
+    // ソース追加
+    addSource: async (name, repoUrl, definitionGlob) => {
+      set({ isLoading: true, error: null });
+      try {
+        const result = await api.addRegistrySource({
+          name,
+          repo_url: repoUrl,
+          definition_glob: definitionGlob,
+        });
+        if (result.success && result.data) {
+          set((state) => ({
+            sources: [...state.sources, result.data!],
+            isLoading: false,
+          }));
+        } else {
+          set({ error: result.error ?? 'Failed to add source', isLoading: false });
+        }
+      } catch (e) {
+        set({ error: String(e), isLoading: false });
+      }
+    },
+
+    // ソース削除
+    removeSource: async (sourceId) => {
+      set({ isLoading: true, error: null });
+      try {
+        const result = await api.removeRegistrySource(sourceId);
+        if (result.success) {
+          set((state) => ({
+            sources: state.sources.filter((s) => s.id !== sourceId),
+            modules: state.modules.filter((m) => m.source_repo !== sourceId),
+            isLoading: false,
+          }));
+        } else {
+          set({ error: result.error ?? 'Failed to remove source', isLoading: false });
+        }
+      } catch (e) {
+        set({ error: String(e), isLoading: false });
+      }
+    },
+
+    // ソース同期
+    syncSource: async (sourceId) => {
+      set((state) => ({
+        isSyncing: { ...state.isSyncing, [sourceId]: true },
+        error: null,
+      }));
+      try {
+        const result = await api.syncRegistrySource(sourceId);
+        if (result.success && result.data) {
+          set((state) => ({
+            modules: [
+              ...state.modules.filter((m) => m.source_repo !== sourceId),
+              ...result.data!,
+            ],
+            isSyncing: { ...state.isSyncing, [sourceId]: false },
+          }));
+        } else {
+          set((state) => ({
+            error: result.error ?? 'Failed to sync source',
+            isSyncing: { ...state.isSyncing, [sourceId]: false },
+          }));
+        }
+      } catch (e) {
+        set((state) => ({
+          error: String(e),
+          isSyncing: { ...state.isSyncing, [sourceId]: false },
+        }));
+      }
+    },
+
+    // 全ソース同期
+    syncAll: async () => {
+      set({ isLoading: true, error: null });
+      try {
+        const result = await api.syncAllSources();
+        if (result.success && result.data) {
+          set({ modules: result.data, isLoading: false });
+        } else {
+          set({ error: result.error ?? 'Failed to sync', isLoading: false });
+        }
+      } catch (e) {
+        set({ error: String(e), isLoading: false });
+      }
+    },
+
+    // レジストリ読み込み
+    loadRegistry: async () => {
+      set({ isLoading: true, error: null });
+      try {
+        const [sourcesResult, modulesResult] = await Promise.all([
+          api.getRegistrySources(),
+          api.getAllModules(),
+        ]);
+
+        set({
+          sources: sourcesResult.success ? (sourcesResult.data ?? []) : [],
+          modules: modulesResult.success ? (modulesResult.data ?? []) : [],
+          isLoading: false,
+        });
+      } catch (e) {
+        set({ error: String(e), isLoading: false });
+      }
+    },
+
+    // 検索
+    setSearchQuery: (query) => set({ searchQuery: query }),
+    setCategoryFilter: (category) => set({ categoryFilter: category }),
+
+    // フィルタ済みモジュール
+    filteredModules: () => {
+      const { modules, searchQuery, categoryFilter } = get();
+      let filtered = modules;
+
+      if (categoryFilter) {
+        filtered = filtered.filter((m) => m.category === categoryFilter);
+      }
+
+      if (searchQuery.trim()) {
+        const q = searchQuery.toLowerCase();
+        filtered = filtered.filter(
+          (m) =>
+            m.name.toLowerCase().includes(q) ||
+            m.summary.toLowerCase().includes(q) ||
+            m.domain.toLowerCase().includes(q)
+        );
+      }
+
+      return filtered;
+    },
+  })
+);

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,106 @@
+// === コアドメインモデル型定義 ===
+// plan.md セクション3に準拠
+
+import type { ModuleDefinition } from './module-registry';
+
+/** アクターのロール */
+export type ActorRole = 'actor' | 'scene' | 'sequence';
+
+/** コンポーネントカテゴリ */
+export type ComponentCategory = 'UI' | 'Logic' | 'System' | 'GameObject';
+
+/** 変数定義 */
+export interface Variable {
+  name: string;
+  type: string;
+  defaultValue?: unknown;
+}
+
+/** タスク定義 */
+export interface Task {
+  name: string;
+  description: string;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+}
+
+/** ポート定義 */
+export interface PortDefinition {
+  name: string;
+  type: string;
+}
+
+/** コンポーネント定義 */
+export interface Component {
+  id: string;
+  name: string;
+  category: ComponentCategory;
+  domain: string;
+  variables: Variable[];
+  tasks: Task[];
+  dependencies: string[];
+  /** モジュールレジストリから取り込まれた場合の元モジュールID */
+  sourceModuleId?: string;
+}
+
+/** アクター */
+export interface Actor {
+  id: string;
+  name: string;
+  role: ActorRole;
+  components: string[];       // Component.id[]
+  children: string[];         // 子Actor.id[]
+  position: { x: number; y: number };
+}
+
+/** 接続 */
+export interface Connection {
+  id: string;
+  sourceActorId: string;
+  sourcePort: string;
+  targetActorId: string;
+  targetPort: string;
+}
+
+/** シーン */
+export interface Scene {
+  id: string;
+  name: string;
+  rootActorId: string;
+  actors: Record<string, Actor>;
+  connections: Connection[];
+}
+
+/** プロジェクト */
+export interface Project {
+  name: string;
+  scenes: Record<string, Scene>;
+  components: Record<string, Component>;
+  activeSceneId: string | null;
+}
+
+/**
+ * ModuleDefinitionからComponentに変換するユーティリティ型
+ * レジストリのモジュールをプロジェクトのコンポーネントとしてインポートする際に使用
+ */
+export function moduleToComponent(module: ModuleDefinition): Component {
+  return {
+    id: crypto.randomUUID(),
+    name: module.name,
+    category: module.category,
+    domain: module.domain,
+    variables: module.variables.map((v) => ({
+      name: v.name,
+      type: v.type,
+      defaultValue: undefined,
+    })),
+    tasks: module.tasks.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputs: t.inputs,
+      outputs: t.outputs,
+    })),
+    dependencies: module.dependencies,
+    sourceModuleId: module.id,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './domain';
+export * from './module-registry';

--- a/src/types/module-registry.ts
+++ b/src/types/module-registry.ts
@@ -1,0 +1,77 @@
+// === モジュールレジストリ型定義 ===
+// Rust側の models/module_definition.rs と対応
+
+/** モジュールカテゴリ */
+export type ModuleCategory = 'UI' | 'Logic' | 'System' | 'GameObject';
+
+/** ポート定義（タスクの入出力） */
+export interface PortDefinition {
+  name: string;
+  type: string;
+}
+
+/** 変数定義 */
+export interface VariableDefinition {
+  name: string;
+  type: string;
+  description?: string;
+}
+
+/** タスク定義 */
+export interface TaskDefinition {
+  name: string;
+  description: string;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+}
+
+/** テストケース */
+export interface TestCase {
+  description: string;
+}
+
+/** Ludusモジュール定義 */
+export interface ModuleDefinition {
+  id: string;
+  name: string;
+  summary: string;
+  category: ModuleCategory;
+  domain: string;
+  required_data: string[];
+  variables: VariableDefinition[];
+  dependencies: string[];
+  tasks: TaskDefinition[];
+  tests: TestCase[];
+  source_path?: string;
+  source_repo?: string;
+}
+
+/** モジュールレジストリソース（GitHubリポジトリ） */
+export interface ModuleRegistrySource {
+  id: string;
+  name: string;
+  repo_url: string;
+  local_path?: string;
+  definition_glob: string;
+  last_synced?: string;
+}
+
+/** レジストリ全体 */
+export interface ModuleRegistry {
+  sources: ModuleRegistrySource[];
+  modules: ModuleDefinition[];
+}
+
+/** コマンド結果 */
+export interface CommandResult<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+/** ソース追加パラメータ */
+export interface AddSourceParams {
+  name: string;
+  repo_url: string;
+  definition_glob?: string;
+}


### PR DESCRIPTION
Implement a complete module registry pipeline:
- Rust backend: GitCloneService (git2-based repo clone/pull), ModuleParser
  (Markdown parser for Ludus module definition format), ModuleRegistryService
  (source management, sync orchestration, search/filter)
- Tauri commands: 9 API endpoints for source CRUD, sync, search, and retrieval
- TypeScript types: ModuleDefinition, ModuleRegistrySource, domain models with
  moduleToComponent() conversion utility
- Zustand store: moduleRegistryStore with async source management, sync status
  tracking, and filtered module queries
- Updated plan.md with section 11 documenting the full architecture

https://claude.ai/code/session_01DXC8rQZ3jj1rpzKh2Lpcaq