### PR TITLE
Add component list and scene preview panels with dirty state tracking

### DIFF
--- a/ars-editor/src/App.tsx
+++ b/ars-editor/src/App.tsx
@@ -1,9 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { ReactFlowProvider } from '@xyflow/react';
 import { SceneList } from './features/scene-manager';
 import { NodeCanvas } from './features/node-editor';
 import { ComponentPicker } from './features/component-picker';
 import { ComponentEditor } from './features/component-editor';
+import { ComponentList } from './features/component-list';
+import { ScenePreview } from './features/preview';
 import { Toolbar } from './components/Toolbar';
 import { useEditorStore } from './stores/editorStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -14,13 +16,30 @@ function AppInner() {
   const componentPickerTarget = useEditorStore((s) => s.componentPickerTarget);
   const panelVisibility = useEditorStore((s) => s.panelVisibility);
   const openComponentEditor = useEditorStore((s) => s.openComponentEditor);
+  const markDirty = useEditorStore((s) => s.markDirty);
+  const markSaved = useEditorStore((s) => s.markSaved);
+  const projectPath = useEditorStore((s) => s.projectPath);
   const project = useProjectStore((s) => s.project);
+
+  // Track project changes to mark dirty
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    markDirty();
+  }, [project, markDirty]);
 
   const handleSave = useCallback(async () => {
     try {
-      const defaultDir = await backend.getDefaultProjectPath();
-      const path = `${defaultDir}/${project.name.replace(/\s+/g, '_')}.json`;
+      let path = projectPath;
+      if (!path) {
+        const defaultDir = await backend.getDefaultProjectPath();
+        path = `${defaultDir}/${project.name.replace(/\s+/g, '_')}.json`;
+      }
       await backend.saveProject(path, project);
+      markSaved(path);
     } catch {
       const json = JSON.stringify(project, null, 2);
       const blob = new Blob([json], { type: 'application/json' });
@@ -30,8 +49,9 @@ function AppInner() {
       a.download = `${project.name.replace(/\s+/g, '_')}.json`;
       a.click();
       URL.revokeObjectURL(url);
+      markSaved();
     }
-  }, [project]);
+  }, [project, projectPath, markSaved]);
 
   useKeyboardShortcuts({ onSave: handleSave });
 
@@ -56,10 +76,24 @@ function AppInner() {
           </div>
         )}
 
+        {/* Component List Panel */}
+        {panelVisibility.componentList && (
+          <div className="w-64 min-w-[256px] bg-zinc-850 border-r border-zinc-700">
+            <ComponentList />
+          </div>
+        )}
+
         {/* Main - Node Editor */}
         <div className="flex-1 flex flex-col overflow-hidden">
           <NodeCanvas />
         </div>
