### PR TITLE
feat: add actor sequences, subscenes, prefabs, and copy-paste

### DIFF
--- a/ars-editor/src/App.tsx
+++ b/ars-editor/src/App.tsx
@@ -6,20 +6,31 @@ import { ComponentPicker } from './features/component-picker';
 import { ComponentEditor } from './features/component-editor';
 import { ComponentList } from './features/component-list';
 import { ScenePreview } from './features/preview';
+import { SequenceEditor } from './features/sequence-editor';
+import { SubScenePicker } from './features/subscene-picker';
+import { PrefabList } from './features/prefab-list';
 import { Toolbar } from './components/Toolbar';
 import { useEditorStore } from './stores/editorStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useProjectStore } from './stores/projectStore';
+import { generateId } from './lib/utils';
 import * as backend from './lib/backend';
 
 function AppInner() {
   const componentPickerTarget = useEditorStore((s) => s.componentPickerTarget);
+  const sequenceEditorTarget = useEditorStore((s) => s.sequenceEditorTarget);
+  const subScenePickerTarget = useEditorStore((s) => s.subScenePickerTarget);
   const panelVisibility = useEditorStore((s) => s.panelVisibility);
   const openComponentEditor = useEditorStore((s) => s.openComponentEditor);
   const markDirty = useEditorStore((s) => s.markDirty);
   const markSaved = useEditorStore((s) => s.markSaved);
   const projectPath = useEditorStore((s) => s.projectPath);
+  const selectedNodeIds = useEditorStore((s) => s.selectedNodeIds);
+  const copyToClipboard = useEditorStore((s) => s.copyToClipboard);
+  const clipboard = useEditorStore((s) => s.clipboard);
   const project = useProjectStore((s) => s.project);
+  const addActor = useProjectStore((s) => s.addActor);
+  const duplicateActor = useProjectStore((s) => s.duplicateActor);
 
   // Track project changes to mark dirty
   const isFirstRender = useRef(true);
@@ -53,7 +64,48 @@ function AppInner() {
     }
   }, [project, projectPath, markSaved]);
 
-  useKeyboardShortcuts({ onSave: handleSave });
+  const handleCopy = useCallback(() => {
+    if (!project.activeSceneId || selectedNodeIds.length === 0) return;
+    const scene = project.scenes[project.activeSceneId];
+    if (!scene) return;
+    const actors = selectedNodeIds
+      .map((id) => scene.actors[id])
+      .filter(Boolean);
+    if (actors.length > 0) {
+      copyToClipboard(actors);
+    }
+  }, [project, selectedNodeIds, copyToClipboard]);
+
+  const handlePaste = useCallback(() => {
+    if (!project.activeSceneId || !clipboard || clipboard.length === 0) return;
+    for (const actor of clipboard) {
+      addActor(project.activeSceneId, {
+        ...actor,
+        id: generateId(),
+        name: `${actor.name} (Paste)`,
+        position: {
+          x: actor.position.x + 50,
+          y: actor.position.y + 50,
+        },
+        parentId: null,
+        children: [],
+      });
+    }
+  }, [project.activeSceneId, clipboard, addActor]);
+
+  const handleDuplicate = useCallback(() => {
+    if (!project.activeSceneId || selectedNodeIds.length === 0) return;
+    for (const id of selectedNodeIds) {
+      duplicateActor(project.activeSceneId, id);
+    }
+  }, [project.activeSceneId, selectedNodeIds, duplicateActor]);
+
+  useKeyboardShortcuts({
+    onSave: handleSave,
+    onCopy: handleCopy,
+    onPaste: handlePaste,
+    onDuplicate: handleDuplicate,
+  });
 
   return (
     <div className="flex flex-col h-screen w-screen bg-zinc-900 text-zinc-200">
@@ -83,6 +135,13 @@ function AppInner() {
           </div>
         )}
 
+        {/* Prefab List Panel */}
+        {panelVisibility.prefabList && (
+          <div className="w-60 min-w-[240px] bg-zinc-850 border-r border-zinc-700">
+            <PrefabList />
+          </div>
+        )}
+
         {/* Main - Node Editor */}
         <div className="flex-1 flex flex-col overflow-hidden">
           <NodeCanvas />
@@ -104,6 +163,12 @@ function AppInner() {
 
         {/* Modal - Component Picker */}
         {componentPickerTarget && <ComponentPicker />}
+
+        {/* Modal - Sequence Editor */}
+        {sequenceEditorTarget && <SequenceEditor />}
+
+        {/* Modal - SubScene Picker */}
+        {subScenePickerTarget && <SubScenePicker />}
       </div>
     </div>
   );

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -86,6 +86,7 @@ export function Toolbar() {
       name: 'Untitled Project',
       scenes: {},
       components: {},
+      prefabs: {},
       activeSceneId: null,
     });
     setProjectPath(null);
