### PR TITLE
feat: add GitHub OAuth authentication and DynamoDB cloud storage

### DIFF
--- a/ars-editor/.gitignore
+++ b/ars-editor/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+.env
+.env.local
+.env.*.local

--- a/ars-editor/src-tauri/.env.example
+++ b/ars-editor/src-tauri/.env.example
@@ -1,0 +1,17 @@
+# GitHub OAuth
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_REDIRECT_URI=http://localhost:5173/auth/github/callback
+
+# AWS
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AWS_REGION=ap-northeast-1
+
+# DynamoDB table names (optional, defaults shown)
+# DYNAMODB_USERS_TABLE=ars-users
+# DYNAMODB_SESSIONS_TABLE=ars-sessions
+# DYNAMODB_PROJECTS_TABLE=ars-projects
+
+# Server port (optional, default: 5173)
+# PORT=5173

--- a/ars-editor/src-tauri/.gitignore
+++ b/ars-editor/src-tauri/.gitignore
@@ -3,3 +3,6 @@
 /target/
 /gen/schemas
 target/
+.env
+.env.local
+.env.*.local

--- a/ars-editor/src-tauri/Cargo.lock
+++ b/ars-editor/src-tauri/Cargo.lock
@@ -79,16 +79,26 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "aws-config",
+ "aws-sdk-dynamodb",
  "axum",
+ "axum-extra",
+ "chrono",
  "dirs-next",
+ "jsonwebtoken",
  "log",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "time",
  "tokio",
+ "tower",
  "tower-http 0.5.2",
+ "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -144,6 +154,395 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.108.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aec313992e654999e9106edb2ed5287e73495b05385b4baae9bbed1c999db88"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,10 +552,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -186,8 +585,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -196,6 +595,30 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "fastrand",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -209,6 +632,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -361,6 +794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +877,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -483,9 +928,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -510,8 +966,19 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -537,9 +1004,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -550,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -700,6 +1167,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -827,6 +1295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +1319,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_filter"
@@ -882,6 +1365,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -941,12 +1430,21 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -962,6 +1460,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
@@ -974,6 +1478,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1198,8 +1708,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1376,6 +1888,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1968,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1986,17 @@ dependencies = [
  "mac",
  "markup5ever",
  "match_token",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1441,12 +2011,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1457,8 +2038,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1482,6 +2063,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1490,8 +2095,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1500,6 +2106,54 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1512,17 +2166,19 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1773,6 +2429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +2468,21 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1881,6 +2562,12 @@ checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2023,6 +2710,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,10 +2786,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2240,10 +2980,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pango"
@@ -2291,6 +3081,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2803,6 +3603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +3625,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2827,10 +3673,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "js-sys",
  "log",
@@ -2849,6 +3695,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2906,6 +3766,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +3866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2984,10 +3935,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3199,6 +4183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +4233,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,6 +4267,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3320,6 +4337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +4378,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3410,6 +4439,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,7 +4480,7 @@ checksum = "6e06d52c379e63da659a483a958110bbde891695a0ecb53e48cc7786d5eda7bb"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -3499,7 +4549,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.4.0",
  "jni",
  "libc",
  "log",
@@ -3513,7 +4563,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3645,7 +4695,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.4.0",
  "jni",
  "objc2",
  "objc2-ui-kit",
@@ -3668,7 +4718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
- "http",
+ "http 1.4.0",
  "jni",
  "log",
  "objc2",
@@ -3700,7 +4750,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever",
- "http",
+ "http 1.4.0",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -3734,6 +4784,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3857,7 +4920,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3871,6 +4934,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.37",
+ "tokio",
 ]
 
 [[package]]
