### PR TITLE
Remove unused variable in listProjects function

### DIFF
--- a/ars-editor/src/lib/backend.ts
+++ b/ars-editor/src/lib/backend.ts
@@ -48,7 +48,6 @@ export async function getDefaultProjectPath(): Promise<string> {
 
 export async function listProjects(): Promise<string[]> {
   if (isTauri()) {
-    const dir = await getDefaultProjectPath();
     // Tauri doesn't have a list command built-in, return empty
     return [];
   }


### PR DESCRIPTION
## Summary
Removed an unused variable declaration in the `listProjects` function that was not being utilized.

## Key Changes
- Removed the unused `dir` variable assignment from `getDefaultProjectPath()` in the Tauri code path of `listProjects()`

## Details
The `dir` variable was being assigned but never used before the function returned an empty array. This cleanup removes the unnecessary variable declaration and its associated async call, improving code clarity without changing the function's behavior.

https://claude.ai/code/session_01FbDd3aHYnRAfQw4AWKKR3f