### PR TITLE
feat: add GitHub sign-in with Git-based project management

### DIFF
--- a/ars-editor/src-tauri/Cargo.lock
+++ b/ars-editor/src-tauri/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "axum-extra",
  "chrono",
  "dirs-next",
+ "git2",
  "jsonwebtoken",
  "log",
  "reqwest 0.12.28",
@@ -1772,6 +1773,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +2561,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +2591,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2735,7 +2791,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -3004,6 +3060,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -3810,7 +3872,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ web-server = [
     "dep:aws-sdk-dynamodb",
     "dep:time",
     "dep:urlencoding",
+    "dep:git2",
 ]
 
 [[bin]]
@@ -68,3 +69,5 @@ urlencoding = { version = "2", optional = true }
 # AWS DynamoDB
 aws-config = { version = "1", optional = true }
 aws-sdk-dynamodb = { version = "1", optional = true }
+# Git operations
+git2 = { version = "0.19", optional = true }

--- a/ars-editor/src-tauri/src/auth.rs
+++ b/ars-editor/src-tauri/src/auth.rs
@@ -39,6 +39,8 @@ pub struct Session {
     pub expires_at: String,
     #[serde(rename = "createdAt")]
     pub created_at: String,
+    #[serde(rename = "accessToken")]
+    pub access_token: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,7 +67,7 @@ struct GitHubUser {
 /// GET /auth/github/login - Redirect to GitHub OAuth
 pub async fn github_login(State(state): State<AppState>) -> Redirect {
     let url = format!(
-        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=read:user%20user:email",
+        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&scope=read:user%20user:email%20repo",
         state.github_client_id,
         urlencoding::encode(&state.github_redirect_uri),
     );
@@ -144,12 +146,13 @@ pub async fn github_callback(
         }
     };
 
-    // Create session
+    // Create session (store access token for Git operations)
     let session = Session {
         id: Uuid::new_v4().to_string(),
         user_id: user.id,
         expires_at: (Utc::now() + chrono::Duration::seconds(SESSION_TTL_SECS)).to_rfc3339(),
         created_at: now,
+        access_token: token_data.access_token.clone(),
     };
     state.dynamo.put_session(&session).await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Failed to create session: {}", e)))?;
@@ -184,6 +187,30 @@ pub async fn logout(
         .path("/")
         .max_age(time::Duration::seconds(0));
     Ok((jar.remove(cookie), Json(())))
+}
+
+/// Extract session from cookie
+pub async fn extract_session(state: &AppState, jar: &CookieJar) -> Result<Session, (StatusCode, String)> {
+    let session_id = jar
+        .get(SESSION_COOKIE)
+        .map(|c| c.value().to_string())
+        .ok_or((StatusCode::UNAUTHORIZED, "Not authenticated".to_string()))?;
+
+    let session = state
+        .dynamo
+        .get_session(&session_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Session lookup failed: {}", e)))?
+        .ok_or((StatusCode::UNAUTHORIZED, "Session not found".to_string()))?;
+
+    let expires_at = chrono::DateTime::parse_from_rfc3339(&session.expires_at)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Invalid session expiry".to_string()))?;
+    if Utc::now() > expires_at {
+        let _ = state.dynamo.delete_session(&session_id).await;
+        return Err((StatusCode::UNAUTHORIZED, "Session expired".to_string()));
+    }
+
+    Ok(session)
 }
 
 /// Extract user from session cookie

--- a/ars-editor/src-tauri/src/dynamo.rs
+++ b/ars-editor/src-tauri/src/dynamo.rs
@@ -96,6 +96,7 @@ impl DynamoClient {
         item.insert("userId".to_string(), AttributeValue::S(session.user_id.clone()));
         item.insert("expiresAt".to_string(), AttributeValue::S(session.expires_at.clone()));
         item.insert("createdAt".to_string(), AttributeValue::S(session.created_at.clone()));
+        item.insert("accessToken".to_string(), AttributeValue::S(session.access_token.clone()));
 
         self.client
             .put_item()
@@ -123,6 +124,7 @@ impl DynamoClient {
                     user_id: get_s(&item, "userId")?,
                     expires_at: get_s(&item, "expiresAt")?,
                     created_at: get_s(&item, "createdAt")?,
+                    access_token: get_s(&item, "accessToken").unwrap_or_default(),
                 };
                 Ok(Some(session))
             }

--- a/ars-editor/src-tauri/src/git_ops.rs
+++ b/ars-editor/src-tauri/src/git_ops.rs
@@ -1,0 +1,349 @@
+use git2::{Cred, FetchOptions, PushOptions, RemoteCallbacks, Repository, Signature};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::models::Project;
+
+const PROJECTS_DIR: &str = "ars-projects";
+const PROJECT_FILE: &str = "project.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitRepo {
+    pub name: String,
+    pub full_name: String,
+    pub description: Option<String>,
+    pub html_url: String,
+    pub clone_url: String,
+    #[serde(rename = "private")]
+    pub is_private: bool,
+    #[serde(rename = "updated_at")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitProjectInfo {
+    pub repo_full_name: String,
+    pub branch: String,
+    pub has_project: bool,
+    pub local_path: String,
+}
+
+fn get_projects_base_dir() -> PathBuf {
+    let home = dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(PROJECTS_DIR)
+}
+
+fn get_repo_local_path(full_name: &str) -> PathBuf {
+    get_projects_base_dir().join(full_name.replace('/', "_"))
+}
+
+fn make_callbacks(token: &str) -> RemoteCallbacks<'_> {
+    let mut callbacks = RemoteCallbacks::new();
+    callbacks.credentials(move |_url, _username_from_url, _allowed_types| {
+        Cred::userpass_plaintext("x-access-token", token)
+    });
+    callbacks
+}
+
+/// List user's GitHub repositories via the API
+pub async fn list_repos(access_token: &str) -> Result<Vec<GitRepo>, String> {
+    let client = reqwest::Client::new();
+    let mut all_repos = Vec::new();
+    let mut page = 1u32;
+
+    loop {
+        let repos: Vec<GitRepo> = client
+            .get("https://api.github.com/user/repos")
+            .query(&[
+                ("per_page", "100"),
+                ("page", &page.to_string()),
+                ("sort", "updated"),
+                ("affiliation", "owner"),
+            ])
+            .header("Authorization", format!("Bearer {}", access_token))
+            .header("User-Agent", "ArsEditor")
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+            .map_err(|e| format!("Failed to fetch repos: {}", e))?
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse repos: {}", e))?;
+
+        if repos.is_empty() {
+            break;
+        }
+        all_repos.extend(repos);
+        page += 1;
+
+        // Safety limit
+        if page > 10 {
+            break;
+        }
+    }
+
+    Ok(all_repos)
+}
+
+/// Create a new GitHub repository
+pub async fn create_repo(
+    access_token: &str,
+    name: &str,
+    description: Option<&str>,
+    private: bool,
+) -> Result<GitRepo, String> {
+    let client = reqwest::Client::new();
+    let mut body = serde_json::json!({
+        "name": name,
+        "private": private,
+        "auto_init": true,
+    });
+    if let Some(desc) = description {
+        body["description"] = serde_json::Value::String(desc.to_string());
+    }
+
+    let repo: GitRepo = client
+        .post("https://api.github.com/user/repos")
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("User-Agent", "ArsEditor")
+        .header("Accept", "application/vnd.github+json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to create repo: {}", e))?
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse created repo: {}", e))?;
+
+    Ok(repo)
+}
+
+/// Clone a GitHub repository to local storage
+pub fn clone_repo(access_token: &str, clone_url: &str, full_name: &str) -> Result<PathBuf, String> {
+    let local_path = get_repo_local_path(full_name);
+
+    // If already cloned, pull instead
+    if local_path.exists() {
+        return pull_repo(access_token, &local_path).map(|_| local_path);
+    }
+
+    std::fs::create_dir_all(&local_path)
+        .map_err(|e| format!("Failed to create directory: {}", e))?;
+
+    let callbacks = make_callbacks(access_token);
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks);
+
+    let mut builder = git2::build::RepoBuilder::new();
+    builder.fetch_options(fo);
+
+    builder
+        .clone(clone_url, &local_path)
+        .map_err(|e| format!("Failed to clone repository: {}", e))?;
+
+    Ok(local_path)
+}
+
+/// Pull latest changes from remote
+fn pull_repo(access_token: &str, local_path: &Path) -> Result<(), String> {
+    let repo = Repository::open(local_path)
+        .map_err(|e| format!("Failed to open repository: {}", e))?;
+
+    let mut remote = repo
+        .find_remote("origin")
+        .map_err(|e| format!("Failed to find remote: {}", e))?;
+
+    let callbacks = make_callbacks(access_token);
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks);
+
+    let branch = get_default_branch(&repo)?;
+
+    remote
+        .fetch(&[&branch], Some(&mut fo), None)
+        .map_err(|e| format!("Failed to fetch: {}", e))?;
+
+    // Fast-forward merge
+    let fetch_head = repo
+        .find_reference("FETCH_HEAD")
+        .map_err(|e| format!("Failed to find FETCH_HEAD: {}", e))?;
+    let fetch_commit = repo
+        .reference_to_annotated_commit(&fetch_head)
+        .map_err(|e| format!("Failed to get commit: {}", e))?;
+
+    let (analysis, _) = repo
+        .merge_analysis(&[&fetch_commit])
+        .map_err(|e| format!("Merge analysis failed: {}", e))?;
+
+    if analysis.is_up_to_date() {
+        return Ok(());
+    }
+
+    if analysis.is_fast_forward() {
+        let refname = format!("refs/heads/{}", branch);
+        let mut reference = repo
+            .find_reference(&refname)
+            .map_err(|e| format!("Failed to find reference: {}", e))?;
+        reference
+            .set_target(fetch_commit.id(), "Fast-forward")
+            .map_err(|e| format!("Failed to set target: {}", e))?;
+        repo.set_head(&refname)
+            .map_err(|e| format!("Failed to set HEAD: {}", e))?;
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            .map_err(|e| format!("Failed to checkout: {}", e))?;
+    }
+
+    Ok(())
+}
+
+fn get_default_branch(repo: &Repository) -> Result<String, String> {
+    // Try to get branch from HEAD
+    if let Ok(head) = repo.head() {
+        if let Some(name) = head.shorthand() {
+            return Ok(name.to_string());
+        }
+    }
+    Ok("main".to_string())
+}
+
+/// Load project from a cloned repository
+pub fn load_project_from_repo(full_name: &str) -> Result<Option<Project>, String> {
+    let local_path = get_repo_local_path(full_name);
+    let project_file = local_path.join(PROJECT_FILE);
+
+    if !project_file.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&project_file)
+        .map_err(|e| format!("Failed to read project file: {}", e))?;
+    let project: Project = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse project: {}", e))?;
+
+    Ok(Some(project))
+}
+
+/// Save project to a cloned repository and push
+pub fn save_and_push(
+    access_token: &str,
+    full_name: &str,
+    project: &Project,
+    commit_message: &str,
+) -> Result<(), String> {
+    let local_path = get_repo_local_path(full_name);
+    let project_file = local_path.join(PROJECT_FILE);
+
+    // Ensure directory exists
+    if !local_path.exists() {
+        return Err("Repository not cloned locally. Clone it first.".to_string());
+    }
+
+    // Write project file
+    let content = serde_json::to_string_pretty(project)
+        .map_err(|e| format!("Failed to serialize project: {}", e))?;
+    std::fs::write(&project_file, content)
+        .map_err(|e| format!("Failed to write project file: {}", e))?;
+
+    // Git add, commit, push
+    let repo = Repository::open(&local_path)
+        .map_err(|e| format!("Failed to open repository: {}", e))?;
+
+    // Stage the file
+    let mut index = repo.index()
+        .map_err(|e| format!("Failed to get index: {}", e))?;
+    index
+        .add_path(Path::new(PROJECT_FILE))
+        .map_err(|e| format!("Failed to stage file: {}", e))?;
+    index.write()
+        .map_err(|e| format!("Failed to write index: {}", e))?;
+
+    let oid = index
+        .write_tree()
+        .map_err(|e| format!("Failed to write tree: {}", e))?;
+    let tree = repo
+        .find_tree(oid)
+        .map_err(|e| format!("Failed to find tree: {}", e))?;
+
+    let signature = Signature::now("Ars Editor", "ars@editor.local")
+        .map_err(|e| format!("Failed to create signature: {}", e))?;
+
+    let parent = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit> = parent.as_ref().map(|c| vec![c]).unwrap_or_default();
+
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        commit_message,
+        &tree,
+        &parents,
+    )
+    .map_err(|e| format!("Failed to commit: {}", e))?;
+
+    // Push
+    let mut remote = repo
+        .find_remote("origin")
+        .map_err(|e| format!("Failed to find remote: {}", e))?;
+
+    let branch = get_default_branch(&repo)?;
+    let callbacks = make_callbacks(access_token);
+    let mut push_options = PushOptions::new();
+    push_options.remote_callbacks(callbacks);
+
+    remote
+        .push(
+            &[format!("refs/heads/{}:refs/heads/{}", branch, branch)],
+            Some(&mut push_options),
+        )
+        .map_err(|e| format!("Failed to push: {}", e))?;
+
+    Ok(())
+}
+
+/// List locally cloned projects
+pub fn list_local_projects() -> Result<Vec<GitProjectInfo>, String> {
+    let base_dir = get_projects_base_dir();
+    if !base_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut projects = Vec::new();
+    let entries = std::fs::read_dir(&base_dir)
+        .map_err(|e| format!("Failed to read projects directory: {}", e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let path = entry.path();
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        // Check if it's a git repo
+        if let Ok(repo) = Repository::open(&path) {
+            let branch = get_default_branch(&repo).unwrap_or_else(|_| "main".to_string());
+            let full_name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().replace('_', "/"))
+                .unwrap_or_default();
+
+            // Replace only the first underscore (owner/repo)
+            let full_name = if let Some(pos) = full_name.find('/') {
+                full_name[..pos].to_string() + "/" + &full_name[pos + 1..]
+            } else {
+                full_name
+            };
+
+            let has_project = path.join(PROJECT_FILE).exists();
+
+            projects.push(GitProjectInfo {
+                repo_full_name: full_name,
+                branch,
+                has_project,
+                local_path: path.to_string_lossy().to_string(),
+            });
+        }
+    }
+
+    Ok(projects)
+}