+
+        {/* Preview Panel */}
+        {panelVisibility.preview && (
+          <div className="w-72 min-w-[288px] bg-zinc-850 border-l border-zinc-700">
+            <ScenePreview />
+          </div>
+        )}
 
         {/* Right Panel - Component Editor */}
         {panelVisibility.componentEditor && (

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -1,13 +1,26 @@
 import { useState, useCallback } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
+import { useEditorStore } from '@/stores/editorStore';
 import { canUndo, canRedo, undo, redo } from '@/stores/historyMiddleware';
 import * as backend from '@/lib/backend';
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
   const loadProject = useProjectStore((s) => s.loadProject);
-  const [projectPath, setProjectPath] = useState<string | null>(null);
+  const isDirty = useEditorStore((s) => s.isDirty);
+  const lastSavedAt = useEditorStore((s) => s.lastSavedAt);
+  const projectPath = useEditorStore((s) => s.projectPath);
+  const markDirty = useEditorStore((s) => s.markDirty);
+  const markSaved = useEditorStore((s) => s.markSaved);
+  const setProjectPath = useEditorStore((s) => s.setProjectPath);
+  const togglePanel = useEditorStore((s) => s.togglePanel);
+  const panelVisibility = useEditorStore((s) => s.panelVisibility);
   const [status, setStatus] = useState<string>('');
+
+  const showStatus = (msg: string) => {
+    setStatus(msg);
+    setTimeout(() => setStatus(''), 2000);
+  };
 
   const handleSave = useCallback(async () => {
     try {
@@ -17,9 +30,8 @@ export function Toolbar() {
         path = `${defaultDir}/${project.name.replace(/\s+/g, '_')}.json`;
       }
       await backend.saveProject(path, project);
-      setProjectPath(path);
-      setStatus('Saved!');
-      setTimeout(() => setStatus(''), 2000);
+      markSaved(path);
+      showStatus('Saved!');
     } catch {
       const json = JSON.stringify(project, null, 2);
       const blob = new Blob([json], { type: 'application/json' });
@@ -29,10 +41,10 @@ export function Toolbar() {
       a.download = `${project.name.replace(/\s+/g, '_')}.json`;
       a.click();
       URL.revokeObjectURL(url);
-      setStatus('Downloaded!');
-      setTimeout(() => setStatus(''), 2000);
+      markSaved();
+      showStatus('Downloaded!');
     }
-  }, [project, projectPath]);
+  }, [project, projectPath, markSaved]);
 
   const handleLoad = useCallback(async () => {
     if (backend.isTauri()) {
@@ -42,11 +54,10 @@ export function Toolbar() {
         const loaded = await backend.loadProject(input);
         loadProject(loaded);
         setProjectPath(input);
-        setStatus('Loaded!');
-        setTimeout(() => setStatus(''), 2000);
+        markSaved(input);
+        showStatus('Loaded!');
       } catch {
-        setStatus('Load failed');
-        setTimeout(() => setStatus(''), 2000);
+        showStatus('Load failed');
       }
     } else {
       const input = document.createElement('input');
@@ -59,19 +70,18 @@ export function Toolbar() {
         try {
           const parsed = JSON.parse(text);
           loadProject(parsed);
-          setStatus('Loaded!');
-          setTimeout(() => setStatus(''), 2000);
+          markSaved();
+          showStatus('Loaded!');
         } catch {
-          setStatus('Invalid file');
-          setTimeout(() => setStatus(''), 2000);
+          showStatus('Invalid file');
         }
       };
       input.click();
     }
-  }, [loadProject]);
+  }, [loadProject, setProjectPath, markSaved]);
 
   const handleNew = useCallback(() => {
-    if (!confirm('Create a new project? Unsaved changes will be lost.')) return;
+    if (isDirty && !confirm('Create a new project? Unsaved changes will be lost.')) return;
     loadProject({
       name: 'Untitled Project',
       scenes: {},
@@ -79,9 +89,13 @@ export function Toolbar() {
       activeSceneId: null,
     });
     setProjectPath(null);
-    setStatus('New project');
-    setTimeout(() => setStatus(''), 2000);
-  }, [loadProject]);
+    markSaved();
+    showStatus('New project');
+  }, [loadProject, setProjectPath, markSaved, isDirty]);
+
+  const lastSavedLabel = lastSavedAt
+    ? `Last saved: ${new Date(lastSavedAt).toLocaleTimeString()}`
+    : '';
 
   return (
     <div className="flex items-center gap-1 px-2 py-1 bg-zinc-800 border-b border-zinc-700 text-xs">
@@ -105,14 +119,14 @@ export function Toolbar() {
         className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors"
         title="Save Project (Ctrl+S)"
       >
-        Save
+        Save{isDirty ? ' *' : ''}
       </button>
 
       <div className="w-px h-4 bg-zinc-600 mx-1" />
 
       {/* Undo/Redo */}
       <button
-        onClick={() => undo()}
+        onClick={() => { undo(); markDirty(); }}
         disabled={!canUndo()}
         className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         title="Undo (Ctrl+Z)"
@@ -120,7 +134,7 @@ export function Toolbar() {
         Undo
       </button>
       <button
-        onClick={() => redo()}
+        onClick={() => { redo(); markDirty(); }}
         disabled={!canRedo()}
         className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         title="Redo (Ctrl+Y)"
@@ -128,9 +142,41 @@ export function Toolbar() {
         Redo
       </button>
 
-      {/* Project name */}
+      <div className="w-px h-4 bg-zinc-600 mx-1" />
+
+      {/* View toggles */}
+      <button
+        onClick={() => togglePanel('componentList')}
+        className={`px-2 py-1 rounded transition-colors ${
+          panelVisibility.componentList
+            ? 'bg-blue-600 text-white'
+            : 'text-zinc-300 hover:bg-zinc-700'
+        }`}
+        title="Toggle Component List"
+      >
+        Components
+      </button>
+      <button
+        onClick={() => togglePanel('preview')}
+        className={`px-2 py-1 rounded transition-colors ${
+          panelVisibility.preview
+            ? 'bg-blue-600 text-white'
+            : 'text-zinc-300 hover:bg-zinc-700'
+        }`}
+        title="Toggle Preview"
+      >
+        Preview
+      </button>
+
+      {/* Project name & status */}
       <div className="flex-1" />
-      <span className="text-zinc-500 truncate max-w-[200px]">{project.name}</span>
+      {lastSavedLabel && !status && (
+        <span className="text-zinc-600 mr-2">{lastSavedLabel}</span>
+      )}
+      <span className="text-zinc-500 truncate max-w-[200px]">
+        {project.name}
+        {isDirty && <span className="text-amber-400 ml-1">(unsaved)</span>}
+      </span>
       {status && (
         <span className="text-green-400 ml-2">{status}</span>
       )}

--- a/ars-editor/src/features/component-list/components/ComponentList.tsx
+++ b/ars-editor/src/features/component-list/components/ComponentList.tsx
@@ -1,0 +1,208 @@
+import { useState, useMemo } from 'react';
+import { useProjectStore } from '@/stores/projectStore';
+import { useEditorStore } from '@/stores/editorStore';
+import type { ComponentCategory } from '@/types/domain';
+
+const CATEGORIES: ComponentCategory[] = ['UI', 'Logic', 'System', 'GameObject'];
+
+const CATEGORY_ICONS: Record<string, string> = {
+  UI: '🖼️',
+  Logic: '🎮',
+  System: '🔧',
+  GameObject: '📦',
+};
+
+export function ComponentList() {
+  const project = useProjectStore((s) => s.project);
+  const deleteComponent = useProjectStore((s) => s.deleteComponent);
+  const openComponentEditor = useEditorStore((s) => s.openComponentEditor);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<ComponentCategory | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const allComponents = useMemo(() => Object.values(project.components), [project.components]);
+
+  const filteredComponents = useMemo(() => {
+    return allComponents.filter((comp) => {
+      if (categoryFilter && comp.category !== categoryFilter) return false;
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        return (
+          comp.name.toLowerCase().includes(q) ||
+          comp.domain.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  }, [allComponents, categoryFilter, searchQuery]);
+
+  const groupedByCategory = useMemo(() => {
+    const groups: Record<string, typeof filteredComponents> = {};
+    for (const comp of filteredComponents) {
+      if (!groups[comp.category]) groups[comp.category] = [];
+      groups[comp.category].push(comp);
+    }
+    return groups;
+  }, [filteredComponents]);
+
+  const handleDelete = (id: string, name: string) => {
+    if (!confirm(`Delete component "${name}"? This will remove it from all actors.`)) return;
+    deleteComponent(id);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-3 py-2 border-b border-zinc-700">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+          Components ({allComponents.length})
+        </h2>
+        <input
+          className="w-full bg-zinc-800 text-white text-sm px-2 py-1 rounded border border-zinc-600 outline-none focus:border-blue-500 mb-2"
+          placeholder="Search..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+        <div className="flex gap-1 flex-wrap">
+          <button
+            className={`text-xs px-2 py-0.5 rounded transition-colors ${
+              categoryFilter === null
+                ? 'bg-blue-600 text-white'
+                : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700'
+            }`}
+            onClick={() => setCategoryFilter(null)}
+          >
+            All
+          </button>
+          {CATEGORIES.map((cat) => (
+            <button
+              key={cat}
+              className={`text-xs px-2 py-0.5 rounded transition-colors ${
+                categoryFilter === cat
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700'
+              }`}
+              onClick={() => setCategoryFilter(cat)}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2 space-y-1">
+        {filteredComponents.length === 0 ? (
+          <p className="text-zinc-500 text-sm text-center py-4">
+            {allComponents.length === 0 ? 'No components defined yet' : 'No matching components'}
+          </p>
+        ) : (
+          Object.entries(groupedByCategory).map(([category, comps]) => (
+            <div key={category} className="mb-2">
+              <div className="text-xs text-zinc-500 font-medium px-1 py-1 uppercase tracking-wider">
+                {CATEGORY_ICONS[category] ?? '📎'} {category} ({comps.length})
+              </div>
+              {comps.map((comp) => (
+                <div key={comp.id}>
+                  <div
+                    className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-zinc-800 cursor-pointer group"
+                    onClick={() => setExpandedId(expandedId === comp.id ? null : comp.id)}
+                  >
+                    <span className="text-xs text-zinc-500">
+                      {expandedId === comp.id ? '▼' : '▶'}
+                    </span>
+                    <span className="text-sm text-zinc-200 flex-1 truncate">{comp.name}</span>
+                    <span className="text-xs text-zinc-600">{comp.domain}</span>
+                    <button
+                      className="text-xs text-blue-400 hover:text-blue-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openComponentEditor(comp.id);
+                      }}
+                      title="Edit"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className="text-xs text-red-400 hover:text-red-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(comp.id, comp.name);
+                      }}
+                      title="Delete"
+                    >
+                      Del
+                    </button>
+                  </div>
+
+                  {expandedId === comp.id && (
+                    <div className="ml-5 pl-3 border-l border-zinc-700 mb-2 space-y-1">
+                      {/* Variables */}
+                      {comp.variables.length > 0 && (
+                        <div>
+                          <div className="text-xs text-zinc-500 font-medium">Variables</div>
+                          {comp.variables.map((v, i) => (
+                            <div key={i} className="text-xs text-zinc-400 pl-2">
+                              {v.name}: <span className="text-zinc-500">{v.type}</span>
+                              {v.defaultValue !== undefined && (
+                                <span className="text-zinc-600"> = {String(v.defaultValue)}</span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Tasks */}
+                      {comp.tasks.length > 0 && (
+                        <div>
+                          <div className="text-xs text-zinc-500 font-medium">Tasks</div>
+                          {comp.tasks.map((t, i) => (
+                            <div key={i} className="text-xs text-zinc-400 pl-2">
+                              <span className="text-zinc-300">{t.name}</span>
+                              {t.inputs.length > 0 && (
+                                <span className="text-zinc-600">
+                                  {' '}in: {t.inputs.map((p) => p.name).join(', ')}
+                                </span>
+                              )}
+                              {t.outputs.length > 0 && (
+                                <span className="text-zinc-600">
+                                  {' '}out: {t.outputs.map((p) => p.name).join(', ')}
+                                </span>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Dependencies */}
+                      {comp.dependencies.length > 0 && (
+                        <div>
+                          <div className="text-xs text-zinc-500 font-medium">Dependencies</div>
+                          {comp.dependencies.map((depId) => {
+                            const dep = project.components[depId];
+                            return (
+                              <div key={depId} className="text-xs text-zinc-400 pl-2">
+                                {dep ? dep.name : depId}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="border-t border-zinc-700 p-2">
+        <button
+          className="w-full text-xs text-blue-400 hover:text-blue-300 hover:bg-zinc-800 py-2 rounded transition-colors"
+          onClick={() => openComponentEditor(null)}
+        >
+          + New Component
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/component-list/index.ts
+++ b/ars-editor/src/features/component-list/index.ts
@@ -1,0 +1,1 @@
+export { ComponentList } from './components/ComponentList';

--- a/ars-editor/src/features/preview/components/ScenePreview.tsx
+++ b/ars-editor/src/features/preview/components/ScenePreview.tsx
@@ -1,0 +1,192 @@
+import { useMemo } from 'react';
+import { useProjectStore } from '@/stores/projectStore';
+
+const ROLE_COLORS: Record<string, string> = {
+  scene: 'text-blue-400',
+  actor: 'text-green-400',
+  sequence: 'text-orange-400',
+};
+
+const ROLE_BG: Record<string, string> = {
+  scene: 'bg-blue-900/30 border-blue-800',
+  actor: 'bg-green-900/30 border-green-800',
+  sequence: 'bg-orange-900/30 border-orange-800',
+};
+
+function ActorPreviewNode({
+  actorId,
+  sceneId,
+  depth,
+}: {
+  actorId: string;
+  sceneId: string;
+  depth: number;
+}) {
+  const project = useProjectStore((s) => s.project);
+  const scene = project.scenes[sceneId];
+  if (!scene) return null;
+
+  const actor = scene.actors[actorId];
+  if (!actor) return null;
+
+  const attachedComponents = actor.components
+    .map((id) => project.components[id])
+    .filter(Boolean);
+
+  // Find connections involving this actor
+  const connections = scene.connections.filter(
+    (c) => c.sourceActorId === actorId || c.targetActorId === actorId,
+  );
+
+  // Find children (actors with parentId === actorId)
+  const children = Object.values(scene.actors).filter(
+    (a) => a.parentId === actorId,
+  );
+
+  return (
+    <div className={`${depth > 0 ? 'ml-4 border-l border-zinc-700 pl-3' : ''}`}>
+      <div className={`rounded border px-3 py-2 mb-1 ${ROLE_BG[actor.role] ?? 'bg-zinc-800 border-zinc-700'}`}>
+        {/* Actor header */}
+        <div className="flex items-center gap-2">
+          <span className={`font-semibold text-sm ${ROLE_COLORS[actor.role] ?? 'text-zinc-300'}`}>
+            {actor.name}
+          </span>
+          <span className="text-xs text-zinc-500">[{actor.role}]</span>
+        </div>
+
+        {/* Attached components */}
+        {attachedComponents.length > 0 && (
+          <div className="mt-1 space-y-0.5">
+            {attachedComponents.map((comp) => (
+              <div key={comp.id} className="text-xs text-zinc-400 flex items-center gap-1">
+                <span className="text-zinc-600">├</span>
+                <span>{comp.name}</span>
+                <span className="text-zinc-600">({comp.category})</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Connections */}
+        {connections.length > 0 && (
+          <div className="mt-1 space-y-0.5">
+            {connections.map((conn) => {
+              const isSource = conn.sourceActorId === actorId;
+              const otherId = isSource ? conn.targetActorId : conn.sourceActorId;
+              const other = scene.actors[otherId];
+              return (
+                <div key={conn.id} className="text-xs text-zinc-500 flex items-center gap-1">
+                  <span className="text-zinc-600">→</span>
+                  <span>
+                    {isSource ? conn.sourcePort : conn.targetPort}
+                    {' → '}
+                    {other?.name ?? otherId}
+                    .{isSource ? conn.targetPort : conn.sourcePort}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Children */}
+      {children.map((child) => (
+        <ActorPreviewNode
+          key={child.id}
+          actorId={child.id}
+          sceneId={sceneId}
+          depth={depth + 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ScenePreview() {
+  const project = useProjectStore((s) => s.project);
+  const activeScene = project.activeSceneId
+    ? project.scenes[project.activeSceneId]
+    : null;
+
+  const stats = useMemo(() => {
+    if (!activeScene) return null;
+    const actors = Object.values(activeScene.actors);
+    const componentIds = new Set(actors.flatMap((a) => a.components));
+    return {
+      actorCount: actors.length,
+      connectionCount: activeScene.connections.length,
+      componentCount: componentIds.size,
+    };
+  }, [activeScene]);
+
+  // Find root-level actors (no parentId)
+  const rootActors = useMemo(() => {
+    if (!activeScene) return [];
+    return Object.values(activeScene.actors).filter(
+      (a) => !a.parentId,
+    );
+  }, [activeScene]);
+
+  if (!activeScene) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="px-3 py-2 border-b border-zinc-700">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+            Preview
+          </h2>
+        </div>
+        <div className="flex-1 flex items-center justify-center text-zinc-500 text-sm">
+          Select a scene to preview
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-3 py-2 border-b border-zinc-700">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+          Preview
+        </h2>
+        <div className="text-sm text-white mt-1">{activeScene.name}</div>
+        {stats && (
+          <div className="flex gap-3 mt-1 text-xs text-zinc-500">
+            <span>{stats.actorCount} actors</span>
+            <span>{stats.connectionCount} connections</span>
+            <span>{stats.componentCount} components</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-1">
+        {rootActors.length === 0 ? (
+          <p className="text-zinc-500 text-sm text-center py-4">No actors in this scene</p>
+        ) : (
+          rootActors.map((actor) => (
+            <ActorPreviewNode
+              key={actor.id}
+              actorId={actor.id}
+              sceneId={activeScene.id}
+              depth={0}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Scene JSON export */}
+      <div className="border-t border-zinc-700 p-2">
+        <button
+          className="w-full text-xs text-zinc-400 hover:text-zinc-300 hover:bg-zinc-800 py-2 rounded transition-colors"
+          onClick={() => {
+            const json = JSON.stringify(activeScene, null, 2);
+            navigator.clipboard.writeText(json);
+          }}
+          title="Copy scene JSON to clipboard"
+        >
+          Copy Scene JSON
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/preview/index.ts
+++ b/ars-editor/src/features/preview/index.ts
@@ -1,0 +1,1 @@
+export { ScenePreview } from './components/ScenePreview';

--- a/ars-editor/src/stores/editorStore.ts
+++ b/ars-editor/src/stores/editorStore.ts
@@ -8,7 +8,12 @@ interface EditorState {
   panelVisibility: {
     sceneManager: boolean;
     componentEditor: boolean;
+    componentList: boolean;
+    preview: boolean;
   };
+  isDirty: boolean;
+  lastSavedAt: number | null;
+  projectPath: string | null;
 
   setSelectedNodes: (ids: string[]) => void;
   openContextMenu: (pos: { x: number; y: number }) => void;
@@ -17,7 +22,10 @@ interface EditorState {
   closeComponentPicker: () => void;
   openComponentEditor: (componentId: string | null) => void;
   closeComponentEditor: () => void;
-  togglePanel: (panel: 'sceneManager' | 'componentEditor') => void;
+  togglePanel: (panel: 'sceneManager' | 'componentEditor' | 'componentList' | 'preview') => void;
+  markDirty: () => void;
+  markSaved: (path?: string) => void;
+  setProjectPath: (path: string | null) => void;
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
@@ -28,7 +36,12 @@ export const useEditorStore = create<EditorState>()((set) => ({
   panelVisibility: {
     sceneManager: true,
     componentEditor: false,
+    componentList: false,
+    preview: false,
   },
+  isDirty: false,
+  lastSavedAt: null,
+  projectPath: null,
 
   setSelectedNodes: (ids) => set({ selectedNodeIds: ids }),
   openContextMenu: (pos) => set({ contextMenu: pos }),
@@ -52,4 +65,12 @@ export const useEditorStore = create<EditorState>()((set) => ({
         [panel]: !s.panelVisibility[panel],
       },
     })),
+  markDirty: () => set({ isDirty: true }),
+  markSaved: (path) =>
+    set((s) => ({
+      isDirty: false,
+      lastSavedAt: Date.now(),
+      projectPath: path ?? s.projectPath,
+    })),
+  setProjectPath: (path) => set({ projectPath: path }),
 }));


### PR DESCRIPTION
## Summary
This PR adds two new UI panels to the editor (Component List and Scene Preview) and implements project dirty state tracking to better manage save operations.

## Key Changes

### New Features
- **Component List Panel**: A new sidebar panel that displays all components in the project with:
  - Search and category filtering (UI, Logic, System, GameObject)
  - Expandable component details showing variables, tasks, and dependencies
  - Quick edit and delete actions
  - Component count and organization by category

- **Scene Preview Panel**: A new sidebar panel that visualizes the active scene with:
  - Hierarchical actor tree with parent-child relationships
  - Attached components and connections for each actor
  - Scene statistics (actor count, connections, components)
  - Scene JSON export functionality

### State Management Improvements
- **Dirty State Tracking**: Added `isDirty`, `lastSavedAt`, and `projectPath` to editor store to track unsaved changes
- **Auto-dirty on Changes**: Project modifications automatically mark the editor as dirty
- **Save State Persistence**: Tracks when the project was last saved and the file path
- **UI Indicators**: Toolbar now shows unsaved indicator (*) and last saved timestamp

### UI/UX Enhancements
- Added toggle buttons in toolbar to show/hide Component List and Preview panels
- Visual indicators for dirty state in project name and save button
- Improved save flow with better path handling for new vs. existing projects
- Confirmation dialogs for destructive operations (new project, delete component)

### Implementation Details
- Component List uses memoized filtering and grouping for performance
- Scene Preview recursively renders actor hierarchies with proper indentation
- Editor store now manages panel visibility state for all panels
- Keyboard shortcuts and save operations properly trigger dirty state updates

https://claude.ai/code/session_01XiJe25gKy6zkeG4NRqED3Q