@@ -4016,8 +5109,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4041,8 +5134,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4070,7 +5163,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4188,6 +5293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,6 +5310,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -4249,6 +5366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4259,6 +5382,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"
@@ -4675,6 +5804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,6 +5857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5088,7 +6237,7 @@ dependencies = [
  "gdkx11",
  "gtk",
  "html5ever",
- "http",
+ "http 1.4.0",
  "javascriptcore-rs",
  "jni",
  "kuchikiki",
@@ -5146,6 +6295,12 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
@@ -5210,6 +6365,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -20,7 +20,21 @@ tauri-build = { version = "2.5.6", optional = true }
 [features]
 default = ["tauri-app"]
 tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build"]
-web-server = ["dep:axum", "dep:tokio", "dep:tower-http"]
+web-server = [
+    "dep:axum",
+    "dep:tokio",
+    "dep:tower-http",
+    "dep:reqwest",
+    "dep:jsonwebtoken",
+    "dep:uuid",
+    "dep:chrono",
+    "dep:tower",
+    "dep:axum-extra",
+    "dep:aws-config",
+    "dep:aws-sdk-dynamodb",
+    "dep:time",
+    "dep:urlencoding",
+]
 
 [[bin]]
 name = "app"
@@ -42,3 +56,15 @@ dirs-next = "2.0"
 axum = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 tower-http = { version = "0.5", features = ["cors", "fs"], optional = true }
+# OAuth & Auth
+reqwest = { version = "0.12", features = ["json"], optional = true }
+jsonwebtoken = { version = "9", optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+tower = { version = "0.5", features = ["util"], optional = true }
+axum-extra = { version = "0.9", features = ["cookie"], optional = true }
+time = { version = "0.3", optional = true }
+urlencoding = { version = "2", optional = true }
+# AWS DynamoDB
+aws-config = { version = "1", optional = true }
+aws-sdk-dynamodb = { version = "1", optional = true }

--- a/ars-editor/src-tauri/src/app_state.rs
+++ b/ars-editor/src-tauri/src/app_state.rs
@@ -1,0 +1,24 @@
+use crate::dynamo::DynamoClient;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub github_client_id: String,
+    pub github_client_secret: String,
+    pub github_redirect_uri: String,
+    pub dynamo: DynamoClient,
+}
+
+impl AppState {
+    pub async fn from_env() -> Self {
+        let dynamo = DynamoClient::new().await;
+        Self {
+            github_client_id: std::env::var("GITHUB_CLIENT_ID")
+                .expect("GITHUB_CLIENT_ID must be set"),
+            github_client_secret: std::env::var("GITHUB_CLIENT_SECRET")
+                .expect("GITHUB_CLIENT_SECRET must be set"),
+            github_redirect_uri: std::env::var("GITHUB_REDIRECT_URI")
+                .unwrap_or_else(|_| "http://localhost:5173/auth/github/callback".to_string()),
+            dynamo,
+        }
+    }
+}

--- a/ars-editor/src-tauri/src/auth.rs
+++ b/ars-editor/src-tauri/src/auth.rs
@@ -1,0 +1,218 @@
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{Json, Redirect},
+};
+use axum_extra::extract::cookie::{Cookie, CookieJar};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::app_state::AppState;
+
+const SESSION_COOKIE: &str = "ars_session";
+const SESSION_TTL_SECS: i64 = 7 * 24 * 60 * 60; // 7 days
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    pub id: String,
+    #[serde(rename = "githubId")]
+    pub github_id: i64,
+    pub login: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "avatarUrl")]
+    pub avatar_url: String,
+    pub email: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub id: String,
+    #[serde(rename = "userId")]
+    pub user_id: String,
+    #[serde(rename = "expiresAt")]
+    pub expires_at: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackQuery {
+    pub code: String,
+    #[allow(dead_code)]
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubTokenResponse {
+    access_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubUser {
+    id: i64,
+    login: String,
+    name: Option<String>,
+    avatar_url: String,
+    email: Option<String>,
+}
+
+/// GET /auth/github/login - Redirect to GitHub OAuth
+pub async fn github_login(State(state): State<AppState>) -> Redirect {
+    let url = format!(
+        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=read:user%20user:email",
+        state.github_client_id,
+        urlencoding::encode(&state.github_redirect_uri),
+    );
+    Redirect::temporary(&url)
+}
+
+/// GET /auth/github/callback - Handle OAuth callback
+pub async fn github_callback(
+    State(state): State<AppState>,
+    Query(query): Query<OAuthCallbackQuery>,
+    jar: CookieJar,
+) -> Result<(CookieJar, Redirect), (StatusCode, String)> {
+    // Exchange code for access token
+    let client = reqwest::Client::new();
+    let token_res = client
+        .post("https://github.com/login/oauth/access_token")
+        .header("Accept", "application/json")
+        .json(&serde_json::json!({
+            "client_id": state.github_client_id,
+            "client_secret": state.github_client_secret,
+            "code": query.code,
+            "redirect_uri": state.github_redirect_uri,
+        }))
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Token exchange failed: {}", e)))?;
+
+    let token_data: GitHubTokenResponse = token_res
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Failed to parse token response: {}", e)))?;
+
+    // Fetch GitHub user info
+    let gh_user: GitHubUser = client
+        .get("https://api.github.com/user")
+        .header("Authorization", format!("Bearer {}", token_data.access_token))
+        .header("User-Agent", "ArsEditor")
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Failed to fetch user: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Failed to parse user: {}", e)))?;
+
+    let now = Utc::now().to_rfc3339();
+
+    // Find or create user in DynamoDB
+    let user = match state.dynamo.get_user_by_github_id(gh_user.id).await {
+        Ok(Some(mut existing)) => {
+            existing.login = gh_user.login;
+            existing.display_name = gh_user.name.unwrap_or_else(|| existing.login.clone());
+            existing.avatar_url = gh_user.avatar_url;
+            existing.email = gh_user.email;
+            existing.updated_at = now.clone();
+            state.dynamo.put_user(&existing).await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to update user: {}", e)))?;
+            existing
+        }
+        Ok(None) => {
+            let new_user = User {
+                id: Uuid::new_v4().to_string(),
+                github_id: gh_user.id,
+                login: gh_user.login.clone(),
+                display_name: gh_user.name.unwrap_or(gh_user.login),
+                avatar_url: gh_user.avatar_url,
+                email: gh_user.email,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+            };
+            state.dynamo.put_user(&new_user).await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to create user: {}", e)))?;
+            new_user
+        }
+        Err(e) => {
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("DynamoDB error: {}", e)));
+        }
+    };
+
+    // Create session
+    let session = Session {
+        id: Uuid::new_v4().to_string(),
+        user_id: user.id,
+        expires_at: (Utc::now() + chrono::Duration::seconds(SESSION_TTL_SECS)).to_rfc3339(),
+        created_at: now,
+    };
+    state.dynamo.put_session(&session).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to create session: {}", e)))?;
+
+    let cookie = Cookie::build((SESSION_COOKIE, session.id))
+        .path("/")
+        .http_only(true)
+        .max_age(time::Duration::seconds(SESSION_TTL_SECS))
+        .same_site(axum_extra::extract::cookie::SameSite::Lax);
+
+    Ok((jar.add(cookie), Redirect::temporary("/")))
+}
+
+/// GET /auth/me - Get current user
+pub async fn get_me(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<Json<User>, (StatusCode, String)> {
+    let user = extract_user(&state, &jar).await?;
+    Ok(Json(user))
+}
+
+/// POST /auth/logout - Clear session
+pub async fn logout(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<(CookieJar, Json<()>), (StatusCode, String)> {
+    if let Some(session_id) = jar.get(SESSION_COOKIE).map(|c| c.value().to_string()) {
+        let _ = state.dynamo.delete_session(&session_id).await;
+    }
+    let cookie = Cookie::build((SESSION_COOKIE, ""))
+        .path("/")
+        .max_age(time::Duration::seconds(0));
+    Ok((jar.remove(cookie), Json(())))
+}
+
+/// Extract user from session cookie
+pub async fn extract_user(state: &AppState, jar: &CookieJar) -> Result<User, (StatusCode, String)> {
+    let session_id = jar
+        .get(SESSION_COOKIE)
+        .map(|c| c.value().to_string())
+        .ok_or((StatusCode::UNAUTHORIZED, "Not authenticated".to_string()))?;
+
+    let session = state
+        .dynamo
+        .get_session(&session_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Session lookup failed: {}", e)))?
+        .ok_or((StatusCode::UNAUTHORIZED, "Session not found".to_string()))?;
+
+    // Check expiration
+    let expires_at = chrono::DateTime::parse_from_rfc3339(&session.expires_at)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Invalid session expiry".to_string()))?;
+    if Utc::now() > expires_at {
+        let _ = state.dynamo.delete_session(&session_id).await;
+        return Err((StatusCode::UNAUTHORIZED, "Session expired".to_string()));
+    }
+
+    state
+        .dynamo
+        .get_user(&session.user_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("User lookup failed: {}", e)))?
+        .ok_or((StatusCode::UNAUTHORIZED, "User not found".to_string()))
+}
+

--- a/ars-editor/src-tauri/src/dynamo.rs
+++ b/ars-editor/src-tauri/src/dynamo.rs
@@ -1,0 +1,285 @@
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::Client;
+use std::collections::HashMap;
+
+use crate::auth::{Session, User};
+use crate::models::Project;
+
+#[derive(Clone)]
+pub struct DynamoClient {
+    client: Client,
+    users_table: String,
+    sessions_table: String,
+    projects_table: String,
+}
+
+impl DynamoClient {
+    pub async fn new() -> Self {
+        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let client = Client::new(&config);
+        Self {
+            client,
+            users_table: std::env::var("DYNAMODB_USERS_TABLE")
+                .unwrap_or_else(|_| "ars-users".to_string()),
+            sessions_table: std::env::var("DYNAMODB_SESSIONS_TABLE")
+                .unwrap_or_else(|_| "ars-sessions".to_string()),
+            projects_table: std::env::var("DYNAMODB_PROJECTS_TABLE")
+                .unwrap_or_else(|_| "ars-projects".to_string()),
+        }
+    }
+
+    // ========== User operations ==========
+
+    pub async fn put_user(&self, user: &User) -> Result<(), String> {
+        let mut item = HashMap::new();
+        item.insert("id".to_string(), AttributeValue::S(user.id.clone()));
+        item.insert("githubId".to_string(), AttributeValue::N(user.github_id.to_string()));
+        item.insert("login".to_string(), AttributeValue::S(user.login.clone()));
+        item.insert("displayName".to_string(), AttributeValue::S(user.display_name.clone()));
+        item.insert("avatarUrl".to_string(), AttributeValue::S(user.avatar_url.clone()));
+        if let Some(ref email) = user.email {
+            item.insert("email".to_string(), AttributeValue::S(email.clone()));
+        }
+        item.insert("createdAt".to_string(), AttributeValue::S(user.created_at.clone()));
+        item.insert("updatedAt".to_string(), AttributeValue::S(user.updated_at.clone()));
+
+        self.client
+            .put_item()
+            .table_name(&self.users_table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB put_user failed: {}", e))?;
+        Ok(())
+    }
+
+    pub async fn get_user(&self, user_id: &str) -> Result<Option<User>, String> {
+        let result = self.client
+            .get_item()
+            .table_name(&self.users_table)
+            .key("id", AttributeValue::S(user_id.to_string()))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB get_user failed: {}", e))?;
+
+        match result.item {
+            Some(item) => Ok(Some(item_to_user(&item)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub async fn get_user_by_github_id(&self, github_id: i64) -> Result<Option<User>, String> {
+        // Use a scan with filter since we're querying by a non-key attribute.
+        // For production, use a GSI on githubId.
+        let result = self.client
+            .scan()
+            .table_name(&self.users_table)
+            .filter_expression("githubId = :gid")
+            .expression_attribute_values(":gid", AttributeValue::N(github_id.to_string()))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB scan users failed: {}", e))?;
+
+        if let Some(items) = result.items {
+            if let Some(item) = items.first() {
+                return Ok(Some(item_to_user(item)?));
+            }
+        }
+        Ok(None)
+    }
+
+    // ========== Session operations ==========
+
+    pub async fn put_session(&self, session: &Session) -> Result<(), String> {
+        let mut item = HashMap::new();
+        item.insert("id".to_string(), AttributeValue::S(session.id.clone()));
+        item.insert("userId".to_string(), AttributeValue::S(session.user_id.clone()));
+        item.insert("expiresAt".to_string(), AttributeValue::S(session.expires_at.clone()));
+        item.insert("createdAt".to_string(), AttributeValue::S(session.created_at.clone()));
+
+        self.client
+            .put_item()
+            .table_name(&self.sessions_table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB put_session failed: {}", e))?;
+        Ok(())
+    }
+
+    pub async fn get_session(&self, session_id: &str) -> Result<Option<Session>, String> {
+        let result = self.client
+            .get_item()
+            .table_name(&self.sessions_table)
+            .key("id", AttributeValue::S(session_id.to_string()))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB get_session failed: {}", e))?;
+
+        match result.item {
+            Some(item) => {
+                let session = Session {
+                    id: get_s(&item, "id")?,
+                    user_id: get_s(&item, "userId")?,
+                    expires_at: get_s(&item, "expiresAt")?,
+                    created_at: get_s(&item, "createdAt")?,
+                };
+                Ok(Some(session))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn delete_session(&self, session_id: &str) -> Result<(), String> {
+        self.client
+            .delete_item()
+            .table_name(&self.sessions_table)
+            .key("id", AttributeValue::S(session_id.to_string()))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB delete_session failed: {}", e))?;
+        Ok(())
+    }
+
+    // ========== Project operations ==========
+
+    pub async fn save_project(&self, user_id: &str, project_id: &str, project: &Project) -> Result<(), String> {
+        let project_json = serde_json::to_string(project)
+            .map_err(|e| format!("Failed to serialize project: {}", e))?;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let mut item = HashMap::new();
+        item.insert("id".to_string(), AttributeValue::S(project_id.to_string()));
+        item.insert("userId".to_string(), AttributeValue::S(user_id.to_string()));
+        item.insert("name".to_string(), AttributeValue::S(project.name.clone()));
+        item.insert("data".to_string(), AttributeValue::S(project_json));
+        item.insert("updatedAt".to_string(), AttributeValue::S(now));
+
+        self.client
+            .put_item()
+            .table_name(&self.projects_table)
+            .set_item(Some(item))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB save_project failed: {}", e))?;
+        Ok(())
+    }
+
+    pub async fn load_project(&self, user_id: &str, project_id: &str) -> Result<Option<Project>, String> {
+        let result = self.client
+            .get_item()
+            .table_name(&self.projects_table)
+            .key("id", AttributeValue::S(project_id.to_string()))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB load_project failed: {}", e))?;
+
+        match result.item {
+            Some(item) => {
+                // Verify ownership
+                let owner = get_s(&item, "userId")?;
+                if owner != user_id {
+                    return Err("Access denied".to_string());
+                }
+                let data = get_s(&item, "data")?;
+                let project: Project = serde_json::from_str(&data)
+                    .map_err(|e| format!("Failed to parse project: {}", e))?;
+                Ok(Some(project))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn list_user_projects(&self, user_id: &str) -> Result<Vec<ProjectSummary>, String> {
+        let result = self.client
+            .scan()
+            .table_name(&self.projects_table)
+            .filter_expression("userId = :uid")
+            .expression_attribute_values(":uid", AttributeValue::S(user_id.to_string()))
+            .projection_expression("id, #n, updatedAt")
+            .expression_attribute_names("#n", "name")
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB list_projects failed: {}", e))?;
+
+        let mut projects = Vec::new();
+        if let Some(items) = result.items {
+            for item in &items {
+                projects.push(ProjectSummary {
+                    id: get_s(item, "id")?,
+                    name: get_s(item, "name")?,
+                    updated_at: get_s(item, "updatedAt").unwrap_or_default(),
+                });
+            }
+        }
+        projects.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(projects)
+    }
+
+    pub async fn delete_project(&self, user_id: &str, project_id: &str) -> Result<(), String> {
+        // Verify ownership first
+        let result = self.client
+            .get_item()
+            .table_name(&self.projects_table)
+            .key("id", AttributeValue::S(project_id.to_string()))
+            .projection_expression("userId")
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB get_project failed: {}", e))?;
+
+        if let Some(item) = result.item {
+            let owner = get_s(&item, "userId")?;
+            if owner != user_id {
+                return Err("Access denied".to_string());
+            }
+        } else {
+            return Err("Project not found".to_string());
+        }
+
+        self.client
+            .delete_item()
+            .table_name(&self.projects_table)
+            .key("id", AttributeValue::S(project_id.to_string()))
+            .send()
+            .await
+            .map_err(|e| format!("DynamoDB delete_project failed: {}", e))?;
+        Ok(())
+    }
+}
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectSummary {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+// Helper functions for DynamoDB attribute extraction
+
+fn get_s(item: &HashMap<String, AttributeValue>, key: &str) -> Result<String, String> {
+    item.get(key)
+        .and_then(|v| v.as_s().ok())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Missing or invalid field: {}", key))
+}
+
+fn item_to_user(item: &HashMap<String, AttributeValue>) -> Result<User, String> {
+    let github_id_str = item
+        .get("githubId")
+        .and_then(|v| v.as_n().ok())
+        .ok_or_else(|| "Missing githubId".to_string())?;
+
+    Ok(User {
+        id: get_s(item, "id")?,
+        github_id: github_id_str.parse::<i64>().map_err(|e| format!("Invalid githubId: {}", e))?,
+        login: get_s(item, "login")?,
+        display_name: get_s(item, "displayName")?,
+        avatar_url: get_s(item, "avatarUrl")?,
+        email: item.get("email").and_then(|v| v.as_s().ok()).map(|s| s.to_string()),
+        created_at: get_s(item, "createdAt")?,
+        updated_at: get_s(item, "updatedAt")?,
+    })
+}

--- a/ars-editor/src-tauri/src/lib.rs
+++ b/ars-editor/src-tauri/src/lib.rs
@@ -1,6 +1,12 @@
 pub mod commands;
 pub mod models;
 #[cfg(feature = "web-server")]
+pub mod app_state;
+#[cfg(feature = "web-server")]
+pub mod auth;
+#[cfg(feature = "web-server")]
+pub mod dynamo;
+#[cfg(feature = "web-server")]
 pub mod web_server;
 
 #[cfg(feature = "tauri-app")]

--- a/ars-editor/src-tauri/src/web_server.rs
+++ b/ars-editor/src-tauri/src/web_server.rs
@@ -1,14 +1,17 @@
 use axum::{
-    extract::Query,
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    routing::{get, post},
+    routing::{delete, get, post},
     Router,
 };
+use axum_extra::extract::cookie::CookieJar;
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 
+use crate::app_state::AppState;
+use crate::auth;
 use crate::commands::project::{
     get_default_project_path_impl, list_projects_impl, load_project_impl, save_project_impl,
 };
@@ -24,6 +27,8 @@ struct SaveRequest {
 struct LoadQuery {
     path: String,
 }
+
+// ========== Local file-based APIs (backward-compatible) ==========
 
 async fn api_save_project(
     Json(req): Json<SaveRequest>,
@@ -53,20 +58,104 @@ async fn api_list_projects() -> Result<Json<Vec<String>>, (StatusCode, String)> 
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
 }
 
-pub fn api_router() -> Router {
+// ========== DynamoDB-backed cloud project APIs ==========
+
+#[derive(Deserialize)]
+struct CloudSaveRequest {
+    #[serde(rename = "projectId")]
+    project_id: String,
+    project: Project,
+}
+
+async fn api_cloud_save_project(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<CloudSaveRequest>,
+) -> Result<Json<()>, (StatusCode, String)> {
+    let user = auth::extract_user(&state, &jar).await?;
+    state
+        .dynamo
+        .save_project(&user.id, &req.project_id, &req.project)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+#[derive(Deserialize)]
+struct CloudLoadQuery {
+    #[serde(rename = "projectId")]
+    project_id: String,
+}
+
+async fn api_cloud_load_project(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Query(q): Query<CloudLoadQuery>,
+) -> Result<Json<Project>, (StatusCode, String)> {
+    let user = auth::extract_user(&state, &jar).await?;
+    state
+        .dynamo
+        .load_project(&user.id, &q.project_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, "Project not found".to_string()))
+}
+
+async fn api_cloud_list_projects(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<Json<Vec<crate::dynamo::ProjectSummary>>, (StatusCode, String)> {
+    let user = auth::extract_user(&state, &jar).await?;
+    state
+        .dynamo
+        .list_user_projects(&user.id)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+async fn api_cloud_delete_project(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Path(project_id): Path<String>,
+) -> Result<Json<()>, (StatusCode, String)> {
+    let user = auth::extract_user(&state, &jar).await?;
+    state
+        .dynamo
+        .delete_project(&user.id, &project_id)
+        .await
+        .map(|_| Json(()))
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+pub fn api_router(state: AppState) -> Router {
     Router::new()
+        // Local file-based APIs (no auth required)
         .route("/api/project/save", post(api_save_project))
         .route("/api/project/load", get(api_load_project))
         .route("/api/project/default-path", get(api_default_path))
         .route("/api/project/list", get(api_list_projects))
+        // Auth routes
+        .route("/auth/github/login", get(auth::github_login))
+        .route("/auth/github/callback", get(auth::github_callback))
+        .route("/auth/me", get(auth::get_me))
+        .route("/auth/logout", post(auth::logout))
+        // Cloud project APIs (auth required)
+        .route("/api/cloud/project/save", post(api_cloud_save_project))
+        .route("/api/cloud/project/load", get(api_cloud_load_project))
+        .route("/api/cloud/project/list", get(api_cloud_list_projects))
+        .route("/api/cloud/project/:project_id", delete(api_cloud_delete_project))
         .layer(CorsLayer::permissive())
+        .with_state(state)
 }
 
 pub async fn serve(port: u16, static_dir: Option<String>) {
+    let state = AppState::from_env().await;
     let app = if let Some(dir) = static_dir {
-        api_router().fallback_service(ServeDir::new(dir))
+        api_router(state).fallback_service(ServeDir::new(dir))
     } else {
-        api_router()
+        api_router(state)
     };
 
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -3,6 +3,7 @@ import { useProjectStore } from '@/stores/projectStore';
 import { useEditorStore } from '@/stores/editorStore';
 import { canUndo, canRedo, undo, redo } from '@/stores/historyMiddleware';
 import * as backend from '@/lib/backend';
+import { UserMenu } from './UserMenu';
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
@@ -192,6 +193,8 @@ export function Toolbar() {
       {status && (
         <span className="text-green-400 ml-2">{status}</span>
       )}
+      <div className="w-px h-4 bg-zinc-600 mx-1" />
+      <UserMenu />
     </div>
   );
 }

--- a/ars-editor/src/components/UserMenu.tsx
+++ b/ars-editor/src/components/UserMenu.tsx
@@ -1,0 +1,77 @@
+import { useState, useRef, useEffect } from 'react';
+import { useAuthStore } from '@/stores/authStore';
+import * as authApi from '@/lib/auth-api';
+import { isTauri } from '@/lib/backend';
+
+export function UserMenu() {
+  const user = useAuthStore((s) => s.user);
+  const loading = useAuthStore((s) => s.loading);
+  const fetchUser = useAuthStore((s) => s.fetchUser);
+  const logout = useAuthStore((s) => s.logout);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isTauri()) {
+      fetchUser();
+    }
+  }, [fetchUser]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  // Don't show in Tauri desktop mode
+  if (isTauri()) return null;
+
+  if (loading) {
+    return <span className="text-zinc-500 text-xs px-2">...</span>;
+  }
+
+  if (!user) {
+    return (
+      <a
+        href={authApi.getLoginUrl()}
+        className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-xs"
+      >
+        Login with GitHub
+      </a>
+    );
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-xs"
+      >
+        <img
+          src={user.avatarUrl}
+          alt={user.displayName}
+          className="w-4 h-4 rounded-full"
+        />
+        <span className="max-w-[100px] truncate">{user.displayName}</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 w-48 bg-zinc-800 border border-zinc-600 rounded shadow-lg z-50">
+          <div className="px-3 py-2 border-b border-zinc-700">
+            <div className="text-sm text-zinc-200 font-medium truncate">{user.displayName}</div>
+            <div className="text-xs text-zinc-500 truncate">@{user.login}</div>
+          </div>
+          <button
+            onClick={() => { logout(); setOpen(false); }}
+            className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ars-editor/src/lib/auth-api.ts
+++ b/ars-editor/src/lib/auth-api.ts
@@ -1,0 +1,48 @@
+import type { User, ProjectSummary } from '@/types/auth';
+import type { Project } from '@/types/domain';
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    ...options,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json();
+}
+
+export async function getMe(): Promise<User> {
+  return fetchJson<User>('/auth/me');
+}
+
+export async function logout(): Promise<void> {
+  await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' });
+}
+
+export function getLoginUrl(): string {
+  return '/auth/github/login';
+}
+
+export async function saveCloudProject(projectId: string, project: Project): Promise<void> {
+  await fetchJson('/api/cloud/project/save', {
+    method: 'POST',
+    body: JSON.stringify({ projectId, project }),
+  });
+}
+
+export async function loadCloudProject(projectId: string): Promise<Project> {
+  return fetchJson<Project>(`/api/cloud/project/load?projectId=${encodeURIComponent(projectId)}`);
+}
+
+export async function listCloudProjects(): Promise<ProjectSummary[]> {
+  return fetchJson<ProjectSummary[]>('/api/cloud/project/list');
+}
+
+export async function deleteCloudProject(projectId: string): Promise<void> {
+  await fetchJson(`/api/cloud/project/${encodeURIComponent(projectId)}`, {
+    method: 'DELETE',
+  });
+}

--- a/ars-editor/src/stores/authStore.ts
+++ b/ars-editor/src/stores/authStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import type { User, ProjectSummary } from '@/types/auth';
+import * as authApi from '@/lib/auth-api';
+
+interface AuthState {
+  user: User | null;
+  loading: boolean;
+  cloudProjects: ProjectSummary[];
+  cloudProjectsLoading: boolean;
+}
+
+interface AuthActions {
+  fetchUser: () => Promise<void>;
+  logout: () => Promise<void>;
+  fetchCloudProjects: () => Promise<void>;
+}
+
+export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
+  user: null,
+  loading: true,
+  cloudProjects: [],
+  cloudProjectsLoading: false,
+
+  fetchUser: async () => {
+    set({ loading: true });
+    try {
+      const user = await authApi.getMe();
+      set({ user, loading: false });
+    } catch {
+      set({ user: null, loading: false });
+    }
+  },
+
+  logout: async () => {
+    try {
+      await authApi.logout();
+    } catch {
+      // ignore
+    }
+    set({ user: null });
+  },
+
+  fetchCloudProjects: async () => {
+    set({ cloudProjectsLoading: true });
+    try {
+      const projects = await authApi.listCloudProjects();
+      set({ cloudProjects: projects, cloudProjectsLoading: false });
+    } catch {
+      set({ cloudProjectsLoading: false });
+    }
+  },
+}));

--- a/ars-editor/src/types/auth.ts
+++ b/ars-editor/src/types/auth.ts
@@ -1,0 +1,16 @@
+export interface User {
+  id: string;
+  githubId: number;
+  login: string;
+  displayName: string;
+  avatarUrl: string;
+  email: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  updatedAt: string;
+}

--- a/docs/env-setup.md
+++ b/docs/env-setup.md
@@ -1,0 +1,124 @@
+# Ars Editor Web Server - 環境変数セットアップガイド
+
+## 概要
+
+WebサーバーモードでGitHub OAuth認証とDynamoDBクラウドストレージを利用するために、以下の環境変数の設定が必要です。
+
+---
+
+## 必須の環境変数
+
+### GitHub OAuth
+
+| 変数名 | 必須 | 説明 |
+|---|---|---|
+| `GITHUB_CLIENT_ID` | **必須** | GitHub OAuth Appの Client ID |
+| `GITHUB_CLIENT_SECRET` | **必須** | GitHub OAuth Appの Client Secret |
+| `GITHUB_REDIRECT_URI` | 任意 | OAuthコールバックURL（デフォルト: `http://localhost:5173/auth/github/callback`） |
+
+### AWS / DynamoDB
+
+| 変数名 | 必須 | 説明 |
+|---|---|---|
+| `AWS_ACCESS_KEY_ID` | **必須** | AWSアクセスキー |
+| `AWS_SECRET_ACCESS_KEY` | **必須** | AWSシークレットキー |
+| `AWS_REGION` | **必須** | AWSリージョン（例: `ap-northeast-1`） |
+| `DYNAMODB_USERS_TABLE` | 任意 | ユーザーテーブル名（デフォルト: `ars-users`） |
+| `DYNAMODB_SESSIONS_TABLE` | 任意 | セッションテーブル名（デフォルト: `ars-sessions`） |
+| `DYNAMODB_PROJECTS_TABLE` | 任意 | プロジェクトテーブル名（デフォルト: `ars-projects`） |
+
+### サーバー設定
+
+| 変数名 | 必須 | 説明 |
+|---|---|---|
+| `PORT` | 任意 | サーバーポート番号（デフォルト: `5173`） |
+
+---
+
+## セットアップ手順
+
+### 1. GitHub OAuth App の作成
+
+1. GitHub > Settings > Developer settings > OAuth Apps > **New OAuth App**
+2. 以下を入力:
+   - **Application name**: `Ars Editor` (任意)
+   - **Homepage URL**: `http://localhost:5173`
+   - **Authorization callback URL**: `http://localhost:5173/auth/github/callback`
+3. 作成後、**Client ID** と **Client Secret** をコピー
+
+### 2. AWS DynamoDB テーブルの作成
+
+以下の3テーブルを作成してください。
+
+#### `ars-users` テーブル
+| キー | 型 | 説明 |
+|---|---|---|
+| `id` (Partition Key) | String | ユーザーID (UUID) |
+
+GSI (Global Secondary Index):
+| インデックス名 | Partition Key | 型 |
+|---|---|---|
+| `github_id-index` | `github_id` | Number |
+
+#### `ars-sessions` テーブル
+| キー | 型 | 説明 |
+|---|---|---|
+| `id` (Partition Key) | String | セッションID (UUID) |
+
+#### `ars-projects` テーブル
+| キー | 型 | 説明 |
+|---|---|---|
+| `user_id` (Partition Key) | String | ユーザーID |
+| `project_id` (Sort Key) | String | プロジェクトID |
+
+### 3. `.env` ファイルの作成
+
+```bash
+cp ars-editor/src-tauri/.env.example ars-editor/src-tauri/.env
+```
+
+`.env` を編集して実際の値を入力:
+
+```env
+# GitHub OAuth
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_REDIRECT_URI=http://localhost:5173/auth/github/callback
+
+# AWS
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AWS_REGION=ap-northeast-1
+
+# DynamoDB (カスタムテーブル名を使う場合のみ)
+# DYNAMODB_USERS_TABLE=ars-users
+# DYNAMODB_SESSIONS_TABLE=ars-sessions
+# DYNAMODB_PROJECTS_TABLE=ars-projects
+
+# Server
+# PORT=5173
+```
+
+### 4. Webサーバーの起動
+
+```bash
+cd ars-editor
+
+# フロントエンドのビルド
+npm run build
+
+# Webサーバー起動（.env を読み込む場合）
+cd src-tauri
+source .env  # or: set -a && source .env && set +a
+cargo run --features web-server --no-default-features --bin ars-web-server -- ../../dist
+```
+
+---
+
+## 本番環境向けの注意事項
+
+- `GITHUB_REDIRECT_URI` を本番URLに変更すること
+- AWS認証はIAMロール（EC2/ECS）やAWS Profileの利用を推奨（環境変数に直接キーを入れない）
+- セッションCookieは `http_only` + `SameSite=Lax` で設定済み
+- 本番では HTTPS + `Secure` cookie フラグの追加を検討すること
+- DynamoDB テーブルにTTL属性を設定してセッションの自動クリーンアップを行うことを推奨


### PR DESCRIPTION
Add GitHub OAuth login flow with session-based auth for the web server mode.
Projects can now be saved/loaded from DynamoDB for authenticated users,
while local file-based storage remains available as a fallback.

Backend (Rust/Axum):
- GitHub OAuth login/callback with access token exchange
- Cookie-based session management with DynamoDB persistence
- User model with GitHub profile sync (create/update on login)
- DynamoDB client for users, sessions, and cloud project storage
- Cloud project CRUD endpoints under /api/cloud/project/*
- Auth routes under /auth/* (login, callback, me, logout)

Frontend (React/TypeScript):
- Auth API client (auth-api.ts) for login, logout, cloud project ops
- Auth store (Zustand) for user state and cloud project listing
- UserMenu component with GitHub avatar, dropdown, and sign out
- Integrated into Toolbar (web mode only, hidden in Tauri desktop)

https://claude.ai/code/session_018ZR8EU3vmZf4YD2XfDLYiZ