### PR TITLE
feat: add MCP server for Claude Code integration

### DIFF
--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,85 @@
+# Ars MCP Server
+
+Arsアクターモデルエンジン用のMCP (Model Context Protocol) サーバー。
+Claude Codeと連携して、Arsプロジェクトの管理・モジュール定義の操作を行えます。
+
+## セットアップ
+
+```bash
+cd mcp-server
+npm install
+npm run build
+```
+
+## Claude Codeでの設定
+
+`.claude/mcp.json` に以下を追加:
+
+```json
+{
+  "mcpServers": {
+    "ars": {
+      "command": "node",
+      "args": ["mcp-server/dist/index.js"],
+      "env": {
+        "ARS_PROJECT_DIR": "/path/to/your/ars/project"
+      }
+    }
+  }
+}
+```
+
+## 提供するツール
+
+### プロジェクト管理
+| ツール | 説明 |
+|--------|------|
+| `list_projects` | .ars.jsonファイルを検索して一覧表示 |
+| `create_project` | 新しいArsプロジェクトを作成 |
+| `load_project` | プロジェクトを読み込んで概要表示 |
+| `get_project_json` | プロジェクトの生JSON構造を取得 |
+
+### シーン管理
+| ツール | 説明 |
+|--------|------|
+| `create_scene` | シーンを追加（ルートアクター自動生成） |
+| `list_scenes` | 全シーン一覧表示 |
+
+### アクター管理
+| ツール | 説明 |
+|--------|------|
+| `add_actor` | シーンにアクターを追加 |
+| `list_actors` | シーン内の全アクター一覧 |
+
+### コンポーネント管理
+| ツール | 説明 |
+|--------|------|
+| `create_component` | コンポーネント定義を作成 |
+| `list_components` | コンポーネント一覧（カテゴリフィルタ対応） |
+| `attach_component` | アクターにコンポーネントをアタッチ |
+
+### 接続管理
+| ツール | 説明 |
+|--------|------|
+| `add_connection` | アクター間にポート接続を追加 |
+
+### モジュール定義
+| ツール | 説明 |
+|--------|------|
+| `parse_module_markdown` | Ars形式Markdownからモジュール定義をパース |
+| `import_module_to_project` | モジュール定義をコンポーネントとしてインポート |
+| `generate_module_markdown` | コンポーネント情報からMarkdown定義書を生成 |
+
+## リソース
+
+| リソース | URI | 説明 |
+|----------|-----|------|
+| 設計書 | `ars://design/plan` | plan.md の内容 |
+| 実装ルール | `ars://design/rules` | ars.md の内容 |
+
+## プロンプト
+
+| プロンプト | 説明 |
+|-----------|------|
+| `new-module-definition` | 新しいモジュール定義書を作成する |
+| `design-scene` | シーン設計を支援する |

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1177 @@
+{
+  "name": "@ars/mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ars/mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "ars-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.0",
+        "typescript": "~5.9.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ars/mcp-server",
+  "version": "0.1.0",
+  "description": "Ars Actor Model Engine - MCP Server for Claude Code",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "ars-mcp-server": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "typescript": "~5.9.3"
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,589 @@
+#!/usr/bin/env node
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ProjectManager } from './project-manager.js';
+import { parseModuleMarkdown } from './module-parser.js';
+import type { Project } from './types.js';
+
+const server = new McpServer({
+  name: 'ars-mcp-server',
+  version: '0.1.0',
+});
+
+// デフォルトのプロジェクトディレクトリはカレント or 環境変数
+const projectDir = process.env.ARS_PROJECT_DIR ?? process.cwd();
+const pm = new ProjectManager(projectDir);
+
+// === Resources ===
+
+server.resource(
+  'project-design',
+  'ars://design/plan',
+  async (uri) => {
+    const planPath = path.join(projectDir, 'plan.md');
+    if (fs.existsSync(planPath)) {
+      return { contents: [{ uri: uri.href, mimeType: 'text/markdown', text: fs.readFileSync(planPath, 'utf-8') }] };
+    }
+    return { contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'plan.md not found' }] };
+  },
+);
+
+server.resource(
+  'implementation-rules',
+  'ars://design/rules',
+  async (uri) => {
+    const arsPath = path.join(projectDir, 'ars.md');
+    if (fs.existsSync(arsPath)) {
+      return { contents: [{ uri: uri.href, mimeType: 'text/markdown', text: fs.readFileSync(arsPath, 'utf-8') }] };
+    }
+    return { contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'ars.md not found' }] };
+  },
+);
+
+// === Tools ===
+
+// --- プロジェクト管理 ---
+
+server.tool(
+  'list_projects',
+  'プロジェクトディレクトリ内の.ars.jsonファイルを検索して一覧表示する',
+  {},
+  async () => {
+    const files = pm.findProjectFiles();
+    if (files.length === 0) {
+      return { content: [{ type: 'text', text: 'プロジェクトファイルが見つかりません。create_project で新規作成してください。' }] };
+    }
+    const list = files.map(f => `- ${path.relative(projectDir, f)}`).join('\n');
+    return { content: [{ type: 'text', text: `発見されたプロジェクト:\n${list}` }] };
+  },
+);
+
+server.tool(
+  'create_project',
+  '新しいArsプロジェクトを作成する',
+  {
+    name: z.string().describe('プロジェクト名'),
+    file_path: z.string().optional().describe('保存先ファイルパス（デフォルト: <name>.ars.json）'),
+  },
+  async ({ name, file_path }) => {
+    const project = pm.createProject(name);
+    const savePath = file_path ?? path.join(projectDir, `${name}.ars.json`);
+    pm.saveProject(savePath, project);
+    return { content: [{ type: 'text', text: `プロジェクト "${name}" を作成しました: ${savePath}` }] };
+  },
+);
+
+server.tool(
+  'load_project',
+  'Arsプロジェクトを読み込んで概要を表示する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+  },
+  async ({ file_path }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    const project = pm.loadProject(fullPath);
+    const summary = pm.summarizeProject(project);
+    return { content: [{ type: 'text', text: summary }] };
+  },
+);
+
+server.tool(
+  'get_project_json',
+  'Arsプロジェクトの生のJSON構造を取得する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+  },
+  async ({ file_path }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    const project = pm.loadProject(fullPath);
+    return { content: [{ type: 'text', text: JSON.stringify(project, null, 2) }] };
+  },
+);
+
+// --- シーン管理 ---
+
+server.tool(
+  'create_scene',
+  'プロジェクトに新しいシーンを追加する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    name: z.string().describe('シーン名'),
+  },
+  async ({ file_path, name }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    let project = pm.loadProject(fullPath);
+    const result = pm.createScene(project, name);
+    project = result.project;
+    pm.saveProject(fullPath, project);
+    return {
+      content: [{
+        type: 'text',
+        text: `シーン "${name}" を作成しました (ID: ${result.scene.id})\nルートアクター: ${result.scene.rootActorId}`,
+      }],
+    };
+  },
+);
+
+server.tool(
+  'list_scenes',
+  'プロジェクト内の全シーンを一覧表示する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+  },
+  async ({ file_path }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    const project = pm.loadProject(fullPath);
+    const scenes = Object.values(project.scenes);
+    if (scenes.length === 0) {
+      return { content: [{ type: 'text', text: 'シーンがありません。' }] };
+    }
+    const list = scenes.map(s => {
+      const actorCount = Object.keys(s.actors).length;
+      const active = project.activeSceneId === s.id ? ' ★' : '';
+      return `- **${s.name}**${active} (ID: ${s.id}) - アクター: ${actorCount}個`;
+    }).join('\n');
+    return { content: [{ type: 'text', text: `シーン一覧:\n${list}` }] };
+  },
+);
+
+// --- アクター管理 ---
+
+server.tool(
+  'add_actor',
+  'シーンにアクターを追加する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    scene_id: z.string().describe('シーンID'),
+    name: z.string().describe('アクター名'),
+    role: z.enum(['actor', 'sequence']).describe('アクターのロール'),
+    x: z.number().optional().describe('X座標（デフォルト: 200）'),
+    y: z.number().optional().describe('Y座標（デフォルト: 200）'),
+  },
+  async ({ file_path, scene_id, name, role, x, y }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    let project = pm.loadProject(fullPath);
+    const result = pm.addActor(project, scene_id, name, role, { x: x ?? 200, y: y ?? 200 });
+    project = result.project;
+    pm.saveProject(fullPath, project);
+    return {
+      content: [{
+        type: 'text',
+        text: `アクター "${name}" [${role}] を追加しました (ID: ${result.actor.id})`,
+      }],
+    };
+  },
+);
+
+server.tool(
+  'list_actors',
+  'シーン内の全アクターを一覧表示する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    scene_id: z.string().describe('シーンID'),
+  },
+  async ({ file_path, scene_id }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    const project = pm.loadProject(fullPath);
+    const scene = project.scenes[scene_id];
+    if (!scene) {
+      return { content: [{ type: 'text', text: `シーンが見つかりません: ${scene_id}` }], isError: true };
+    }
+    const actors = Object.values(scene.actors);
+    const list = actors.map(a => {
+      const compNames = a.components.map(cid => project.components[cid]?.name ?? cid);
+      const comps = compNames.length > 0 ? ` [${compNames.join(', ')}]` : '';
+      return `- **${a.name}** [${a.role}] (ID: ${a.id})${comps}`;
+    }).join('\n');
+    return { content: [{ type: 'text', text: `シーン "${scene.name}" のアクター一覧:\n${list}` }] };
+  },
+);
+
+// --- コンポーネント管理 ---
+
+server.tool(
+  'create_component',
+  'プロジェクトに新しいコンポーネントを定義する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    name: z.string().describe('コンポーネント名'),
+    category: z.enum(['UI', 'Logic', 'System', 'GameObject']).describe('カテゴリ'),
+    domain: z.string().describe('所属ドメイン'),
+    variables: z.array(z.object({
+      name: z.string(),
+      type: z.string(),
+    })).optional().describe('変数定義の配列'),
+    tasks: z.array(z.object({
+      name: z.string(),
+      description: z.string(),
+      inputs: z.array(z.object({ name: z.string(), type: z.string() })).optional(),
+      outputs: z.array(z.object({ name: z.string(), type: z.string() })).optional(),
+    })).optional().describe('タスク定義の配列'),
+    dependencies: z.array(z.string()).optional().describe('依存コンポーネントID'),
+  },
+  async ({ file_path, name, category, domain, variables, tasks, dependencies }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    let project = pm.loadProject(fullPath);
+    const result = pm.createComponent(project, {
+      name,
+      category,
+      domain,
+      variables: variables?.map(v => ({ ...v, defaultValue: undefined })),
+      tasks: tasks?.map(t => ({
+        name: t.name,
+        description: t.description,
+        inputs: t.inputs ?? [],
+        outputs: t.outputs ?? [],
+      })),
+      dependencies,
+    });
+    project = result.project;
+    pm.saveProject(fullPath, project);
+    return {
+      content: [{
+        type: 'text',
+        text: `コンポーネント "${name}" [${category}] を作成しました (ID: ${result.component.id})`,
+      }],
+    };
+  },
+);
+
+server.tool(
+  'list_components',
+  'プロジェクト内の全コンポーネントをカテゴリ別に一覧表示する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    category: z.enum(['UI', 'Logic', 'System', 'GameObject']).optional().describe('フィルタするカテゴリ'),
+  },
+  async ({ file_path, category }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    const project = pm.loadProject(fullPath);
+    let components = Object.values(project.components);
+    if (category) {
+      components = components.filter(c => c.category === category);
+    }
+    if (components.length === 0) {
+      return { content: [{ type: 'text', text: category ? `${category} カテゴリのコンポーネントはありません。` : 'コンポーネントがありません。' }] };
+    }
+    const list = components.map(c =>
+      `- **${c.name}** [${c.category}] (${c.domain}) ID: ${c.id}\n  タスク: ${c.tasks.map(t => t.name).join(', ') || 'なし'}\n  変数: ${c.variables.map(v => `${v.name}:${v.type}`).join(', ') || 'なし'}`
+    ).join('\n');
+    return { content: [{ type: 'text', text: `コンポーネント一覧:\n${list}` }] };
+  },
+);
+
+server.tool(
+  'attach_component',
+  'アクターにコンポーネントをアタッチする',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    scene_id: z.string().describe('シーンID'),
+    actor_id: z.string().describe('アクターID'),
+    component_id: z.string().describe('コンポーネントID'),
+  },
+  async ({ file_path, scene_id, actor_id, component_id }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    let project = pm.loadProject(fullPath);
+    project = pm.attachComponent(project, scene_id, actor_id, component_id);
+    pm.saveProject(fullPath, project);
+    const compName = project.components[component_id]?.name ?? component_id;
+    const actorName = project.scenes[scene_id]?.actors[actor_id]?.name ?? actor_id;
+    return {
+      content: [{
+        type: 'text',
+        text: `コンポーネント "${compName}" をアクター "${actorName}" にアタッチしました。`,
+      }],
+    };
+  },
+);
+
+// --- 接続管理 ---
+
+server.tool(
+  'add_connection',
+  'シーン内のアクター間に接続を追加する',
+  {
+    file_path: z.string().describe('.ars.json ファイルのパス'),
+    scene_id: z.string().describe('シーンID'),
+    source_actor_id: z.string().describe('接続元アクターID'),
+    source_port: z.string().describe('接続元ポート名'),
+    target_actor_id: z.string().describe('接続先アクターID'),
+    target_port: z.string().describe('接続先ポート名'),
+  },
+  async ({ file_path, scene_id, source_actor_id, source_port, target_actor_id, target_port }) => {
+    const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+    let project = pm.loadProject(fullPath);
+    const result = pm.addConnection(project, scene_id, {
+      sourceActorId: source_actor_id,
+      sourcePort: source_port,
+      targetActorId: target_actor_id,
+      targetPort: target_port,
+    });
+    project = result.project;
+    pm.saveProject(fullPath, project);
+    return {
+      content: [{
+        type: 'text',
+        text: `接続を追加しました (ID: ${result.connection.id}): ${source_actor_id}:${source_port} → ${target_actor_id}:${target_port}`,
+      }],
+    };
+  },
+);
+
+// --- モジュール定義パーサー ---
+
+server.tool(
+  'parse_module_markdown',
+  'Ars形式のMarkdownからモジュール定義をパースする',
+  {
+    file_path: z.string().optional().describe('Markdownファイルのパス（file_path か content のいずれかを指定）'),
+    content: z.string().optional().describe('パースするMarkdown文字列（file_path か content のいずれかを指定）'),
+  },
+  async ({ file_path, content }) => {
+    let markdown: string;
+    if (content) {
+      markdown = content;
+    } else if (file_path) {
+      const fullPath = path.isAbsolute(file_path) ? file_path : path.join(projectDir, file_path);
+      markdown = fs.readFileSync(fullPath, 'utf-8');
+    } else {
+      return { content: [{ type: 'text', text: 'file_path または content を指定してください。' }], isError: true };
+    }
+
+    const modules = parseModuleMarkdown(markdown, file_path);
+    if (modules.length === 0) {
+      return { content: [{ type: 'text', text: 'モジュール定義が見つかりませんでした。' }] };
+    }
+
+    const summary = modules.map(m =>
+      `## ${m.name}\n- カテゴリ: ${m.category}\n- ドメイン: ${m.domain}\n- タスク: ${m.tasks.map(t => t.name).join(', ')}\n- テスト: ${m.tests.length}件`
+    ).join('\n\n');
+
+    return {
+      content: [
+        { type: 'text', text: `${modules.length}個のモジュール定義を検出:\n\n${summary}` },
+        { type: 'text', text: `\n\n### JSON:\n\`\`\`json\n${JSON.stringify(modules, null, 2)}\n\`\`\`` },
+      ],
+    };
+  },
+);
+
+server.tool(
+  'import_module_to_project',
+  'パース済みモジュール定義をプロジェクトのコンポーネントとしてインポートする',
+  {
+    project_file: z.string().describe('.ars.json ファイルのパス'),
+    module_file: z.string().optional().describe('モジュール定義のMarkdownファイルパス'),
+    module_content: z.string().optional().describe('モジュール定義のMarkdown文字列'),
+    module_name: z.string().optional().describe('インポートするモジュール名（省略時は全モジュール）'),
+  },
+  async ({ project_file, module_file, module_content, module_name }) => {
+    const projectPath = path.isAbsolute(project_file) ? project_file : path.join(projectDir, project_file);
+    let project = pm.loadProject(projectPath);
+
+    let markdown: string;
+    if (module_content) {
+      markdown = module_content;
+    } else if (module_file) {
+      const fullPath = path.isAbsolute(module_file) ? module_file : path.join(projectDir, module_file);
+      markdown = fs.readFileSync(fullPath, 'utf-8');
+    } else {
+      return { content: [{ type: 'text', text: 'module_file または module_content を指定してください。' }], isError: true };
+    }
+
+    let modules = parseModuleMarkdown(markdown, module_file);
+    if (module_name) {
+      modules = modules.filter(m => m.name === module_name);
+    }
+
+    if (modules.length === 0) {
+      return { content: [{ type: 'text', text: 'インポートするモジュールが見つかりませんでした。' }], isError: true };
+    }
+
+    const imported: string[] = [];
+    for (const mod of modules) {
+      const result = pm.createComponent(project, {
+        name: mod.name,
+        category: mod.category,
+        domain: mod.domain,
+        variables: mod.variables.map((v: { name: string; type: string }) => ({ name: v.name, type: v.type, defaultValue: undefined })),
+        tasks: mod.tasks,
+        dependencies: mod.dependencies,
+      });
+      result.component.sourceModuleId = mod.id;
+      project = result.project;
+      imported.push(`${mod.name} (ID: ${result.component.id})`);
+    }
+
+    pm.saveProject(projectPath, project);
+    return {
+      content: [{
+        type: 'text',
+        text: `${imported.length}個のモジュールをコンポーネントとしてインポートしました:\n${imported.map(n => `- ${n}`).join('\n')}`,
+      }],
+    };
+  },
+);
+
+// --- ユーティリティ ---
+
+server.tool(
+  'generate_module_markdown',
+  'コンポーネント定義からArs形式のMarkdownモジュール定義書を生成する',
+  {
+    name: z.string().describe('モジュール名'),
+    summary: z.string().describe('概要'),
+    category: z.enum(['UI', 'Logic', 'System', 'GameObject']).describe('カテゴリ'),
+    domain: z.string().describe('所属ドメイン'),
+    required_data: z.array(z.string()).optional().describe('必要なデータ'),
+    variables: z.array(z.object({
+      name: z.string(),
+      type: z.string(),
+      description: z.string().optional(),
+    })).optional().describe('変数定義'),
+    dependencies: z.array(z.string()).optional().describe('依存先'),
+    inputs: z.array(z.string()).optional().describe('入力ポート'),
+    outputs: z.array(z.string()).optional().describe('出力ポート'),
+    tasks: z.array(z.object({
+      name: z.string(),
+      description: z.string(),
+    })).optional().describe('タスク定義'),
+    tests: z.array(z.string()).optional().describe('テストケース'),
+  },
+  async (params) => {
+    const lines: string[] = [
+      `### ${params.name} モジュール定義`,
+      '',
+      '#### 概要',
+      params.summary,
+      '',
+      '#### カテゴリ',
+      params.category,
+      '',
+      '#### 所属ドメイン',
+      params.domain,
+    ];
+
+    if (params.required_data?.length) {
+      lines.push('', '#### 必要なデータ');
+      for (const d of params.required_data) lines.push(`- ${d}`);
+    }
+
+    if (params.variables?.length) {
+      lines.push('', '#### 変数');
+      for (const v of params.variables) {
+        const desc = v.description ? `: ${v.description}` : '';
+        lines.push(`- ${v.name} (${v.type})${desc}`);
+      }
+    }
+
+    if (params.dependencies?.length) {
+      lines.push('', '#### 依存');
+      for (const d of params.dependencies) lines.push(`- ${d}`);
+    }
+
+    lines.push('', '#### 作業');
+
+    if (params.inputs?.length) {
+      lines.push('##### 入力');
+      for (const i of params.inputs) lines.push(`- ${i}`);
+    }
+
+    if (params.outputs?.length) {
+      lines.push('##### 出力');
+      for (const o of params.outputs) lines.push(`- ${o}`);
+    }
+
+    if (params.tasks?.length) {
+      lines.push('##### タスク');
+      for (const t of params.tasks) lines.push(`- ${t.name}: ${t.description}`);
+    }
+
+    if (params.tests?.length) {
+      lines.push('', '#### テスト');
+      for (const t of params.tests) lines.push(`- ${t}`);
+    }
+
+    const markdown = lines.join('\n');
+    return { content: [{ type: 'text', text: markdown }] };
+  },
+);
+
+// === Prompts ===
+
+server.prompt(
+  'new-module-definition',
+  'Arsモジュール定義書を新しく作成するためのプロンプト',
+  {
+    module_name: z.string().describe('モジュール名'),
+    purpose: z.string().describe('モジュールの目的'),
+  },
+  ({ module_name, purpose }) => ({
+    messages: [{
+      role: 'user',
+      content: {
+        type: 'text',
+        text: `以下の要件でArsモジュール定義書を作成してください。
+
+モジュール名: ${module_name}
+目的: ${purpose}
+
+Arsのモジュール定義書フォーマットに従って、以下のセクションを含めてください:
+- 概要
+- カテゴリ（UI / Logic / System / GameObject のいずれか）
+- 所属ドメイン
+- 必要なデータ
+- 変数（名前と型を含む）
+- 依存先
+- 作業（入力、出力、タスク）
+- テスト（各タスクのテストケース）
+
+generate_module_markdown ツールを使って定義書を生成してください。`,
+      },
+    }],
+  }),
+);
+
+server.prompt(
+  'design-scene',
+  'Arsシーンの設計を支援するプロンプト',
+  {
+    scene_name: z.string().describe('シーン名'),
+    description: z.string().describe('シーンの説明'),
+  },
+  ({ scene_name, description }) => ({
+    messages: [{
+      role: 'user',
+      content: {
+        type: 'text',
+        text: `以下のシーンを設計してください。
+
+シーン名: ${scene_name}
+説明: ${description}
+
+Arsのアクターモデルに基づき、以下を提案してください:
+1. 必要なアクター（名前、ロール）
+2. 各アクターに必要なコンポーネント（カテゴリ、タスク）
+3. アクター間の接続（ポート接続）
+4. 子アクターの内包関係
+
+提案後、create_scene, add_actor, create_component, attach_component ツールで実装してください。`,
+      },
+    }],
+  }),
+);
+
+// === サーバー起動 ===
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error('MCP server error:', error);
+  process.exit(1);
+});