--- a/ars-editor/src-tauri/src/lib.rs
+++ b/ars-editor/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ pub mod auth;
 #[cfg(feature = "web-server")]
 pub mod dynamo;
 #[cfg(feature = "web-server")]
+pub mod git_ops;
+#[cfg(feature = "web-server")]
 pub mod web_server;
 
 #[cfg(feature = "tauri-app")]

--- a/ars-editor/src-tauri/src/web_server.rs
+++ b/ars-editor/src-tauri/src/web_server.rs
@@ -15,6 +15,7 @@ use crate::auth;
 use crate::commands::project::{
     get_default_project_path_impl, list_projects_impl, load_project_impl, save_project_impl,
 };
+use crate::git_ops;
 use crate::models::Project;
 
 #[derive(Deserialize)]
@@ -129,6 +130,149 @@ async fn api_cloud_delete_project(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
 }
 
+// ========== Git project management APIs ==========
+
+/// GET /api/git/repos - List user's GitHub repositories
+async fn api_git_list_repos(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<Json<Vec<git_ops::GitRepo>>, (StatusCode, String)> {
+    let session = auth::extract_session(&state, &jar).await?;
+    let repos = git_ops::list_repos(&session.access_token)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
+    Ok(Json(repos))
+}
+
+#[derive(Deserialize)]
+struct CreateRepoRequest {
+    name: String,
+    description: Option<String>,
+    private: Option<bool>,
+}
+
+/// POST /api/git/repos - Create a new GitHub repository
+async fn api_git_create_repo(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<CreateRepoRequest>,
+) -> Result<Json<git_ops::GitRepo>, (StatusCode, String)> {
+    let session = auth::extract_session(&state, &jar).await?;
+    let repo = git_ops::create_repo(
+        &session.access_token,
+        &req.name,
+        req.description.as_deref(),
+        req.private.unwrap_or(true),
+    )
+    .await
+    .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
+    Ok(Json(repo))
+}
+
+#[derive(Deserialize)]
+struct CloneRequest {
+    #[serde(rename = "cloneUrl")]
+    clone_url: String,
+    #[serde(rename = "fullName")]
+    full_name: String,
+}
+
+/// POST /api/git/clone - Clone a repository
+async fn api_git_clone(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<CloneRequest>,
+) -> Result<Json<git_ops::GitProjectInfo>, (StatusCode, String)> {
+    let session = auth::extract_session(&state, &jar).await?;
+    let token = session.access_token.clone();
+    let clone_url = req.clone_url.clone();
+    let full_name = req.full_name.clone();
+
+    // Clone is blocking (git2), run in a blocking task
+    let result = tokio::task::spawn_blocking(move || {
+        git_ops::clone_repo(&token, &clone_url, &full_name)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    let has_project = result.join("project.json").exists();
+
+    Ok(Json(git_ops::GitProjectInfo {
+        repo_full_name: req.full_name,
+        branch: "main".to_string(),
+        has_project,
+        local_path: result.to_string_lossy().to_string(),
+    }))
+}
+
+/// GET /api/git/project/load?repo=owner/name - Load project from cloned repo
+async fn api_git_load_project(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Query(q): Query<GitLoadQuery>,
+) -> Result<Json<Option<Project>>, (StatusCode, String)> {
+    let _session = auth::extract_session(&state, &jar).await?;
+    let repo = q.repo.clone();
+
+    let project = tokio::task::spawn_blocking(move || git_ops::load_project_from_repo(&repo))
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(project))
+}
+
+#[derive(Deserialize)]
+struct GitLoadQuery {
+    repo: String,
+}
+
+#[derive(Deserialize)]
+struct GitPushRequest {
+    #[serde(rename = "fullName")]
+    full_name: String,
+    project: Project,
+    message: Option<String>,
+}
+
+/// POST /api/git/push - Save project and push to GitHub
+async fn api_git_push(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<GitPushRequest>,
+) -> Result<Json<()>, (StatusCode, String)> {
+    let session = auth::extract_session(&state, &jar).await?;
+    let token = session.access_token.clone();
+    let full_name = req.full_name.clone();
+    let project = req.project.clone();
+    let message = req.message.unwrap_or_else(|| "Update project via Ars Editor".to_string());
+
+    tokio::task::spawn_blocking(move || {
+        git_ops::save_and_push(&token, &full_name, &project, &message)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(()))
+}
+
+/// GET /api/git/projects - List locally cloned projects
+async fn api_git_list_local_projects(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<Json<Vec<git_ops::GitProjectInfo>>, (StatusCode, String)> {
+    let _session = auth::extract_session(&state, &jar).await?;
+
+    let projects = tokio::task::spawn_blocking(git_ops::list_local_projects)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(projects))
+}
+
 pub fn api_router(state: AppState) -> Router {
     Router::new()
         // Local file-based APIs (no auth required)
@@ -146,6 +290,12 @@ pub fn api_router(state: AppState) -> Router {
         .route("/api/cloud/project/load", get(api_cloud_load_project))
         .route("/api/cloud/project/list", get(api_cloud_list_projects))
         .route("/api/cloud/project/:project_id", delete(api_cloud_delete_project))
+        // Git project management APIs (auth required)
+        .route("/api/git/repos", get(api_git_list_repos).post(api_git_create_repo))
+        .route("/api/git/clone", post(api_git_clone))
+        .route("/api/git/project/load", get(api_git_load_project))
+        .route("/api/git/push", post(api_git_push))
+        .route("/api/git/projects", get(api_git_list_local_projects))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }

--- a/ars-editor/src/components/ProjectManager.tsx
+++ b/ars-editor/src/components/ProjectManager.tsx
@@ -1,0 +1,352 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuthStore } from '@/stores/authStore';
+import { useProjectStore } from '@/stores/projectStore';
+import { useEditorStore } from '@/stores/editorStore';
+import * as authApi from '@/lib/auth-api';
+import type { GitRepo } from '@/types/auth';
+
+interface ProjectManagerProps {
+  onClose: () => void;
+}
+
+type Tab = 'repos' | 'local' | 'new';
+
+export function ProjectManager({ onClose }: ProjectManagerProps) {
+  const user = useAuthStore((s) => s.user);
+  const gitRepos = useAuthStore((s) => s.gitRepos);
+  const gitReposLoading = useAuthStore((s) => s.gitReposLoading);
+  const localGitProjects = useAuthStore((s) => s.localGitProjects);
+  const fetchGitRepos = useAuthStore((s) => s.fetchGitRepos);
+  const fetchLocalGitProjects = useAuthStore((s) => s.fetchLocalGitProjects);
+  const setActiveGitRepo = useAuthStore((s) => s.setActiveGitRepo);
+  const loadProject = useProjectStore((s) => s.loadProject);
+  const project = useProjectStore((s) => s.project);
+  const markSaved = useEditorStore((s) => s.markSaved);
+
+  const [tab, setTab] = useState<Tab>('repos');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // New repo form
+  const [newRepoName, setNewRepoName] = useState('');
+  const [newRepoDesc, setNewRepoDesc] = useState('');
+  const [newRepoPrivate, setNewRepoPrivate] = useState(true);
+
+  useEffect(() => {
+    if (user) {
+      fetchGitRepos();
+      fetchLocalGitProjects();
+    }
+  }, [user, fetchGitRepos, fetchLocalGitProjects]);
+
+  const showStatus = (msg: string) => {
+    setStatus(msg);
+    setTimeout(() => setStatus(''), 3000);
+  };
+
+  const handleClone = useCallback(async (repo: GitRepo) => {
+    setLoading(true);
+    showStatus(`Cloning ${repo.full_name}...`);
+    try {
+      const info = await authApi.cloneGitRepo(repo.clone_url, repo.full_name);
+      showStatus('Clone complete!');
+
+      // Try to load project from the cloned repo
+      const loadedProject = await authApi.loadGitProject(info.repo_full_name);
+      if (loadedProject) {
+        loadProject(loadedProject);
+        setActiveGitRepo(info.repo_full_name);
+        markSaved();
+        showStatus('Project loaded!');
+      } else {
+        setActiveGitRepo(info.repo_full_name);
+        showStatus('Cloned (no project.json found)');
+      }
+      fetchLocalGitProjects();
+    } catch (e) {
+      showStatus(`Clone failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadProject, setActiveGitRepo, markSaved, fetchLocalGitProjects]);
+
+  const handleLoadLocal = useCallback(async (repoFullName: string) => {
+    setLoading(true);
+    showStatus('Loading project...');
+    try {
+      const loadedProject = await authApi.loadGitProject(repoFullName);
+      if (loadedProject) {
+        loadProject(loadedProject);
+        setActiveGitRepo(repoFullName);
+        markSaved();
+        showStatus('Project loaded!');
+      } else {
+        showStatus('No project.json in this repository');
+      }
+    } catch (e) {
+      showStatus(`Load failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadProject, setActiveGitRepo, markSaved]);
+
+  const handlePush = useCallback(async (repoFullName: string) => {
+    setLoading(true);
+    showStatus('Pushing to GitHub...');
+    try {
+      await authApi.pushGitProject(repoFullName, project);
+      markSaved();
+      showStatus('Pushed successfully!');
+    } catch (e) {
+      showStatus(`Push failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [project, markSaved]);
+
+  const handleCreateRepo = useCallback(async () => {
+    if (!newRepoName.trim()) return;
+    setLoading(true);
+    showStatus('Creating repository...');
+    try {
+      const repo = await authApi.createGitRepo(
+        newRepoName.trim(),
+        newRepoDesc.trim() || undefined,
+        newRepoPrivate,
+      );
+      showStatus('Repository created!');
+      setNewRepoName('');
+      setNewRepoDesc('');
+
+      // Clone the new repo and save current project
+      const info = await authApi.cloneGitRepo(repo.clone_url, repo.full_name);
+      await authApi.pushGitProject(info.repo_full_name, project);
+      setActiveGitRepo(info.repo_full_name);
+      markSaved();
+      showStatus('Project saved to new repo!');
+
+      fetchGitRepos();
+      fetchLocalGitProjects();
+      setTab('local');
+    } catch (e) {
+      showStatus(`Failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [newRepoName, newRepoDesc, newRepoPrivate, project, setActiveGitRepo, markSaved, fetchGitRepos, fetchLocalGitProjects]);
+
+  if (!user) {
+    return (
+      <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center" onClick={onClose}>
+        <div className="bg-zinc-800 rounded-lg shadow-xl p-6 max-w-sm" onClick={(e) => e.stopPropagation()}>
+          <p className="text-zinc-300 mb-4">Sign in with GitHub to manage projects.</p>
+          <a
+            href={authApi.getLoginUrl()}
+            className="block w-full text-center px-4 py-2 bg-zinc-700 hover:bg-zinc-600 text-white rounded transition-colors"
+          >
+            Sign in with GitHub
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  const activeGitRepo = useAuthStore.getState().activeGitRepo;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center" onClick={onClose}>
+      <div
+        className="bg-zinc-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-700">
+          <h2 className="text-sm font-semibold text-white">Project Manager</h2>
+          <div className="flex items-center gap-2">
+            {activeGitRepo && (
+              <span className="text-xs text-zinc-400 truncate max-w-[200px]">
+                {activeGitRepo}
+              </span>
+            )}
+            <button
+              onClick={onClose}
+              className="text-zinc-400 hover:text-white text-lg leading-none"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-zinc-700">
+          {(['repos', 'local', 'new'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-4 py-2 text-xs font-medium transition-colors ${
+                tab === t
+                  ? 'text-blue-400 border-b-2 border-blue-400'
+                  : 'text-zinc-400 hover:text-zinc-200'
+              }`}
+            >
+              {t === 'repos' ? 'GitHub Repos' : t === 'local' ? 'Cloned Projects' : 'New Repository'}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {/* Status */}
+          {status && (
+            <div className="mb-3 px-3 py-2 bg-zinc-700/50 rounded text-xs text-zinc-300">
+              {status}
+            </div>
+          )}
+
+          {/* GitHub Repos tab */}
+          {tab === 'repos' && (
+            <div className="space-y-1">
+              {gitReposLoading ? (
+                <p className="text-zinc-500 text-sm">Loading repositories...</p>
+              ) : gitRepos.length === 0 ? (
+                <p className="text-zinc-500 text-sm">No repositories found.</p>
+              ) : (
+                gitRepos.map((repo) => (
+                  <div
+                    key={repo.full_name}
+                    className="flex items-center justify-between px-3 py-2 rounded hover:bg-zinc-700/50 transition-colors"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-zinc-200 truncate">{repo.full_name}</span>
+                        {repo.private && (
+                          <span className="text-[10px] px-1.5 py-0.5 bg-zinc-600 rounded text-zinc-400">
+                            private
+                          </span>
+                        )}
+                      </div>
+                      {repo.description && (
+                        <p className="text-xs text-zinc-500 truncate mt-0.5">{repo.description}</p>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => handleClone(repo)}
+                      disabled={loading}
+                      className="ml-2 px-3 py-1 text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded transition-colors"
+                    >
+                      Clone
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* Local Projects tab */}
+          {tab === 'local' && (
+            <div className="space-y-1">
+              {localGitProjects.length === 0 ? (
+                <p className="text-zinc-500 text-sm">No cloned projects. Clone a repository first.</p>
+              ) : (
+                localGitProjects.map((proj) => (
+                  <div
+                    key={proj.repo_full_name}
+                    className={`flex items-center justify-between px-3 py-2 rounded transition-colors ${
+                      activeGitRepo === proj.repo_full_name
+                        ? 'bg-blue-600/20 border border-blue-500/30'
+                        : 'hover:bg-zinc-700/50'
+                    }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm text-zinc-200 truncate">{proj.repo_full_name}</div>
+                      <div className="text-xs text-zinc-500">
+                        {proj.branch} {proj.has_project ? '' : '(no project.json)'}
+                      </div>
+                    </div>
+                    <div className="flex gap-1.5 ml-2">
+                      <button
+                        onClick={() => handleLoadLocal(proj.repo_full_name)}
+                        disabled={loading}
+                        className="px-3 py-1 text-xs bg-zinc-600 hover:bg-zinc-500 disabled:opacity-50 text-white rounded transition-colors"
+                      >
+                        Load
+                      </button>
+                      <button
+                        onClick={() => handlePush(proj.repo_full_name)}
+                        disabled={loading}
+                        className="px-3 py-1 text-xs bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white rounded transition-colors"
+                      >
+                        Push
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {/* New Repository tab */}
+          {tab === 'new' && (
+            <div className="space-y-4 max-w-md">
+              <p className="text-xs text-zinc-400">
+                Create a new GitHub repository and save the current project to it.
+              </p>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Repository Name</label>
+                <input
+                  type="text"
+                  value={newRepoName}
+                  onChange={(e) => setNewRepoName(e.target.value)}
+                  placeholder="my-ars-project"
+                  className="w-full px-3 py-1.5 bg-zinc-700 border border-zinc-600 rounded text-sm text-zinc-200 placeholder-zinc-500 focus:outline-none focus:border-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Description (optional)</label>
+                <input
+                  type="text"
+                  value={newRepoDesc}
+                  onChange={(e) => setNewRepoDesc(e.target.value)}
+                  placeholder="Ars Editor project"
+                  className="w-full px-3 py-1.5 bg-zinc-700 border border-zinc-600 rounded text-sm text-zinc-200 placeholder-zinc-500 focus:outline-none focus:border-blue-500"
+                />
+              </div>
+              <label className="flex items-center gap-2 text-xs text-zinc-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={newRepoPrivate}
+                  onChange={(e) => setNewRepoPrivate(e.target.checked)}
+                  className="accent-blue-500"
+                />
+                Private repository
+              </label>
+              <button
+                onClick={handleCreateRepo}
+                disabled={loading || !newRepoName.trim()}
+                className="px-4 py-2 text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded transition-colors"
+              >
+                Create & Save Project
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Footer with push shortcut */}
+        {activeGitRepo && (
+          <div className="flex items-center justify-between px-4 py-2 border-t border-zinc-700">
+            <span className="text-xs text-zinc-500">
+              Active: <span className="text-zinc-300">{activeGitRepo}</span>
+            </span>
+            <button
+              onClick={() => handlePush(activeGitRepo)}
+              disabled={loading}
+              className="px-3 py-1 text-xs bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white rounded transition-colors"
+            >
+              Push Current Project
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -1,10 +1,13 @@
 import { useState, useCallback } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
 import { useEditorStore } from '@/stores/editorStore';
+import { useAuthStore } from '@/stores/authStore';
 import { canUndo, canRedo, undo, redo } from '@/stores/historyMiddleware';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import * as backend from '@/lib/backend';
+import * as authApi from '@/lib/auth-api';
 import { UserMenu } from './UserMenu';
+import { ProjectManager } from './ProjectManager';
 
 export function Toolbar() {
   const project = useProjectStore((s) => s.project);
@@ -20,8 +23,11 @@ export function Toolbar() {
   const setMobileSceneMenu = useEditorStore((s) => s.setMobileSceneMenu);
   const mobileBottomSheetOpen = useEditorStore((s) => s.mobileBottomSheetOpen);
   const setMobileBottomSheet = useEditorStore((s) => s.setMobileBottomSheet);
+  const activeGitRepo = useAuthStore((s) => s.activeGitRepo);
   const [status, setStatus] = useState<string>('');
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [showProjectManager, setShowProjectManager] = useState(false);
+  const [pushing, setPushing] = useState(false);
   const isMobile = useIsMobile();
 
   const showStatus = (msg: string) => {
@@ -100,6 +106,21 @@ export function Toolbar() {
     markSaved();
     showStatus('New project');
   }, [loadProject, setProjectPath, markSaved, isDirty]);
+
+  const handleGitPush = useCallback(async () => {
+    if (!activeGitRepo) return;
+    setPushing(true);
+    showStatus('Pushing to GitHub...');
+    try {
+      await authApi.pushGitProject(activeGitRepo, project);
+      markSaved();
+      showStatus('Pushed!');
+    } catch {
+      showStatus('Push failed');
+    } finally {
+      setPushing(false);
+    }
+  }, [activeGitRepo, project, markSaved]);
 
   const lastSavedLabel = lastSavedAt
     ? `Last saved: ${new Date(lastSavedAt).toLocaleTimeString()}`
@@ -230,12 +251,33 @@ export function Toolbar() {
                 Preview
               </button>
               <div className="h-px bg-zinc-700 my-1" />
+              {!backend.isTauri() && (
+                <button
+                  onClick={() => { setShowProjectManager(true); setMobileMenuOpen(false); }}
+                  className="w-full text-left px-3 py-2 text-zinc-300 hover:bg-zinc-700 transition-colors"
+                >
+                  Projects
+                </button>
+              )}
+              {activeGitRepo && (
+                <button
+                  onClick={() => { handleGitPush(); setMobileMenuOpen(false); }}
+                  disabled={pushing}
+                  className="w-full text-left px-3 py-2 text-green-400 hover:bg-zinc-700 transition-colors disabled:opacity-50"
+                >
+                  Push to GitHub
+                </button>
+              )}
+              <div className="h-px bg-zinc-700 my-1" />
               <div className="px-3 py-2 text-zinc-500 truncate">
                 {project.name}
                 {isDirty && <span className="text-amber-400 ml-1">*</span>}
               </div>
             </div>
           </>
+        )}
+        {showProjectManager && (
+          <ProjectManager onClose={() => setShowProjectManager(false)} />
         )}
       </div>
     );
@@ -337,7 +379,29 @@ export function Toolbar() {
         <span className="text-green-400 ml-2">{status}</span>
       )}
       <div className="w-px h-4 bg-zinc-600 mx-1" />
-      <UserMenu />
+      {activeGitRepo && (
+        <button
+          onClick={handleGitPush}
+          disabled={pushing}
+          className="px-2 py-1 text-green-400 hover:bg-zinc-700 rounded transition-colors disabled:opacity-50"
+          title={`Push to ${activeGitRepo}`}
+        >
+          Push{pushing ? '...' : ''}
+        </button>
+      )}
+      {!backend.isTauri() && (
+        <button
+          onClick={() => setShowProjectManager(true)}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors"
+          title="Project Manager"
+        >
+          Projects
+        </button>
+      )}
+      <UserMenu onOpenProjectManager={() => setShowProjectManager(true)} />
+      {showProjectManager && (
+        <ProjectManager onClose={() => setShowProjectManager(false)} />
+      )}
     </div>
   );
 }

--- a/ars-editor/src/components/UserMenu.tsx
+++ b/ars-editor/src/components/UserMenu.tsx
@@ -2,13 +2,19 @@ import { useState, useRef, useEffect } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import * as authApi from '@/lib/auth-api';
 import { isTauri } from '@/lib/backend';
+import { ProjectManager } from './ProjectManager';
 
-export function UserMenu() {
+interface UserMenuProps {
+  onOpenProjectManager?: () => void;
+}
+
+export function UserMenu({ onOpenProjectManager }: UserMenuProps) {
   const user = useAuthStore((s) => s.user);
   const loading = useAuthStore((s) => s.loading);
   const fetchUser = useAuthStore((s) => s.fetchUser);
   const logout = useAuthStore((s) => s.logout);
   const [open, setOpen] = useState(false);
+  const [showProjectManager, setShowProjectManager] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -27,6 +33,15 @@ export function UserMenu() {
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
+  const handleOpenProjects = () => {
+    setOpen(false);
+    if (onOpenProjectManager) {
+      onOpenProjectManager();
+    } else {
+      setShowProjectManager(true);
+    }
+  };
+
   // Don't show in Tauri desktop mode
   if (isTauri()) return null;
 
@@ -36,42 +51,58 @@ export function UserMenu() {
 
   if (!user) {
     return (
-      <a
-        href={authApi.getLoginUrl()}
-        className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-xs"
-      >
-        Login with GitHub
-      </a>
+      <>
+        <a
+          href={authApi.getLoginUrl()}
+          className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-xs"
+        >
+          Login with GitHub
+        </a>
+        {showProjectManager && (
+          <ProjectManager onClose={() => setShowProjectManager(false)} />
+        )}
+      </>
     );
   }
 
   return (
-    <div ref={ref} className="relative">
-      <button
-        onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-xs"
-      >
-        <img
-          src={user.avatarUrl}
-          alt={user.displayName}
-          className="w-4 h-4 rounded-full"
-        />
-        <span className="max-w-[100px] truncate">{user.displayName}</span>
-      </button>
-      {open && (
-        <div className="absolute right-0 top-full mt-1 w-48 bg-zinc-800 border border-zinc-600 rounded shadow-lg z-50">
-          <div className="px-3 py-2 border-b border-zinc-700">
-            <div className="text-sm text-zinc-200 font-medium truncate">{user.displayName}</div>
-            <div className="text-xs text-zinc-500 truncate">@{user.login}</div>
+    <>
+      <div ref={ref} className="relative">
+        <button
+          onClick={() => setOpen(!open)}
+          className="flex items-center gap-1.5 px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors text-xs"
+        >
+          <img
+            src={user.avatarUrl}
+            alt={user.displayName}
+            className="w-4 h-4 rounded-full"
+          />
+          <span className="max-w-[100px] truncate">{user.displayName}</span>
+        </button>
+        {open && (
+          <div className="absolute right-0 top-full mt-1 w-48 bg-zinc-800 border border-zinc-600 rounded shadow-lg z-50">
+            <div className="px-3 py-2 border-b border-zinc-700">
+              <div className="text-sm text-zinc-200 font-medium truncate">{user.displayName}</div>
+              <div className="text-xs text-zinc-500 truncate">@{user.login}</div>
+            </div>
+            <button
+              onClick={handleOpenProjects}
+              className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+            >
+              Projects
+            </button>
+            <button
+              onClick={() => { logout(); setOpen(false); }}
+              className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+            >
+              Sign out
+            </button>
           </div>
-          <button
-            onClick={() => { logout(); setOpen(false); }}
-            className="w-full text-left px-3 py-2 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
-          >
-            Sign out
-          </button>
-        </div>
+        )}
+      </div>
+      {showProjectManager && (
+        <ProjectManager onClose={() => setShowProjectManager(false)} />
       )}
-    </div>
+    </>
   );
 }

--- a/ars-editor/src/lib/auth-api.ts
+++ b/ars-editor/src/lib/auth-api.ts
@@ -1,4 +1,4 @@
-import type { User, ProjectSummary } from '@/types/auth';
+import type { User, ProjectSummary, GitRepo, GitProjectInfo } from '@/types/auth';
 import type { Project } from '@/types/domain';
 
 async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
@@ -45,4 +45,52 @@ export async function deleteCloudProject(projectId: string): Promise<void> {
   await fetchJson(`/api/cloud/project/${encodeURIComponent(projectId)}`, {
     method: 'DELETE',
   });
+}
+
+// ========== Git project management APIs ==========
+
+export async function listGitRepos(): Promise<GitRepo[]> {
+  return fetchJson<GitRepo[]>('/api/git/repos');
+}
+
+export async function createGitRepo(
+  name: string,
+  description?: string,
+  isPrivate?: boolean,
+): Promise<GitRepo> {
+  return fetchJson<GitRepo>('/api/git/repos', {
+    method: 'POST',
+    body: JSON.stringify({ name, description, private: isPrivate ?? true }),
+  });
+}
+
+export async function cloneGitRepo(
+  cloneUrl: string,
+  fullName: string,
+): Promise<GitProjectInfo> {
+  return fetchJson<GitProjectInfo>('/api/git/clone', {
+    method: 'POST',
+    body: JSON.stringify({ cloneUrl, fullName }),
+  });
+}
+
+export async function loadGitProject(repo: string): Promise<Project | null> {
+  return fetchJson<Project | null>(
+    `/api/git/project/load?repo=${encodeURIComponent(repo)}`,
+  );
+}
+
+export async function pushGitProject(
+  fullName: string,
+  project: Project,
+  message?: string,
+): Promise<void> {
+  await fetchJson('/api/git/push', {
+    method: 'POST',
+    body: JSON.stringify({ fullName, project, message }),
+  });
+}
+
+export async function listLocalGitProjects(): Promise<GitProjectInfo[]> {
+  return fetchJson<GitProjectInfo[]>('/api/git/projects');
 }

--- a/ars-editor/src/stores/authStore.ts
+++ b/ars-editor/src/stores/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { User, ProjectSummary } from '@/types/auth';
+import type { User, ProjectSummary, GitRepo, GitProjectInfo } from '@/types/auth';
 import * as authApi from '@/lib/auth-api';
 
 interface AuthState {
@@ -7,12 +7,19 @@ interface AuthState {
   loading: boolean;
   cloudProjects: ProjectSummary[];
   cloudProjectsLoading: boolean;
+  gitRepos: GitRepo[];
+  gitReposLoading: boolean;
+  localGitProjects: GitProjectInfo[];
+  activeGitRepo: string | null;
 }
 
 interface AuthActions {
   fetchUser: () => Promise<void>;
   logout: () => Promise<void>;
   fetchCloudProjects: () => Promise<void>;
+  fetchGitRepos: () => Promise<void>;
+  fetchLocalGitProjects: () => Promise<void>;
+  setActiveGitRepo: (repo: string | null) => void;
 }
 
 export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
@@ -20,6 +27,10 @@ export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
   loading: true,
   cloudProjects: [],
   cloudProjectsLoading: false,
+  gitRepos: [],
+  gitReposLoading: false,
+  localGitProjects: [],
+  activeGitRepo: null,
 
   fetchUser: async () => {
     set({ loading: true });
@@ -37,7 +48,7 @@ export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
     } catch {
       // ignore
     }
-    set({ user: null });
+    set({ user: null, gitRepos: [], localGitProjects: [], activeGitRepo: null });
   },
 
   fetchCloudProjects: async () => {
@@ -49,4 +60,25 @@ export const useAuthStore = create<AuthState & AuthActions>()((set) => ({
       set({ cloudProjectsLoading: false });
     }
   },
+
+  fetchGitRepos: async () => {
+    set({ gitReposLoading: true });
+    try {
+      const repos = await authApi.listGitRepos();
+      set({ gitRepos: repos, gitReposLoading: false });
+    } catch {
+      set({ gitReposLoading: false });
+    }
+  },
+
+  fetchLocalGitProjects: async () => {
+    try {
+      const projects = await authApi.listLocalGitProjects();
+      set({ localGitProjects: projects });
+    } catch {
+      // ignore
+    }
+  },
+
+  setActiveGitRepo: (repo) => set({ activeGitRepo: repo }),
 }));

--- a/ars-editor/src/types/auth.ts
+++ b/ars-editor/src/types/auth.ts
@@ -14,3 +14,20 @@ export interface ProjectSummary {
   name: string;
   updatedAt: string;
 }
+
+export interface GitRepo {
+  name: string;
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  clone_url: string;
+  private: boolean;
+  updated_at: string;
+}
+
+export interface GitProjectInfo {
+  repo_full_name: string;
+  branch: string;
+  has_project: boolean;
+  local_path: string;
+}


### PR DESCRIPTION
- Store GitHub access token in session for authenticated Git operations
- Add git_ops.rs module with clone, push, commit, and repo listing via git2
- Add backend API routes for Git operations (repos, clone, push, load)
- Add ProjectManager UI component with tabs for GitHub repos, local projects, and new repo creation
- Integrate push button and project manager into Toolbar and UserMenu
- Request 'repo' OAuth scope for repository access

https://claude.ai/code/session_016CZ4MrjfZrpuLbrmz2yRsy