@@ -155,6 +156,17 @@ export function Toolbar() {
         title="Toggle Component List"
       >
         Components
+      </button>
+      <button
+        onClick={() => togglePanel('prefabList')}
+        className={`px-2 py-1 rounded transition-colors ${
+          panelVisibility.prefabList
+            ? 'bg-purple-600 text-white'
+            : 'text-zinc-300 hover:bg-zinc-700'
+        }`}
+        title="Toggle Prefab List"
+      >
+        Prefabs
       </button>
       <button
         onClick={() => togglePanel('preview')}

--- a/ars-editor/src/features/node-editor/components/ActorNode.tsx
+++ b/ars-editor/src/features/node-editor/components/ActorNode.tsx
@@ -16,7 +16,17 @@ const CATEGORY_ICONS: Record<string, string> = {
 export const ActorNode = memo(function ActorNode({ data, selected }: NodeProps) {
   const nodeData = data as unknown as ActorNodeData;
   const components = useProjectStore((s) => s.project.components);
+  const scenes = useProjectStore((s) => s.project.scenes);
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const activeScene = activeSceneId ? scenes[activeSceneId] : null;
+  const actor = activeScene?.actors[nodeData.actorId];
   const openComponentPicker = useEditorStore((s) => s.openComponentPicker);
+  const openSequenceEditor = useEditorStore((s) => s.openSequenceEditor);
+  const openSubScenePicker = useEditorStore((s) => s.openSubScenePicker);
+  const copyToClipboard = useEditorStore((s) => s.copyToClipboard);
+  const duplicateActor = useProjectStore((s) => s.duplicateActor);
+  const createPrefab = useProjectStore((s) => s.createPrefab);
+  const prefabs = useProjectStore((s) => s.project.prefabs);
   const colors = ROLE_COLORS[nodeData.role];
 
   const attachedComponents = nodeData.componentIds
@@ -37,6 +47,10 @@ export const ActorNode = memo(function ActorNode({ data, selected }: NodeProps) 
     }
   }
 
+  const subSceneName = actor?.subSceneId ? scenes[actor.subSceneId]?.name : null;
+  const sequenceCount = actor?.sequences?.length ?? 0;
+  const prefabName = actor?.prefabId ? prefabs[actor.prefabId]?.name : null;
+
   return (
     <div
       className={cn(
@@ -49,8 +63,20 @@ export const ActorNode = memo(function ActorNode({ data, selected }: NodeProps) 
       {/* Header */}
       <div className={cn('px-3 py-2 rounded-t-md flex items-center justify-between', colors.header)}>
         <span className="text-white font-semibold text-sm truncate">{nodeData.name}</span>
-        <span className="text-white/70 text-xs ml-2">[{nodeData.role}]</span>
+        <div className="flex items-center gap-1 ml-2">
+          {prefabName && (
+            <span className="text-white/50 text-[10px] bg-white/10 px-1 rounded">P</span>
+          )}
+          <span className="text-white/70 text-xs">[{nodeData.role}]</span>
+        </div>
       </div>
+
+      {/* Prefab indicator */}
+      {prefabName && (
+        <div className="px-3 py-1 border-t border-zinc-700">
+          <div className="text-purple-400 text-[10px]">Prefab: {prefabName}</div>
+        </div>
+      )}
 
       {/* Components */}
       <div className="px-3 py-2 border-t border-zinc-700">
@@ -76,6 +102,91 @@ export const ActorNode = memo(function ActorNode({ data, selected }: NodeProps) 
           }}
         >
           [+ Add]
+        </button>
+      </div>
+
+      {/* Sequences */}
+      <div className="px-3 py-2 border-t border-zinc-700">
+        <div className="flex items-center justify-between">
+          <div className="text-zinc-400 text-xs">
+            Sequences: {sequenceCount > 0 ? `(${sequenceCount})` : ''}
+          </div>
+          <button
+            className="text-xs text-orange-400 hover:text-orange-300 transition-colors"
+            onClick={(e) => {
+              e.stopPropagation();
+              openSequenceEditor(nodeData.actorId);
+            }}
+          >
+            [Edit]
+          </button>
+        </div>
+        {sequenceCount > 0 && actor?.sequences && (
+          <div className="mt-1 space-y-0.5">
+            {actor.sequences.slice(0, 3).map((step) => (
+              <div key={step.id} className="text-[10px] text-zinc-500 truncate">
+                {step.order + 1}. {step.name}
+              </div>
+            ))}
+            {sequenceCount > 3 && (
+              <div className="text-[10px] text-zinc-600">...+{sequenceCount - 3} more</div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* SubScene */}
+      <div className="px-3 py-1.5 border-t border-zinc-700">
+        <div className="flex items-center justify-between">
+          <div className="text-zinc-400 text-xs">
+            SubScene: {subSceneName ? <span className="text-cyan-400">{subSceneName}</span> : <span className="text-zinc-600 italic">None</span>}
+          </div>
+          <button
+            className="text-xs text-cyan-400 hover:text-cyan-300 transition-colors"
+            onClick={(e) => {
+              e.stopPropagation();
+              openSubScenePicker(nodeData.actorId);
+            }}
+          >
+            [Set]
+          </button>
+        </div>
+      </div>
+
+      {/* Actions: Copy, Duplicate, Save as Prefab */}
+      <div className="px-3 py-1.5 border-t border-zinc-700 flex gap-1 flex-wrap">
+        <button
+          className="text-[10px] text-zinc-400 hover:text-white bg-zinc-800 hover:bg-zinc-700 px-1.5 py-0.5 rounded transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (actor) copyToClipboard([actor]);
+          }}
+          title="Copy Actor"
+        >
+          Copy
+        </button>
+        <button
+          className="text-[10px] text-zinc-400 hover:text-white bg-zinc-800 hover:bg-zinc-700 px-1.5 py-0.5 rounded transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (activeSceneId) duplicateActor(activeSceneId, nodeData.actorId);
+          }}
+          title="Duplicate Actor"
+        >
+          Duplicate
+        </button>
+        <button
+          className="text-[10px] text-purple-400 hover:text-purple-300 bg-zinc-800 hover:bg-zinc-700 px-1.5 py-0.5 rounded transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (activeSceneId) {
+              const name = prompt('Prefab name:', nodeData.name);
+              if (name) createPrefab(name, activeSceneId, nodeData.actorId);
+            }
+          }}
+          title="Save as Prefab"
+        >
+          Save Prefab
         </button>
       </div>
 

--- a/ars-editor/src/features/node-editor/components/ContextMenu.tsx
+++ b/ars-editor/src/features/node-editor/components/ContextMenu.tsx
@@ -2,6 +2,7 @@ import { useEditorStore } from '@/stores/editorStore';
 import { useProjectStore } from '@/stores/projectStore';
 import type { ActorRole } from '@/types/domain';
 import { useCallback, useEffect, useRef } from 'react';
+import { generateId } from '@/lib/utils';
 
 interface ContextMenuProps {
   flowPosition: { x: number; y: number } | null;
@@ -10,8 +11,11 @@ interface ContextMenuProps {
 export function ContextMenu({ flowPosition }: ContextMenuProps) {
   const contextMenu = useEditorStore((s) => s.contextMenu);
   const closeContextMenu = useEditorStore((s) => s.closeContextMenu);
+  const clipboard = useEditorStore((s) => s.clipboard);
   const addActor = useProjectStore((s) => s.addActor);
+  const instantiatePrefab = useProjectStore((s) => s.instantiatePrefab);
   const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const prefabs = useProjectStore((s) => s.project.prefabs);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -33,10 +37,37 @@ export function ContextMenu({ flowPosition }: ContextMenuProps) {
         components: [],
         children: [],
         position: flowPosition,
+        sequences: [],
+        subSceneId: null,
+        prefabId: null,
       });
       closeContextMenu();
     },
     [activeSceneId, addActor, closeContextMenu, flowPosition],
+  );
+
+  const handlePaste = useCallback(() => {
+    if (!activeSceneId || !flowPosition || !clipboard) return;
+    for (const actor of clipboard) {
+      addActor(activeSceneId, {
+        ...actor,
+        id: generateId(),
+        name: `${actor.name} (Paste)`,
+        position: flowPosition,
+        parentId: null,
+        children: [],
+      });
+    }
+    closeContextMenu();
+  }, [activeSceneId, addActor, clipboard, closeContextMenu, flowPosition]);
+
+  const handleInstantiatePrefab = useCallback(
+    (prefabId: string) => {
+      if (!activeSceneId || !flowPosition) return;
+      instantiatePrefab(prefabId, activeSceneId, flowPosition);
+      closeContextMenu();
+    },
+    [activeSceneId, instantiatePrefab, closeContextMenu, flowPosition],
   );
 
   if (!contextMenu) return null;
@@ -46,10 +77,12 @@ export function ContextMenu({ flowPosition }: ContextMenuProps) {
     { label: 'Add Sequence', role: 'sequence', icon: '🟠' },
   ];
 
+  const prefabList = Object.values(prefabs);
+
   return (
     <div
       ref={menuRef}
-      className="absolute z-50 bg-zinc-800 border border-zinc-600 rounded-lg shadow-xl py-1 min-w-[160px]"
+      className="absolute z-50 bg-zinc-800 border border-zinc-600 rounded-lg shadow-xl py-1 min-w-[180px]"
       style={{ left: contextMenu.x, top: contextMenu.y }}
     >
       <div className="px-3 py-1 text-xs text-zinc-500 uppercase tracking-wider">Add Node</div>
@@ -63,6 +96,38 @@ export function ContextMenu({ flowPosition }: ContextMenuProps) {
           <span>{label}</span>
         </button>
       ))}
+
+      {/* Paste */}
+      {clipboard && clipboard.length > 0 && (
+        <>
+          <div className="h-px bg-zinc-700 my-1" />
+          <button
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors"
+            onClick={handlePaste}
+          >
+            <span>📋</span>
+            <span>Paste Actor ({clipboard.length})</span>
+          </button>
+        </>
+      )}
+
+      {/* Prefabs */}
+      {prefabList.length > 0 && (
+        <>
+          <div className="h-px bg-zinc-700 my-1" />
+          <div className="px-3 py-1 text-xs text-zinc-500 uppercase tracking-wider">From Prefab</div>
+          {prefabList.map((prefab) => (
+            <button
+              key={prefab.id}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm text-purple-300 hover:bg-zinc-700 transition-colors"
+              onClick={() => handleInstantiatePrefab(prefab.id)}
+            >
+              <span>🟣</span>
+              <span>{prefab.name}</span>
+            </button>
+          ))}
+        </>
+      )}
     </div>
   );
 }