--- a/mcp-server/src/module-parser.ts
+++ b/mcp-server/src/module-parser.ts
@@ -1,0 +1,156 @@
+import type { ModuleDefinition, ComponentCategory, PortDefinition } from './types.js';
+
+/**
+ * Arsモジュール定義のMarkdownをパースする
+ * plan.md セクション8 / Rust側 module_parser.rs と同等のロジック
+ */
+export function parseModuleMarkdown(content: string, sourcePath?: string): ModuleDefinition[] {
+  const modules: ModuleDefinition[] = [];
+  const sections = splitByModuleHeaders(content);
+
+  for (const [name, sectionContent] of sections) {
+    const module = parseSingleModule(name, sectionContent, sourcePath);
+    if (module) modules.push(module);
+  }
+
+  return modules;
+}
+
+function splitByModuleHeaders(content: string): [string, string][] {
+  const result: [string, string][] = [];
+  const headerRegex = /^###\s+(.+?)(?:\s+モジュール定義)?$/gm;
+  const matches: { name: string; index: number; end: number }[] = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = headerRegex.exec(content)) !== null) {
+    matches.push({
+      name: match[1].trim(),
+      index: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].end;
+    const end = i + 1 < matches.length ? matches[i + 1].index : content.length;
+    result.push([matches[i].name, content.slice(start, end)]);
+  }
+
+  return result;
+}
+
+function parseSingleModule(name: string, content: string, sourcePath?: string): ModuleDefinition | null {
+  const summary = extractSection(content, '概要') ?? '';
+  const categoryStr = extractSection(content, 'カテゴリ') ?? '';
+  const category = parseCategory(categoryStr);
+  if (!category) return null;
+
+  const domain = extractSection(content, '所属ドメイン') ?? '';
+  const requiredData = extractListItems(content, '必要なデータ');
+  const variables = parseVariables(content);
+  const dependencies = extractListItems(content, '依存');
+  const tasks = parseTasks(content);
+  const tests = extractListItems(content, 'テスト').map(desc => ({ description: desc }));
+
+  return {
+    id: crypto.randomUUID(),
+    name,
+    summary,
+    category,
+    domain,
+    required_data: requiredData,
+    variables,
+    dependencies,
+    tasks,
+    tests,
+    source_path: sourcePath,
+  };
+}
+
+function parseCategory(s: string): ComponentCategory | null {
+  const trimmed = s.trim();
+  if (['UI', 'Logic', 'System', 'GameObject'].includes(trimmed)) {
+    return trimmed as ComponentCategory;
+  }
+  return null;
+}
+
+function extractSection(content: string, header: string): string | null {
+  const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`^####\\s+${escaped}\\s*\\n([\\s\\S]*?)(?=\\n####|\\n###|$)`, 'm');
+  const match = regex.exec(content);
+  if (!match) return null;
+  const text = match[1].trim();
+  return text || null;
+}
+
+function extractListItems(content: string, header: string): string[] {
+  const section = extractSection(content, header);
+  if (!section) return [];
+
+  return section
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('- ') || line.startsWith('* '))
+    .map(line => line.slice(2).trim());
+}
+
+function parseVariables(content: string): ModuleDefinition['variables'] {
+  const items = extractListItems(content, '変数');
+  return items.map(item => {
+    const parts = item.split(':');
+    if (parts.length >= 2) {
+      const namePart = parts[0].trim();
+      const desc = parts.slice(1).join(':').trim();
+      const typeMatch = namePart.match(/^(.+?)\s*\((.+?)\)$/);
+      if (typeMatch) {
+        return { name: typeMatch[1].trim(), type: typeMatch[2].trim(), description: desc };
+      }
+      return { name: namePart, type: 'unknown', description: desc };
+    }
+    return { name: item, type: 'unknown' };
+  });
+}
+
+function parseTasks(content: string): ModuleDefinition['tasks'] {
+  const taskRegex = /^#####\s+タスク\s*\n([\s\S]*?)(?=\n####|\n###|\n#####|$)/m;
+  const taskMatch = taskRegex.exec(content);
+  if (!taskMatch) return [];
+
+  const inputs = parsePortSection(content, '入力');
+  const outputs = parsePortSection(content, '出力');
+
+  return taskMatch[1]
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('- ') || line.startsWith('* '))
+    .map(line => {
+      const text = line.slice(2).trim();
+      const colonIdx = text.indexOf(':');
+      if (colonIdx >= 0) {
+        return {
+          name: text.slice(0, colonIdx).trim(),
+          description: text.slice(colonIdx + 1).trim(),
+          inputs,
+          outputs,
+        };
+      }
+      return { name: text, description: '', inputs, outputs };
+    });
+}
+
+function parsePortSection(content: string, header: string): PortDefinition[] {
+  const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`^#####\\s+${escaped}\\s*\\n([\\s\\S]*?)(?=\\n#####|\\n####|\\n###|$)`, 'm');
+  const match = regex.exec(content);
+  if (!match) return [];
+
+  return match[1]
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.startsWith('- ') || line.startsWith('* '))
+    .map(line => ({
+      name: line.slice(2).trim(),
+      type: 'any',
+    }));
+}

