### PR TITLE
Add web server support alongside Tauri desktop app

### DIFF
--- a/ars-editor/package.json
+++ b/ars-editor/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:web": "vite",
     "build": "tsc -b && vite build",
+    "build:web-server": "cd src-tauri && cargo build --features web-server --no-default-features --bin ars-web-server",
+    "serve:web": "cd src-tauri && cargo run --features web-server --no-default-features --bin ars-web-server -- ../dist",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/ars-editor/src-tauri/Cargo.lock
+++ b/ars-editor/src-tauri/Cargo.lock
@@ -79,6 +79,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "dirs-next",
  "log",
  "serde",
@@ -86,6 +87,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tokio",
+ "tower-http 0.5.2",
 ]
 
 [[package]]
@@ -93,6 +96,17 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atk"
@@ -128,6 +142,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -805,6 +874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,10 +1463,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -1402,6 +1493,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1852,6 +1944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +1969,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2734,7 +2842,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2802,6 +2910,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2970,6 +3084,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,6 +3121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3077,6 +3214,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3707,9 +3854,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3843,6 +4004,32 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3881,6 +4068,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -3974,6 +4162,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -15,12 +15,30 @@ name = "app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.5.6" }
+tauri-build = { version = "2.5.6", optional = true }
+
+[features]
+default = ["tauri-app"]
+tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build"]
+web-server = ["dep:axum", "dep:tokio", "dep:tower-http"]
+
+[[bin]]
+name = "app"
+path = "src/main.rs"
+required-features = ["tauri-app"]
+
+[[bin]]
+name = "ars-web-server"
+path = "src/web_main.rs"
+required-features = ["web-server"]
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.10.3" }
-tauri-plugin-log = "2"
+tauri = { version = "2.10.3", optional = true }
+tauri-plugin-log = { version = "2", optional = true }
 dirs-next = "2.0"
+axum = { version = "0.7", optional = true }
+tokio = { version = "1", features = ["full"], optional = true }
+tower-http = { version = "0.5", features = ["cors", "fs"], optional = true }

--- a/ars-editor/src-tauri/build.rs
+++ b/ars-editor/src-tauri/build.rs
@@ -1,3 +1,4 @@
 fn main() {
-  tauri_build::build()
+  #[cfg(feature = "tauri-app")]
+  tauri_build::build();
 }

--- a/ars-editor/src-tauri/src/commands/project.rs
+++ b/ars-editor/src-tauri/src/commands/project.rs
@@ -2,17 +2,37 @@ use crate::models::Project;
 use std::fs;
 use std::path::PathBuf;
 
+#[cfg(feature = "tauri-app")]
 #[tauri::command]
 pub fn save_project(path: String, project: Project) -> Result<(), String> {
+    save_project_impl(path, project)
+}
+
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+pub fn load_project(path: String) -> Result<Project, String> {
+    load_project_impl(path)
+}
+
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+pub fn get_default_project_path() -> Result<String, String> {
+    get_default_project_path_impl()
+}
+
+pub fn save_project_impl(path: String, project: Project) -> Result<(), String> {
     let json = serde_json::to_string_pretty(&project)
         .map_err(|e| format!("Failed to serialize project: {}", e))?;
+    if let Some(parent) = std::path::Path::new(&path).parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create directory: {}", e))?;
+    }
     fs::write(&path, json)
         .map_err(|e| format!("Failed to write file: {}", e))?;
     Ok(())
 }
 
