### PR TITLE
feat: add mobile-responsive UI with collapsible scene menu and slide-up panels

### DIFF
--- a/ars-editor/src/App.tsx
+++ b/ars-editor/src/App.tsx
@@ -14,6 +14,7 @@ import { useEditorStore } from './stores/editorStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useProjectStore } from './stores/projectStore';
 import { generateId } from './lib/utils';
+import { useIsMobile } from './hooks/useIsMobile';
 import * as backend from './lib/backend';
 
 function AppInner() {
@@ -28,9 +29,14 @@ function AppInner() {
   const selectedNodeIds = useEditorStore((s) => s.selectedNodeIds);
   const copyToClipboard = useEditorStore((s) => s.copyToClipboard);
   const clipboard = useEditorStore((s) => s.clipboard);
+  const mobileSceneMenuOpen = useEditorStore((s) => s.mobileSceneMenuOpen);
+  const setMobileSceneMenu = useEditorStore((s) => s.setMobileSceneMenu);
+  const mobileBottomSheetOpen = useEditorStore((s) => s.mobileBottomSheetOpen);
+  const setMobileBottomSheet = useEditorStore((s) => s.setMobileBottomSheet);
   const project = useProjectStore((s) => s.project);
   const addActor = useProjectStore((s) => s.addActor);
   const duplicateActor = useProjectStore((s) => s.duplicateActor);
+  const isMobile = useIsMobile();
 
   // Track project changes to mark dirty
   const isFirstRender = useRef(true);
@@ -107,6 +113,99 @@ function AppInner() {
     onDuplicate: handleDuplicate,
   });
 
+  // --- Mobile Layout ---
+  if (isMobile) {
+    return (
+      <div className="flex flex-col h-screen w-screen bg-zinc-900 text-zinc-200">
+        <Toolbar />
+
+        {/* Fullscreen Node Editor */}
+        <div className="flex-1 flex flex-col overflow-hidden relative">
+          <NodeCanvas />
+
+          {/* Mobile Scene Menu Overlay */}
+          {mobileSceneMenuOpen && (
+            <div
+              className="mobile-overlay"
+              onClick={() => setMobileSceneMenu(false)}
+            />
+          )}
+          <div
+            className={`mobile-scene-drawer ${mobileSceneMenuOpen ? 'open' : ''}`}
+          >
+            <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-700">
+              <h2 className="text-sm font-semibold text-white">Scenes</h2>
+              <button
+                onClick={() => setMobileSceneMenu(false)}
+                className="text-zinc-400 hover:text-white text-lg"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="flex-1 overflow-hidden">
+              <SceneList />
+            </div>
+            <div className="border-t border-zinc-700 p-2">
+              <button
+                className="w-full text-xs text-blue-400 hover:text-blue-300 hover:bg-zinc-800 py-2 rounded transition-colors"
+                onClick={() => {
+                  openComponentEditor(null);
+                  setMobileSceneMenu(false);
+                  setMobileBottomSheet(true);
+                }}
+              >
+                + New Component
+              </button>
+            </div>
+          </div>
+
+          {/* Mobile Bottom Sheet for data input */}
+          <div
+            className={`mobile-bottom-sheet ${mobileBottomSheetOpen ? 'open' : ''}`}
+          >
+            <div
+              className="mobile-bottom-sheet-handle"
+              onClick={() => setMobileBottomSheet(!mobileBottomSheetOpen)}
+            >
+              <div className="mobile-bottom-sheet-bar" />
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {panelVisibility.componentEditor && <ComponentEditor />}
+              {panelVisibility.preview && !panelVisibility.componentEditor && (
+                <ScenePreview />
+              )}
+              {panelVisibility.componentList &&
+                !panelVisibility.componentEditor &&
+                !panelVisibility.preview && <ComponentList />}
+              {panelVisibility.prefabList &&
+                !panelVisibility.componentEditor &&
+                !panelVisibility.preview &&
+                !panelVisibility.componentList && <PrefabList />}
+              {!panelVisibility.componentEditor &&
+                !panelVisibility.preview &&
+                !panelVisibility.componentList &&
+                !panelVisibility.prefabList && (
+                  <div className="p-4 text-zinc-500 text-sm text-center">
+                    Toggle panels from the toolbar to view content here.
+                  </div>
+                )}
+            </div>
+          </div>
+        </div>
+
+        {/* Modal - Component Picker */}
+        {componentPickerTarget && <ComponentPicker />}
+
+        {/* Modal - Sequence Editor */}
+        {sequenceEditorTarget && <SequenceEditor />}
+
+        {/* Modal - SubScene Picker */}
+        {subScenePickerTarget && <SubScenePicker />}
+      </div>
+    );
+  }
+
+  // --- Desktop Layout ---
   return (
     <div className="flex flex-col h-screen w-screen bg-zinc-900 text-zinc-200">
       <Toolbar />

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
 import { useEditorStore } from '@/stores/editorStore';
 import { canUndo, canRedo, undo, redo } from '@/stores/historyMiddleware';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import * as backend from '@/lib/backend';
 
 export function Toolbar() {
@@ -15,7 +16,12 @@ export function Toolbar() {
   const setProjectPath = useEditorStore((s) => s.setProjectPath);
   const togglePanel = useEditorStore((s) => s.togglePanel);
   const panelVisibility = useEditorStore((s) => s.panelVisibility);
+  const setMobileSceneMenu = useEditorStore((s) => s.setMobileSceneMenu);
+  const mobileBottomSheetOpen = useEditorStore((s) => s.mobileBottomSheetOpen);
+  const setMobileBottomSheet = useEditorStore((s) => s.setMobileBottomSheet);
   const [status, setStatus] = useState<string>('');
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const showStatus = (msg: string) => {
     setStatus(msg);
@@ -98,6 +104,143 @@ export function Toolbar() {
     ? `Last saved: ${new Date(lastSavedAt).toLocaleTimeString()}`
     : '';
 
+  // --- Mobile Toolbar ---
+  if (isMobile) {
+    return (
+      <div className="flex items-center gap-1 px-2 py-1 bg-zinc-800 border-b border-zinc-700 text-xs relative">
+        {/* Hamburger - open scene drawer */}
+        <button
+          onClick={() => setMobileSceneMenu(true)}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-base"
+          title="Scenes"
+        >
+          ☰
+        </button>
+
+        {/* Save */}
+        <button
+          onClick={handleSave}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors"
+          title="Save"
+        >
+          Save{isDirty ? ' *' : ''}
+        </button>
+
+        {/* Undo/Redo */}
+        <button
+          onClick={() => { undo(); markDirty(); }}
+          disabled={!canUndo()}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors disabled:opacity-30"
+          title="Undo"
+        >
+          ↩
+        </button>
+        <button
+          onClick={() => { redo(); markDirty(); }}
+          disabled={!canRedo()}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors disabled:opacity-30"
+          title="Redo"
+        >
+          ↪
+        </button>
+
+        {/* Bottom sheet toggle */}
+        <button
+          onClick={() => setMobileBottomSheet(!mobileBottomSheetOpen)}
+          className={`px-2 py-1 rounded transition-colors ${
+            mobileBottomSheetOpen
+              ? 'bg-blue-600 text-white'
+              : 'text-zinc-300 hover:bg-zinc-700'
+          }`}
+          title="Toggle Panel"
+        >
+          ▤
+        </button>
+
+        <div className="flex-1" />
+
+        {/* More menu */}
+        <button
+          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors"
+        >
+          ⋯
+        </button>
+
+        {status && (
+          <span className="text-green-400 ml-1">{status}</span>
+        )}
+
+        {/* Dropdown menu */}
+        {mobileMenuOpen && (
+          <>
+            <div
+              className="fixed inset-0 z-40"
+              onClick={() => setMobileMenuOpen(false)}
+            />
+            <div className="absolute right-2 top-full mt-1 bg-zinc-800 border border-zinc-600 rounded-lg shadow-xl z-50 py-1 min-w-[160px]">
+              <button
+                onClick={() => { handleNew(); setMobileMenuOpen(false); }}
+                className="w-full text-left px-3 py-2 text-zinc-300 hover:bg-zinc-700 transition-colors"
+              >
+                New Project
+              </button>
+              <button
+                onClick={() => { handleLoad(); setMobileMenuOpen(false); }}
+                className="w-full text-left px-3 py-2 text-zinc-300 hover:bg-zinc-700 transition-colors"
+              >
+                Open Project
+              </button>
+              <div className="h-px bg-zinc-700 my-1" />
+              <button
+                onClick={() => {
+                  togglePanel('componentList');
+                  setMobileBottomSheet(true);
+                  setMobileMenuOpen(false);
+                }}
+                className={`w-full text-left px-3 py-2 transition-colors ${
+                  panelVisibility.componentList ? 'text-blue-400' : 'text-zinc-300 hover:bg-zinc-700'
+                }`}
+              >
+                Components
+              </button>
+              <button
+                onClick={() => {
+                  togglePanel('prefabList');
+                  setMobileBottomSheet(true);
+                  setMobileMenuOpen(false);
+                }}
+                className={`w-full text-left px-3 py-2 transition-colors ${
+                  panelVisibility.prefabList ? 'text-purple-400' : 'text-zinc-300 hover:bg-zinc-700'
+                }`}
+              >
+                Prefabs
+              </button>
+              <button
+                onClick={() => {
+                  togglePanel('preview');
+                  setMobileBottomSheet(true);
+                  setMobileMenuOpen(false);
+                }}
+                className={`w-full text-left px-3 py-2 transition-colors ${
+                  panelVisibility.preview ? 'text-blue-400' : 'text-zinc-300 hover:bg-zinc-700'
+                }`}
+              >
+                Preview
+              </button>
+              <div className="h-px bg-zinc-700 my-1" />
+              <div className="px-3 py-2 text-zinc-500 truncate">
+                {project.name}
+                {isDirty && <span className="text-amber-400 ml-1">*</span>}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // --- Desktop Toolbar ---
   return (
     <div className="flex items-center gap-1 px-2 py-1 bg-zinc-800 border-b border-zinc-700 text-xs">
       {/* File operations */}

--- a/ars-editor/src/hooks/useIsMobile.ts
+++ b/ars-editor/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => window.innerWidth < MOBILE_BREAKPOINT,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}

--- a/ars-editor/src/index.css
+++ b/ars-editor/src/index.css
@@ -26,3 +26,80 @@ body {
 .react-flow__attribution {
   display: none;
 }
+
+/* ===== Mobile Layout ===== */
+
+/* Overlay backdrop for scene drawer */
+.mobile-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 40;
+}
+
+/* Scene drawer - slides in from left */
+.mobile-scene-drawer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  max-width: 80vw;
+  background: #1e1e22;
+  border-right: 1px solid #3f3f46;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.25s ease-out;
+}
+
+.mobile-scene-drawer.open {
+  transform: translateX(0);
+}
+
+/* Bottom sheet for data input */
+.mobile-bottom-sheet {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 55vh;
+  max-height: 55vh;
+  background: #1e1e22;
+  border-top: 1px solid #3f3f46;
+  border-radius: 12px 12px 0 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(calc(100% - 36px));
+  transition: transform 0.3s ease-out;
+}
+
+.mobile-bottom-sheet.open {
+  transform: translateY(0);
+}
+
+/* Drag handle area */
+.mobile-bottom-sheet-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 0 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.mobile-bottom-sheet-bar {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: #52525b;
+}
+
+/* Mobile toolbar adjustments */
+@media (max-width: 767px) {
+  .toolbar-desktop-only {
+    display: none;
+  }
+}

--- a/ars-editor/src/stores/editorStore.ts
+++ b/ars-editor/src/stores/editorStore.ts
@@ -19,6 +19,8 @@ interface EditorState {
   isDirty: boolean;
   lastSavedAt: number | null;
   projectPath: string | null;
+  mobileSceneMenuOpen: boolean;
+  mobileBottomSheetOpen: boolean;
 
   setSelectedNodes: (ids: string[]) => void;
   openContextMenu: (pos: { x: number; y: number }) => void;
@@ -37,6 +39,8 @@ interface EditorState {
   markDirty: () => void;
   markSaved: (path?: string) => void;
   setProjectPath: (path: string | null) => void;
+  setMobileSceneMenu: (open: boolean) => void;
+  setMobileBottomSheet: (open: boolean) => void;
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
@@ -57,6 +61,8 @@ export const useEditorStore = create<EditorState>()((set) => ({
   isDirty: false,
   lastSavedAt: null,
   projectPath: null,
+  mobileSceneMenuOpen: false,
+  mobileBottomSheetOpen: false,
 
   setSelectedNodes: (ids) => set({ selectedNodeIds: ids }),
   openContextMenu: (pos) => set({ contextMenu: pos }),
@@ -67,6 +73,7 @@ export const useEditorStore = create<EditorState>()((set) => ({
     set({
       componentEditorTarget: componentId,
       panelVisibility: { sceneManager: true, componentEditor: true, componentList: false, preview: false, prefabList: false },
+      mobileBottomSheetOpen: true,
     }),
   closeComponentEditor: () =>
     set((s) => ({
@@ -94,4 +101,6 @@ export const useEditorStore = create<EditorState>()((set) => ({
       projectPath: path ?? s.projectPath,
     })),
   setProjectPath: (path) => set({ projectPath: path }),
+  setMobileSceneMenu: (open) => set({ mobileSceneMenuOpen: open }),
+  setMobileBottomSheet: (open) => set({ mobileBottomSheetOpen: open }),
 }));


### PR DESCRIPTION
- Scene panel becomes a slide-in drawer toggled via hamburger menu on mobile
- Node editor takes full screen on mobile devices (<768px)
- Data input panels (component editor, preview, component list) display in a
  slide-up bottom sheet from the screen bottom
- Toolbar adapts for mobile with compact controls and overflow menu
- Add useIsMobile hook for responsive breakpoint detection

https://claude.ai/code/session_01VhhsVd7GVjiHMvojxpkNC4