--- a/mcp-server/src/project-manager.ts
+++ b/mcp-server/src/project-manager.ts
@@ -1,0 +1,242 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Project, Scene, Actor, Component, Connection } from './types.js';
+
+/**
+ * Arsプロジェクトファイルの読み書きを管理するクラス
+ */
+export class ProjectManager {
+  private projectDir: string;
+
+  constructor(projectDir: string) {
+    this.projectDir = projectDir;
+  }
+
+  /** プロジェクトディレクトリのパスを取得 */
+  getProjectDir(): string {
+    return this.projectDir;
+  }
+
+  /** プロジェクトファイル(.ars.json)を検索 */
+  findProjectFiles(): string[] {
+    const files: string[] = [];
+    this.scanDir(this.projectDir, files, 3);
+    return files;
+  }
+
+  private scanDir(dir: string, results: string[], maxDepth: number): void {
+    if (maxDepth <= 0) return;
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'target') continue;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          this.scanDir(fullPath, results, maxDepth - 1);
+        } else if (entry.name.endsWith('.ars.json')) {
+          results.push(fullPath);
+        }
+      }
+    } catch {
+      // ディレクトリ読み取りエラーは無視
+    }
+  }
+
+  /** プロジェクトを読み込み */
+  loadProject(filePath: string): Project {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(content) as Project;
+  }
+
+  /** プロジェクトを保存 */
+  saveProject(filePath: string, project: Project): void {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(filePath, JSON.stringify(project, null, 2), 'utf-8');
+  }
+
+  /** 新規プロジェクトを作成 */
+  createProject(name: string): Project {
+    return {
+      name,
+      scenes: {},
+      components: {},
+      activeSceneId: null,
+    };
+  }
+
+  /** シーンを作成 */
+  createScene(project: Project, name: string): { project: Project; scene: Scene } {
+    const sceneId = crypto.randomUUID();
+    const rootActorId = crypto.randomUUID();
+
+    const rootActor: Actor = {
+      id: rootActorId,
+      name,
+      role: 'scene',
+      components: [],
+      children: [],
+      position: { x: 0, y: 0 },
+    };
+
+    const scene: Scene = {
+      id: sceneId,
+      name,
+      rootActorId,
+      actors: { [rootActorId]: rootActor },
+      connections: [],
+    };
+
+    project.scenes[sceneId] = scene;
+    if (!project.activeSceneId) {
+      project.activeSceneId = sceneId;
+    }
+
+    return { project, scene };
+  }
+
+  /** アクターを追加 */
+  addActor(
+    project: Project,
+    sceneId: string,
+    name: string,
+    role: 'actor' | 'sequence',
+    position: { x: number; y: number } = { x: 200, y: 200 },
+  ): { project: Project; actor: Actor } {
+    const scene = project.scenes[sceneId];
+    if (!scene) throw new Error(`Scene not found: ${sceneId}`);
+
+    const actor: Actor = {
+      id: crypto.randomUUID(),
+      name,
+      role,
+      components: [],
+      children: [],
+      position,
+    };
+
+    scene.actors[actor.id] = actor;
+    return { project, actor };
+  }
+
+  /** コンポーネントを作成 */
+  createComponent(
+    project: Project,
+    params: {
+      name: string;
+      category: Component['category'];
+      domain: string;
+      variables?: Component['variables'];
+      tasks?: Component['tasks'];
+      dependencies?: string[];
+    },
+  ): { project: Project; component: Component } {
+    const component: Component = {
+      id: crypto.randomUUID(),
+      name: params.name,
+      category: params.category,
+      domain: params.domain,
+      variables: params.variables ?? [],
+      tasks: params.tasks ?? [],
+      dependencies: params.dependencies ?? [],
+    };
+
+    project.components[component.id] = component;
+    return { project, component };
+  }
+
+  /** アクターにコンポーネントをアタッチ */
+  attachComponent(
+    project: Project,
+    sceneId: string,
+    actorId: string,
+    componentId: string,
+  ): Project {
+    const scene = project.scenes[sceneId];
+    if (!scene) throw new Error(`Scene not found: ${sceneId}`);
+    const actor = scene.actors[actorId];
+    if (!actor) throw new Error(`Actor not found: ${actorId}`);
+    if (!project.components[componentId]) throw new Error(`Component not found: ${componentId}`);
+
+    if (!actor.components.includes(componentId)) {
+      actor.components.push(componentId);
+    }
+    return project;
+  }
+
+  /** 接続を追加 */
+  addConnection(
+    project: Project,
+    sceneId: string,
+    params: {
+      sourceActorId: string;
+      sourcePort: string;
+      targetActorId: string;
+      targetPort: string;
+    },
+  ): { project: Project; connection: Connection } {
+    const scene = project.scenes[sceneId];
+    if (!scene) throw new Error(`Scene not found: ${sceneId}`);
+
+    const connection: Connection = {
+      id: crypto.randomUUID(),
+      ...params,
+    };
+
+    scene.connections.push(connection);
+    return { project, connection };
+  }
+
+  /** プロジェクトの概要を生成 */
+  summarizeProject(project: Project): string {
+    const sceneCount = Object.keys(project.scenes).length;
+    const componentCount = Object.keys(project.components).length;
+    let actorCount = 0;
+    let connectionCount = 0;
+
+    for (const scene of Object.values(project.scenes)) {
+      actorCount += Object.keys(scene.actors).length;
+      connectionCount += scene.connections.length;
+    }
+
+    const lines: string[] = [
+      `# プロジェクト: ${project.name}`,
+      ``,
+      `## 統計`,
+      `- シーン数: ${sceneCount}`,
+      `- コンポーネント数: ${componentCount}`,
+      `- アクター数（全シーン合計）: ${actorCount}`,
+      `- 接続数（全シーン合計）: ${connectionCount}`,
+    ];
+
+    if (sceneCount > 0) {
+      lines.push('', '## シーン一覧');
+      for (const scene of Object.values(project.scenes)) {
+        const actors = Object.values(scene.actors);
+        const isActive = project.activeSceneId === scene.id ? ' (アクティブ)' : '';
+        lines.push(`- **${scene.name}**${isActive}: アクター ${actors.length}個, 接続 ${scene.connections.length}個`);
+        for (const actor of actors) {
+          lines.push(`  - ${actor.name} [${actor.role}] コンポーネント: ${actor.components.length}個`);
+        }
+      }
+    }
+
+    if (componentCount > 0) {
+      lines.push('', '## コンポーネント一覧');
+      const byCategory: Record<string, Component[]> = {};
+      for (const comp of Object.values(project.components)) {
+        (byCategory[comp.category] ??= []).push(comp);
+      }
+      for (const [category, comps] of Object.entries(byCategory)) {
+        lines.push(`### ${category}`);
+        for (const comp of comps) {
+          lines.push(`- **${comp.name}** (${comp.domain}): タスク ${comp.tasks.length}個, 変数 ${comp.variables.length}個`);
+        }
+      }
+    }
+
+    return lines.join('\n');
+  }
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,0 +1,86 @@
+// === Ars ドメインモデル型定義 ===
+// src/types/domain.ts & src/types/module-registry.ts と対応
+
+export type ActorRole = 'actor' | 'scene' | 'sequence';
+export type ComponentCategory = 'UI' | 'Logic' | 'System' | 'GameObject';
+
+export interface Variable {
+  name: string;
+  type: string;
+  defaultValue?: unknown;
+}
+
+export interface PortDefinition {
+  name: string;
+  type: string;
+}
+
+export interface Task {
+  name: string;
+  description: string;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+}
+
+export interface Component {
+  id: string;
+  name: string;
+  category: ComponentCategory;
+  domain: string;
+  variables: Variable[];
+  tasks: Task[];
+  dependencies: string[];
+  sourceModuleId?: string;
+}
+
+export interface Actor {
+  id: string;
+  name: string;
+  role: ActorRole;
+  components: string[];
+  children: string[];
+  position: { x: number; y: number };
+}
+
+export interface Connection {
+  id: string;
+  sourceActorId: string;
+  sourcePort: string;
+  targetActorId: string;
+  targetPort: string;
+}
+
+export interface Scene {
+  id: string;
+  name: string;
+  rootActorId: string;
+  actors: Record<string, Actor>;
+  connections: Connection[];
+}
+
+export interface Project {
+  name: string;
+  scenes: Record<string, Scene>;
+  components: Record<string, Component>;
+  activeSceneId: string | null;
+}
+
+export interface ModuleDefinition {
+  id: string;
+  name: string;
+  summary: string;
+  category: ComponentCategory;
+  domain: string;
+  required_data: string[];
+  variables: Array<{ name: string; type: string; description?: string }>;
+  dependencies: string[];
+  tasks: Array<{
+    name: string;
+    description: string;
+    inputs: PortDefinition[];
+    outputs: PortDefinition[];
+  }>;
+  tests: Array<{ description: string }>;
+  source_path?: string;
+  source_repo?: string;
+}

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Implements a TypeScript MCP server that exposes 15 tools for managing
Ars projects through Claude Code, including project/scene/actor/component
CRUD, module definition parsing, and Markdown generation.

https://claude.ai/code/session_01Pr9nyvDaUHMPnwG98CAPtU