--- a/ars-editor/src/features/prefab-list/components/PrefabList.tsx
+++ b/ars-editor/src/features/prefab-list/components/PrefabList.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { useProjectStore } from '@/stores/projectStore';
+import { cn } from '@/lib/utils';
+
+export function PrefabList() {
+  const prefabs = useProjectStore((s) => s.project.prefabs);
+  const deletePrefab = useProjectStore((s) => s.deletePrefab);
+  const renamePrefab = useProjectStore((s) => s.renamePrefab);
+  const instantiatePrefab = useProjectStore((s) => s.instantiatePrefab);
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+
+  const prefabList = Object.values(prefabs);
+
+  const handleStartRename = (id: string, currentName: string) => {
+    setEditingId(id);
+    setEditName(currentName);
+  };
+
+  const handleFinishRename = (id: string) => {
+    const trimmed = editName.trim();
+    if (trimmed) {
+      renamePrefab(id, trimmed);
+    }
+    setEditingId(null);
+  };
+
+  const handleInstantiate = (prefabId: string) => {
+    if (!activeSceneId) return;
+    instantiatePrefab(prefabId, activeSceneId, {
+      x: 300 + Math.random() * 100,
+      y: 200 + Math.random() * 100,
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-3 py-2 border-b border-zinc-700">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+          Prefabs
+        </h2>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2 space-y-1">
+        {prefabList.length === 0 ? (
+          <p className="text-zinc-500 text-sm text-center py-4">
+            No prefabs yet. Save an Actor as a Prefab to reuse it.
+          </p>
+        ) : (
+          prefabList.map((prefab) => (
+            <div
+              key={prefab.id}
+              className="group flex items-center gap-2 px-3 py-2 rounded-md text-sm hover:bg-zinc-700 text-zinc-300 transition-colors"
+            >
+              <span className="text-base">🟣</span>
+              {editingId === prefab.id ? (
+                <input
+                  className="flex-1 bg-zinc-900 text-white px-1 py-0.5 rounded text-sm outline-none border border-zinc-500"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onBlur={() => handleFinishRename(prefab.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleFinishRename(prefab.id);
+                    if (e.key === 'Escape') setEditingId(null);
+                  }}
+                  autoFocus
+                />
+              ) : (
+                <span
+                  className="flex-1 truncate cursor-pointer"
+                  onDoubleClick={() => handleStartRename(prefab.id, prefab.name)}
+                >
+                  {prefab.name}
+                </span>
+              )}
+              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                  className={cn(
+                    'text-xs px-1.5 py-0.5 rounded transition-colors',
+                    activeSceneId
+                      ? 'text-cyan-400 hover:bg-zinc-600'
+                      : 'text-zinc-600 cursor-not-allowed',
+                  )}
+                  onClick={() => handleInstantiate(prefab.id)}
+                  disabled={!activeSceneId}
+                  title="Add to scene"
+                >
+                  +
+                </button>
+                <button
+                  className="text-xs text-red-400 hover:bg-zinc-600 px-1.5 py-0.5 rounded transition-colors"
+                  onClick={() => {
+                    if (confirm(`Delete prefab "${prefab.name}"?`)) {
+                      deletePrefab(prefab.id);
+                    }
+                  }}
+                  title="Delete prefab"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/prefab-list/index.ts
+++ b/ars-editor/src/features/prefab-list/index.ts
@@ -1,0 +1,1 @@
+export { PrefabList } from './components/PrefabList';

--- a/ars-editor/src/features/sequence-editor/components/SequenceEditor.tsx
+++ b/ars-editor/src/features/sequence-editor/components/SequenceEditor.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { useEditorStore } from '@/stores/editorStore';
+import { useProjectStore } from '@/stores/projectStore';
+
+export function SequenceEditor() {
+  const actorId = useEditorStore((s) => s.sequenceEditorTarget);
+  const closeSequenceEditor = useEditorStore((s) => s.closeSequenceEditor);
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const scenes = useProjectStore((s) => s.project.scenes);
+  const addSequenceStep = useProjectStore((s) => s.addSequenceStep);
+  const removeSequenceStep = useProjectStore((s) => s.removeSequenceStep);
+  const updateSequenceStep = useProjectStore((s) => s.updateSequenceStep);
+
+  const [newName, setNewName] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+
+  if (!actorId || !activeSceneId) return null;
+
+  const scene = scenes[activeSceneId];
+  if (!scene) return null;
+  const actor = scene.actors[actorId];
+  if (!actor) return null;
+
+  const sequences = actor.sequences ?? [];
+
+  const handleAdd = () => {
+    const name = newName.trim();
+    if (!name) return;
+    addSequenceStep(activeSceneId, actorId, {
+      name,
+      description: newDesc.trim(),
+      order: sequences.length,
+    });
+    setNewName('');
+    setNewDesc('');
+  };
+
+  const handleMoveUp = (index: number) => {
+    if (index <= 0) return;
+    const current = sequences[index];
+    const prev = sequences[index - 1];
+    updateSequenceStep(activeSceneId, actorId, current.id, { order: prev.order });
+    updateSequenceStep(activeSceneId, actorId, prev.id, { order: current.order });
+  };
+
+  const handleMoveDown = (index: number) => {
+    if (index >= sequences.length - 1) return;
+    const current = sequences[index];
+    const next = sequences[index + 1];
+    updateSequenceStep(activeSceneId, actorId, current.id, { order: next.order });
+    updateSequenceStep(activeSceneId, actorId, next.id, { order: current.order });
+  };
+
+  const sorted = [...sequences].sort((a, b) => a.order - b.order);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeSequenceEditor}>
+      <div
+        className="bg-zinc-800 border border-zinc-600 rounded-lg shadow-2xl w-[480px] max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-700">
+          <h2 className="text-sm font-semibold text-white">
+            Sequences - {actor.name}
+          </h2>
+          <button
+            className="text-zinc-400 hover:text-white text-sm"
+            onClick={closeSequenceEditor}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Sequence list */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-2">
+          {sorted.length === 0 ? (
+            <div className="text-zinc-500 text-sm text-center py-4">No sequences defined</div>
+          ) : (
+            sorted.map((step, idx) => (
+              <div
+                key={step.id}
+                className="bg-zinc-900 rounded-md p-3 border border-zinc-700"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-orange-400 text-xs font-mono">#{idx + 1}</span>
+                    <input
+                      className="bg-transparent text-white text-sm font-medium outline-none border-b border-transparent focus:border-zinc-500"
+                      value={step.name}
+                      onChange={(e) =>
+                        updateSequenceStep(activeSceneId, actorId, step.id, {
+                          name: e.target.value,
+                        })
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      className="text-zinc-500 hover:text-white text-xs px-1"
+                      onClick={() => handleMoveUp(idx)}
+                      disabled={idx === 0}
+                      title="Move up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      className="text-zinc-500 hover:text-white text-xs px-1"
+                      onClick={() => handleMoveDown(idx)}
+                      disabled={idx === sorted.length - 1}
+                      title="Move down"
+                    >
+                      ↓
+                    </button>
+                    <button
+                      className="text-red-400 hover:text-red-300 text-xs px-1"
+                      onClick={() => removeSequenceStep(activeSceneId, actorId, step.id)}
+                      title="Remove"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+                <input
+                  className="w-full bg-transparent text-zinc-400 text-xs outline-none border-b border-transparent focus:border-zinc-500"
+                  value={step.description}
+                  placeholder="Description..."
+                  onChange={(e) =>
+                    updateSequenceStep(activeSceneId, actorId, step.id, {
+                      description: e.target.value,
+                    })
+                  }
+                />
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Add new step */}
+        <div className="border-t border-zinc-700 p-4 space-y-2">
+          <div className="text-xs text-zinc-400 mb-1">Add Step:</div>
+          <input
+            className="w-full bg-zinc-900 text-white text-sm px-3 py-1.5 rounded border border-zinc-600 outline-none focus:border-orange-500"
+            placeholder="Step name..."
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAdd();
+            }}
+          />
+          <input
+            className="w-full bg-zinc-900 text-white text-sm px-3 py-1.5 rounded border border-zinc-600 outline-none focus:border-orange-500"
+            placeholder="Description (optional)..."
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAdd();
+            }}
+          />
+          <button
+            className="w-full bg-orange-600 hover:bg-orange-500 text-white text-sm py-1.5 rounded transition-colors disabled:opacity-50"
+            onClick={handleAdd}
+            disabled={!newName.trim()}
+          >
+            + Add Step
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/sequence-editor/index.ts
+++ b/ars-editor/src/features/sequence-editor/index.ts
@@ -1,0 +1,1 @@
+export { SequenceEditor } from './components/SequenceEditor';

--- a/ars-editor/src/features/subscene-picker/components/SubScenePicker.tsx
+++ b/ars-editor/src/features/subscene-picker/components/SubScenePicker.tsx
@@ -1,0 +1,81 @@
+import { useEditorStore } from '@/stores/editorStore';
+import { useProjectStore } from '@/stores/projectStore';
+
+export function SubScenePicker() {
+  const actorId = useEditorStore((s) => s.subScenePickerTarget);
+  const closeSubScenePicker = useEditorStore((s) => s.closeSubScenePicker);
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const scenes = useProjectStore((s) => s.project.scenes);
+  const setActorSubScene = useProjectStore((s) => s.setActorSubScene);
+
+  if (!actorId || !activeSceneId) return null;
+
+  const scene = scenes[activeSceneId];
+  if (!scene) return null;
+  const actor = scene.actors[actorId];
+  if (!actor) return null;
+
+  const availableScenes = Object.values(scenes).filter((s) => s.id !== activeSceneId);
+
+  const handleSelect = (subSceneId: string | null) => {
+    setActorSubScene(activeSceneId, actorId, subSceneId);
+    closeSubScenePicker();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={closeSubScenePicker}>
+      <div
+        className="bg-zinc-800 border border-zinc-600 rounded-lg shadow-2xl w-[400px] max-h-[60vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-700">
+          <h2 className="text-sm font-semibold text-white">
+            Set SubScene - {actor.name}
+          </h2>
+          <button
+            className="text-zinc-400 hover:text-white text-sm"
+            onClick={closeSubScenePicker}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Scene list */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-1">
+          {/* None option */}
+          <button
+            className={`w-full text-left px-3 py-2 rounded text-sm transition-colors ${
+              !actor.subSceneId
+                ? 'bg-cyan-600 text-white'
+                : 'text-zinc-300 hover:bg-zinc-700'
+            }`}
+            onClick={() => handleSelect(null)}
+          >
+            (None)
+          </button>
+
+          {availableScenes.length === 0 ? (
+            <div className="text-zinc-500 text-sm text-center py-4">
+              No other scenes available. Create another scene first.
+            </div>
+          ) : (
+            availableScenes.map((s) => (
+              <button
+                key={s.id}
+                className={`w-full text-left px-3 py-2 rounded text-sm transition-colors ${
+                  actor.subSceneId === s.id
+                    ? 'bg-cyan-600 text-white'
+                    : 'text-zinc-300 hover:bg-zinc-700'
+                }`}
+                onClick={() => handleSelect(s.id)}
+              >
+                🎬 {s.name}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/subscene-picker/index.ts
+++ b/ars-editor/src/features/subscene-picker/index.ts
@@ -1,0 +1,1 @@
+export { SubScenePicker } from './components/SubScenePicker';

--- a/ars-editor/src/hooks/useKeyboardShortcuts.ts
+++ b/ars-editor/src/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,9 @@ import { undo, redo } from '@/stores/historyMiddleware';
 
 interface KeyboardShortcutOptions {
   onSave?: () => void;
+  onCopy?: () => void;
+  onPaste?: () => void;
+  onDuplicate?: () => void;
 }
 
 export function useKeyboardShortcuts(options: KeyboardShortcutOptions = {}) {
@@ -12,6 +15,8 @@ export function useKeyboardShortcuts(options: KeyboardShortcutOptions = {}) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const isCtrl = e.ctrlKey || e.metaKey;
+      const target = e.target as HTMLElement;
+      const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 
       if (isCtrl && e.key === 'z' && !e.shiftKey) {
         e.preventDefault();
@@ -22,6 +27,15 @@ export function useKeyboardShortcuts(options: KeyboardShortcutOptions = {}) {
       } else if (isCtrl && e.key === 's') {
         e.preventDefault();
         optionsRef.current.onSave?.();
+      } else if (isCtrl && e.key === 'c' && !isInput) {
+        e.preventDefault();
+        optionsRef.current.onCopy?.();
+      } else if (isCtrl && e.key === 'v' && !isInput) {
+        e.preventDefault();
+        optionsRef.current.onPaste?.();
+      } else if (isCtrl && e.key === 'd' && !isInput) {
+        e.preventDefault();
+        optionsRef.current.onDuplicate?.();
       }
     };
 

--- a/ars-editor/src/stores/editorStore.ts
+++ b/ars-editor/src/stores/editorStore.ts
@@ -1,15 +1,20 @@
 import { create } from 'zustand';
+import type { Actor } from '@/types/domain';
 
 interface EditorState {
   selectedNodeIds: string[];
   contextMenu: { x: number; y: number } | null;
   componentPickerTarget: string | null;
   componentEditorTarget: string | null;
+  sequenceEditorTarget: string | null;
+  subScenePickerTarget: string | null;
+  clipboard: Actor[] | null;
   panelVisibility: {
     sceneManager: boolean;
     componentEditor: boolean;
     componentList: boolean;
     preview: boolean;
+    prefabList: boolean;
   };
   isDirty: boolean;
   lastSavedAt: number | null;
@@ -22,7 +27,13 @@ interface EditorState {
   closeComponentPicker: () => void;
   openComponentEditor: (componentId: string | null) => void;
   closeComponentEditor: () => void;
-  togglePanel: (panel: 'sceneManager' | 'componentEditor' | 'componentList' | 'preview') => void;
+  openSequenceEditor: (actorId: string) => void;
+  closeSequenceEditor: () => void;
+  openSubScenePicker: (actorId: string) => void;
+  closeSubScenePicker: () => void;
+  copyToClipboard: (actors: Actor[]) => void;
+  clearClipboard: () => void;
+  togglePanel: (panel: 'sceneManager' | 'componentEditor' | 'componentList' | 'preview' | 'prefabList') => void;
   markDirty: () => void;
   markSaved: (path?: string) => void;
   setProjectPath: (path: string | null) => void;
@@ -33,11 +44,15 @@ export const useEditorStore = create<EditorState>()((set) => ({
   contextMenu: null,
   componentPickerTarget: null,
   componentEditorTarget: null,
+  sequenceEditorTarget: null,
+  subScenePickerTarget: null,
+  clipboard: null,
   panelVisibility: {
     sceneManager: true,
     componentEditor: false,
     componentList: false,
     preview: false,
+    prefabList: false,
   },
   isDirty: false,
   lastSavedAt: null,
@@ -51,13 +66,19 @@ export const useEditorStore = create<EditorState>()((set) => ({
   openComponentEditor: (componentId) =>
     set({
       componentEditorTarget: componentId,
-      panelVisibility: { sceneManager: true, componentEditor: true },
+      panelVisibility: { sceneManager: true, componentEditor: true, componentList: false, preview: false, prefabList: false },
     }),
   closeComponentEditor: () =>
     set((s) => ({
       componentEditorTarget: null,
       panelVisibility: { ...s.panelVisibility, componentEditor: false },
     })),
+  openSequenceEditor: (actorId) => set({ sequenceEditorTarget: actorId }),
+  closeSequenceEditor: () => set({ sequenceEditorTarget: null }),
+  openSubScenePicker: (actorId) => set({ subScenePickerTarget: actorId }),
+  closeSubScenePicker: () => set({ subScenePickerTarget: null }),
+  copyToClipboard: (actors) => set({ clipboard: JSON.parse(JSON.stringify(actors)) }),
+  clearClipboard: () => set({ clipboard: null }),
   togglePanel: (panel) =>
     set((s) => ({
       panelVisibility: {

--- a/ars-editor/src/stores/projectStore.ts
+++ b/ars-editor/src/stores/projectStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Project, Actor, Connection, Component, Scene } from '@/types/domain';
+import type { Project, Actor, Connection, Component, Scene, SequenceStep, Prefab } from '@/types/domain';
 import { generateId } from '@/lib/utils';
 
 interface ProjectActions {
@@ -16,6 +16,22 @@ interface ProjectActions {
   setActorComponents: (sceneId: string, actorId: string, componentIds: string[]) => void;
   setActorParent: (sceneId: string, actorId: string, parentId: string | null) => void;
   renameActor: (sceneId: string, actorId: string, name: string) => void;
+  duplicateActor: (sceneId: string, actorId: string, offset?: { x: number; y: number }) => string | null;
+
+  // Sequence actions
+  setActorSequences: (sceneId: string, actorId: string, sequences: SequenceStep[]) => void;
+  addSequenceStep: (sceneId: string, actorId: string, step: Omit<SequenceStep, 'id'>) => void;
+  removeSequenceStep: (sceneId: string, actorId: string, stepId: string) => void;
+  updateSequenceStep: (sceneId: string, actorId: string, stepId: string, updates: Partial<SequenceStep>) => void;
+
+  // SubScene actions
+  setActorSubScene: (sceneId: string, actorId: string, subSceneId: string | null) => void;
+
+  // Prefab actions
+  createPrefab: (name: string, sceneId: string, actorId: string) => string | null;
+  deletePrefab: (id: string) => void;
+  renamePrefab: (id: string, name: string) => void;
+  instantiatePrefab: (prefabId: string, sceneId: string, position: { x: number; y: number }) => string | null;
 
   // Connection actions
   addConnection: (sceneId: string, connection: Omit<Connection, 'id'>) => void;
@@ -38,6 +54,7 @@ const initialProject: Project = {
   name: 'Untitled Project',
   scenes: {},
   components: {},
+  prefabs: {},
   activeSceneId: null,
 };
 
@@ -54,6 +71,9 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
       components: [],
       children: [],
       position: { x: 250, y: 50 },
+      sequences: [],
+      subSceneId: null,
+      prefabId: null,
     };
     const scene: Scene = {
       id: sceneId,
@@ -114,7 +134,13 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
 
   addActor: (sceneId: string, actorData) => {
     const id = actorData.id ?? generateId();
-    const actor: Actor = { ...actorData, id };
+    const actor: Actor = {
+      ...actorData,
+      id,
+      sequences: actorData.sequences ?? [],
+      subSceneId: actorData.subSceneId ?? null,
+      prefabId: actorData.prefabId ?? null,
+    };
     set((state) => {
       const scene = state.project.scenes[sceneId];
       if (!scene) return state;
@@ -139,7 +165,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
       const scene = state.project.scenes[sceneId];
       if (!scene) return state;
       const { [actorId]: _, ...remainingActors } = scene.actors;
-      // Remove children references and connections involving this actor
       const updatedActors = Object.fromEntries(
         Object.entries(remainingActors).map(([k, a]) => [
           k,
@@ -219,7 +244,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
       if (!scene) return state;
       const actor = scene.actors[actorId];
       if (!actor) return state;
-      // Remove from old parent's children
       const updatedActors = { ...scene.actors };
       for (const a of Object.values(updatedActors)) {
         if (a.children.includes(actorId)) {
@@ -229,7 +253,6 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
           };
         }
       }
-      // Set new parent
       updatedActors[actorId] = { ...actor, parentId };
       if (parentId && updatedActors[parentId]) {
         updatedActors[parentId] = {
@@ -271,6 +294,262 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
         },
       };
     });
+  },
+
+  duplicateActor: (sceneId, actorId, offset = { x: 50, y: 50 }) => {
+    const { project } = get();
+    const scene = project.scenes[sceneId];
+    if (!scene) return null;
+    const actor = scene.actors[actorId];
+    if (!actor) return null;
+
+    const newId = generateId();
+    const newActor: Actor = {
+      ...JSON.parse(JSON.stringify(actor)),
+      id: newId,
+      name: `${actor.name} (Copy)`,
+      position: {
+        x: actor.position.x + offset.x,
+        y: actor.position.y + offset.y,
+      },
+      parentId: null,
+      children: [],
+      prefabId: actor.prefabId,
+    };
+
+    set((state) => {
+      const s = state.project.scenes[sceneId];
+      if (!s) return state;
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...s,
+              actors: { ...s.actors, [newId]: newActor },
+            },
+          },
+        },
+      };
+    });
+    return newId;
+  },
+
+  // Sequence actions
+  setActorSequences: (sceneId, actorId, sequences) => {
+    set((state) => {
+      const scene = state.project.scenes[sceneId];
+      if (!scene) return state;
+      const actor = scene.actors[actorId];
+      if (!actor) return state;
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...scene,
+              actors: {
+                ...scene.actors,
+                [actorId]: { ...actor, sequences },
+              },
+            },
+          },
+        },
+      };
+    });
+  },
+
+  addSequenceStep: (sceneId, actorId, stepData) => {
+    set((state) => {
+      const scene = state.project.scenes[sceneId];
+      if (!scene) return state;
+      const actor = scene.actors[actorId];
+      if (!actor) return state;
+      const step: SequenceStep = { ...stepData, id: generateId() };
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...scene,
+              actors: {
+                ...scene.actors,
+                [actorId]: { ...actor, sequences: [...actor.sequences, step] },
+              },
+            },
+          },
+        },
+      };
+    });
+  },
+
+  removeSequenceStep: (sceneId, actorId, stepId) => {
+    set((state) => {
+      const scene = state.project.scenes[sceneId];
+      if (!scene) return state;
+      const actor = scene.actors[actorId];
+      if (!actor) return state;
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...scene,
+              actors: {
+                ...scene.actors,
+                [actorId]: {
+                  ...actor,
+                  sequences: actor.sequences.filter((s) => s.id !== stepId),
+                },
+              },
+            },
+          },
+        },
+      };
+    });
+  },
+
+  updateSequenceStep: (sceneId, actorId, stepId, updates) => {
+    set((state) => {
+      const scene = state.project.scenes[sceneId];
+      if (!scene) return state;
+      const actor = scene.actors[actorId];
+      if (!actor) return state;
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...scene,
+              actors: {
+                ...scene.actors,
+                [actorId]: {
+                  ...actor,
+                  sequences: actor.sequences.map((s) =>
+                    s.id === stepId ? { ...s, ...updates } : s,
+                  ),
+                },
+              },
+            },
+          },
+        },
+      };
+    });
+  },
+
+  // SubScene actions
+  setActorSubScene: (sceneId, actorId, subSceneId) => {
+    set((state) => {
+      const scene = state.project.scenes[sceneId];
+      if (!scene) return state;
+      const actor = scene.actors[actorId];
+      if (!actor) return state;
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...scene,
+              actors: {
+                ...scene.actors,
+                [actorId]: { ...actor, subSceneId },
+              },
+            },
+          },
+        },
+      };
+    });
+  },
+
+  // Prefab actions
+  createPrefab: (name, sceneId, actorId) => {
+    const { project } = get();
+    const scene = project.scenes[sceneId];
+    if (!scene) return null;
+    const actor = scene.actors[actorId];
+    if (!actor) return null;
+
+    const prefabId = generateId();
+    const { id: _id, position: _pos, parentId: _pid, prefabId: _pfid, ...actorData } = actor;
+    const prefab: Prefab = {
+      id: prefabId,
+      name,
+      actor: JSON.parse(JSON.stringify(actorData)),
+    };
+
+    set((state) => ({
+      project: {
+        ...state.project,
+        prefabs: { ...state.project.prefabs, [prefabId]: prefab },
+      },
+    }));
+    return prefabId;
+  },
+
+  deletePrefab: (id) => {
+    set((state) => {
+      const { [id]: _, ...remaining } = state.project.prefabs;
+      return {
+        project: { ...state.project, prefabs: remaining },
+      };
+    });
+  },
+
+  renamePrefab: (id, name) => {
+    set((state) => {
+      const prefab = state.project.prefabs[id];
+      if (!prefab) return state;
+      return {
+        project: {
+          ...state.project,
+          prefabs: {
+            ...state.project.prefabs,
+            [id]: { ...prefab, name },
+          },
+        },
+      };
+    });
+  },
+
+  instantiatePrefab: (prefabId, sceneId, position) => {
+    const { project } = get();
+    const prefab = project.prefabs[prefabId];
+    if (!prefab) return null;
+    const scene = project.scenes[sceneId];
+    if (!scene) return null;
+
+    const newId = generateId();
+    const newActor: Actor = {
+      ...JSON.parse(JSON.stringify(prefab.actor)),
+      id: newId,
+      position,
+      parentId: null,
+      prefabId,
+    };
+
+    set((state) => {
+      const s = state.project.scenes[sceneId];
+      if (!s) return state;
+      return {
+        project: {
+          ...state.project,
+          scenes: {
+            ...state.project.scenes,
+            [sceneId]: {
+              ...s,
+              actors: { ...s.actors, [newId]: newActor },
+            },
+          },
+        },
+      };
+    });
+    return newId;
   },
 
   addConnection: (sceneId, connectionData) => {
@@ -333,7 +612,31 @@ export const useProjectStore = create<ProjectState & ProjectActions>()((set, get
     });
   },
 
-  loadProject: (project) => set({ project }),
+  loadProject: (project) => set({
+    project: {
+      ...project,
+      prefabs: project.prefabs ?? {},
+      scenes: Object.fromEntries(
+        Object.entries(project.scenes).map(([k, scene]) => [
+          k,
+          {
+            ...scene,
+            actors: Object.fromEntries(
+              Object.entries(scene.actors).map(([ak, actor]) => [
+                ak,
+                {
+                  ...actor,
+                  sequences: actor.sequences ?? [],
+                  subSceneId: actor.subSceneId ?? null,
+                  prefabId: actor.prefabId ?? null,
+                },
+              ]),
+            ),
+          },
+        ]),
+      ),
+    },
+  }),
 
   getActiveScene: () => {
     const { project } = get();

--- a/ars-editor/src/types/domain.ts
+++ b/ars-editor/src/types/domain.ts
@@ -31,6 +31,13 @@ export interface Component {
   dependencies: string[];
 }
 
+export interface SequenceStep {
+  id: string;
+  name: string;
+  description: string;
+  order: number;
+}
+
 export interface Actor {
   id: string;
   name: string;
@@ -39,6 +46,15 @@ export interface Actor {
   children: string[];
   position: { x: number; y: number };
   parentId?: string | null;
+  sequences: SequenceStep[];
+  subSceneId?: string | null;
+  prefabId?: string | null;
+}
+
+export interface Prefab {
+  id: string;
+  name: string;
+  actor: Omit<Actor, 'id' | 'position' | 'parentId' | 'prefabId'>;
 }
 
 export interface Connection {
@@ -61,5 +77,6 @@ export interface Project {
   name: string;
   scenes: Record<string, Scene>;
   components: Record<string, Component>;
+  prefabs: Record<string, Prefab>;
   activeSceneId: string | null;
 }


### PR DESCRIPTION
- Add SequenceStep type and sequences field to Actor for defining ordered
  steps on each actor
- Add subSceneId field to Actor allowing scenes to reference other scenes
  as subscenes
- Add Prefab system (create from actor, instantiate, manage in panel)
  enabling actor reuse like Unity prefabs
- Add copy/paste/duplicate for all actors via UI buttons, context menu,
  and keyboard shortcuts (Ctrl+C/V/D)
- Add SequenceEditor modal for CRUD operations on actor sequences
- Add SubScenePicker modal for assigning subscenes to actors
- Add PrefabList panel with rename/delete/instantiate actions
- Update ContextMenu with paste and prefab instantiation options
- Backward-compatible project loading with migration defaults

https://claude.ai/code/session_015gxUVScHLjoiBcauBBU4Ns