-#[tauri::command]
-pub fn load_project(path: String) -> Result<Project, String> {
+pub fn load_project_impl(path: String) -> Result<Project, String> {
     let content = fs::read_to_string(&path)
         .map_err(|e| format!("Failed to read file: {}", e))?;
     let project: Project = serde_json::from_str(&content)
@@ -20,8 +40,7 @@ pub fn load_project(path: String) -> Result<Project, String> {
     Ok(project)
 }
 
-#[tauri::command]
-pub fn get_default_project_path() -> Result<String, String> {
+pub fn get_default_project_path_impl() -> Result<String, String> {
     let home = dirs_next::document_dir()
         .or_else(dirs_next::home_dir)
         .ok_or_else(|| "Cannot determine home directory".to_string())?;
@@ -29,4 +48,21 @@ pub fn get_default_project_path() -> Result<String, String> {
     fs::create_dir_all(&path)
         .map_err(|e| format!("Failed to create directory: {}", e))?;
     Ok(path.to_string_lossy().to_string())
+}
+
+pub fn list_projects_impl() -> Result<Vec<String>, String> {
+    let dir = get_default_project_path_impl()?;
+    let entries = fs::read_dir(&dir)
+        .map_err(|e| format!("Failed to read directory: {}", e))?;
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let path = entry.path();
+        if path.extension().map(|e| e == "json").unwrap_or(false) {
+            if let Some(name) = path.file_name() {
+                files.push(name.to_string_lossy().to_string());
+            }
+        }
+    }
+    Ok(files)
 }

--- a/ars-editor/src-tauri/src/lib.rs
+++ b/ars-editor/src-tauri/src/lib.rs
@@ -1,7 +1,9 @@
-mod commands;
-mod models;
+pub mod commands;
+pub mod models;
+#[cfg(feature = "web-server")]
+pub mod web_server;
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
+#[cfg(feature = "tauri-app")]
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {

--- a/ars-editor/src-tauri/src/web_main.rs
+++ b/ars-editor/src-tauri/src/web_main.rs
@@ -5,7 +5,7 @@ async fn main() {
     let port: u16 = env::var("PORT")
         .ok()
         .and_then(|p| p.parse().ok())
-        .unwrap_or(3000);
+        .unwrap_or(5173);
 
     let static_dir = env::args().nth(1);
 

--- a/ars-editor/src-tauri/src/web_main.rs
+++ b/ars-editor/src-tauri/src/web_main.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    let port: u16 = env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000);
+
+    let static_dir = env::args().nth(1);
+
+    app_lib::web_server::serve(port, static_dir).await;
+}

--- a/ars-editor/src-tauri/src/web_server.rs
+++ b/ars-editor/src-tauri/src/web_server.rs
@@ -1,0 +1,77 @@
+use axum::{
+    extract::Query,
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use serde::Deserialize;
+use tower_http::cors::CorsLayer;
+use tower_http::services::ServeDir;
+
+use crate::commands::project::{
+    get_default_project_path_impl, list_projects_impl, load_project_impl, save_project_impl,
+};
+use crate::models::Project;
+
+#[derive(Deserialize)]
+struct SaveRequest {
+    path: String,
+    project: Project,
+}
+
+#[derive(Deserialize)]
+struct LoadQuery {
+    path: String,
+}
+
+async fn api_save_project(
+    Json(req): Json<SaveRequest>,
+) -> Result<Json<()>, (StatusCode, String)> {
+    save_project_impl(req.path, req.project)
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+async fn api_load_project(
+    Query(q): Query<LoadQuery>,
+) -> Result<Json<Project>, (StatusCode, String)> {
+    load_project_impl(q.path)
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+async fn api_default_path() -> Result<Json<String>, (StatusCode, String)> {
+    get_default_project_path_impl()
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+async fn api_list_projects() -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    list_projects_impl()
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+pub fn api_router() -> Router {
+    Router::new()
+        .route("/api/project/save", post(api_save_project))
+        .route("/api/project/load", get(api_load_project))
+        .route("/api/project/default-path", get(api_default_path))
+        .route("/api/project/list", get(api_list_projects))
+        .layer(CorsLayer::permissive())
+}
+
+pub async fn serve(port: u16, static_dir: Option<String>) {
+    let app = if let Some(dir) = static_dir {
+        api_router().fallback_service(ServeDir::new(dir))
+    } else {
+        api_router()
+    };
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    println!("Ars Editor web server listening on http://localhost:{}", port);
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/ars-editor/src/App.tsx
+++ b/ars-editor/src/App.tsx
@@ -8,6 +8,7 @@ import { Toolbar } from './components/Toolbar';
 import { useEditorStore } from './stores/editorStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useProjectStore } from './stores/projectStore';
+import * as backend from './lib/backend';
 
 function AppInner() {
   const componentPickerTarget = useEditorStore((s) => s.componentPickerTarget);
@@ -17,12 +18,10 @@ function AppInner() {
 
   const handleSave = useCallback(async () => {
     try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      const defaultDir = await invoke<string>('get_default_project_path');
+      const defaultDir = await backend.getDefaultProjectPath();
       const path = `${defaultDir}/${project.name.replace(/\s+/g, '_')}.json`;
-      await invoke('save_project', { path, project });
+      await backend.saveProject(path, project);
     } catch {
-      // Fallback: download as file in browser dev mode
       const json = JSON.stringify(project, null, 2);
       const blob = new Blob([json], { type: 'application/json' });
       const url = URL.createObjectURL(blob);

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
 import { canUndo, canRedo, undo, redo } from '@/stores/historyMiddleware';
+import * as backend from '@/lib/backend';
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
@@ -10,18 +11,16 @@ export function Toolbar() {
 
   const handleSave = useCallback(async () => {
     try {
-      const { invoke } = await import('@tauri-apps/api/core');
       let path = projectPath;
       if (!path) {
-        const defaultDir = await invoke<string>('get_default_project_path');
+        const defaultDir = await backend.getDefaultProjectPath();
         path = `${defaultDir}/${project.name.replace(/\s+/g, '_')}.json`;
       }
-      await invoke('save_project', { path, project });
+      await backend.saveProject(path, project);
       setProjectPath(path);
       setStatus('Saved!');
       setTimeout(() => setStatus(''), 2000);
-    } catch (e) {
-      // In dev mode without Tauri, fall back to download
+    } catch {
       const json = JSON.stringify(project, null, 2);
       const blob = new Blob([json], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -36,18 +35,20 @@ export function Toolbar() {
   }, [project, projectPath]);
 
   const handleLoad = useCallback(async () => {
-    try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      // In Tauri, use a simple prompt for path
-      const input = prompt('Enter project file path:');
-      if (!input) return;
-      const loaded = await invoke<typeof project>('load_project', { path: input });
-      loadProject(loaded);
-      setProjectPath(input);
-      setStatus('Loaded!');
-      setTimeout(() => setStatus(''), 2000);
-    } catch (e) {
-      // In dev mode, use file input
+    if (backend.isTauri()) {
+      try {
+        const input = prompt('Enter project file path:');
+        if (!input) return;
+        const loaded = await backend.loadProject(input);
+        loadProject(loaded);
+        setProjectPath(input);
+        setStatus('Loaded!');
+        setTimeout(() => setStatus(''), 2000);
+      } catch {
+        setStatus('Load failed');
+        setTimeout(() => setStatus(''), 2000);
+      }
+    } else {
       const input = document.createElement('input');
       input.type = 'file';
       input.accept = '.json';

--- a/ars-editor/src/lib/backend.ts
+++ b/ars-editor/src/lib/backend.ts
@@ -1,0 +1,58 @@
+import type { Project } from '@/types/domain';
+
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<T>(cmd, args);
+}
+
+async function webFetch<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`/api${url}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json();
+}
+
+export async function saveProject(path: string, project: Project): Promise<void> {
+  if (isTauri()) {
+    await tauriInvoke('save_project', { path, project });
+  } else {
+    await webFetch('/project/save', {
+      method: 'POST',
+      body: JSON.stringify({ path, project }),
+    });
+  }
+}
+
+export async function loadProject(path: string): Promise<Project> {
+  if (isTauri()) {
+    return tauriInvoke<Project>('load_project', { path });
+  }
+  return webFetch<Project>(`/project/load?path=${encodeURIComponent(path)}`);
+}
+
+export async function getDefaultProjectPath(): Promise<string> {
+  if (isTauri()) {
+    return tauriInvoke<string>('get_default_project_path');
+  }
+  return webFetch<string>('/project/default-path');
+}
+
+export async function listProjects(): Promise<string[]> {
+  if (isTauri()) {
+    const dir = await getDefaultProjectPath();
+    // Tauri doesn't have a list command built-in, return empty
+    return [];
+  }
+  return webFetch<string[]>('/project/list');
+}
+
+export { isTauri };

--- a/ars-editor/src/lib/tauri-commands.ts
+++ b/ars-editor/src/lib/tauri-commands.ts
@@ -1,17 +1,16 @@
-import { invoke } from '@tauri-apps/api/core';
-import type { Project } from '@/types/domain';
 import { useProjectStore } from '@/stores/projectStore';
+import * as backend from './backend';
 
 export async function saveProjectToFile(path: string): Promise<void> {
   const project = useProjectStore.getState().project;
-  await invoke('save_project', { path, project });
+  await backend.saveProject(path, project);
 }
 
 export async function loadProjectFromFile(path: string): Promise<void> {
-  const project = await invoke<Project>('load_project', { path });
+  const project = await backend.loadProject(path);
   useProjectStore.getState().loadProject(project);
 }
 
 export async function getDefaultProjectPath(): Promise<string> {
-  return invoke<string>('get_default_project_path');
+  return backend.getDefaultProjectPath();
 }

--- a/ars-editor/vite.config.ts
+++ b/ars-editor/vite.config.ts
@@ -12,11 +12,11 @@ export default defineConfig({
   },
   clearScreen: false,
   server: {
-    port: 5173,
+    port: 5174,
     strictPort: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:5173',
         changeOrigin: true,
       },
     },

--- a/ars-editor/vite.config.ts
+++ b/ars-editor/vite.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
   envPrefix: ['VITE_', 'TAURI_'],
   build: {


### PR DESCRIPTION
## Summary
This PR adds a web server backend to Ars Editor, enabling it to run as a standalone web application in addition to the existing Tauri desktop app. The changes introduce feature-gated compilation, a new HTTP API layer, and a unified backend abstraction that works with both Tauri and web environments.

## Key Changes

- **Web Server Implementation** (`web_server.rs`): New Axum-based HTTP server with REST API endpoints for project operations (save, load, list, default path). Includes CORS support and optional static file serving.

- **Backend Abstraction Layer** (`lib/backend.ts`): New TypeScript module that provides a unified interface for project operations, automatically routing to either Tauri commands or HTTP API calls based on the runtime environment.

- **Feature-Gated Cargo Configuration**: 
  - Split `Cargo.toml` into `tauri-app` (default) and `web-server` features
  - Made Tauri dependencies optional
  - Added new dependencies: `axum`, `tokio`, `tower-http`
  - Created separate binaries: `app` (Tauri) and `ars-web-server` (web)

- **Refactored Project Commands** (`commands/project.rs`): Extracted implementation logic into `*_impl` functions that are shared between Tauri commands and web API handlers. Added `list_projects_impl()` for directory listing.

- **Updated UI Components**: Modified `Toolbar.tsx` and `App.tsx` to use the new backend abstraction instead of direct Tauri invocations.

- **Development & Build Scripts** (`package.json`): Added `build:web-server` and `serve:web` scripts for building and running the web server variant.

- **Vite Proxy Configuration**: Added `/api` proxy to route API calls to the web server during development.

## Notable Implementation Details

- The backend abstraction uses runtime detection (`isTauri()`) to determine which implementation to use
- Project commands now support directory creation on save
- Web server listens on configurable port (default 3000) and can serve static files
- Tauri build script is now conditionally compiled based on feature flags

https://claude.ai/code/session_01Qk8hrHabrZkpr5cPE8FzAw