### PR TITLE
Add SLSA provenance attestation and SBOM to Docker builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -215,6 +215,9 @@ jobs:
     if: inputs.deploy == true
     environment: production
     timeout-minutes: 10
+    permissions:
+      id-token: write    # OIDC for AWS credentials
+      contents: none     # deploy ジョブはリポジトリ読み取り不要
 
     steps:
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,8 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  attestations: write   # SLSA provenance (public リポジトリ移行後に有効)
+  id-token: write       # OIDC for provenance signing
 
 env:
   REGISTRY: ghcr.io
@@ -101,7 +103,8 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        id: push
+        uses: docker/build-push-action@v6
         with:
           context: ./ars-editor
           push: true
@@ -109,6 +112,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ars-editor
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   # -------------------------------------------------------------------
   # resource-depot イメージのビルド & プッシュ
@@ -145,7 +157,8 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        id: push
+        uses: docker/build-push-action@v6
         with:
           context: ./resource-depot
           push: true
@@ -153,6 +166,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/resource-depot
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
   # -------------------------------------------------------------------
   # data-organizer イメージのビルド & プッシュ
@@ -189,7 +211,8 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        id: push
+        uses: docker/build-push-action@v6
         with:
           context: ./data-organizer
           push: true
@@ -197,3 +220,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/data-organizer
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary
This PR enhances the Docker image build workflows with SLSA provenance attestation and Software Bill of Materials (SBOM) generation for improved supply chain security. It also updates the build-and-deploy workflow to use OIDC for AWS credentials with proper permission scoping.

## Key Changes

### Docker Publish Workflow (`docker-publish.yml`)
- Added required permissions for SLSA provenance:
  - `attestations: write` - for publishing provenance attestations
  - `id-token: write` - for OIDC token generation during provenance signing
- Updated all three Docker build jobs (ars-editor, resource-depot, data-organizer):
  - Upgraded `docker/build-push-action` from v5 to v6
  - Added `id: push` to capture build output digest
  - Enabled `provenance: true` and `sbom: true` options
  - Added new `actions/attest-build-provenance@v2` step to sign and push provenance attestations to registry
- Provenance attestation is currently configured for future use when the repository becomes public

### Build and Deploy Workflow (`build-and-deploy.yml`)
- Added explicit permission scoping to the deploy job:
  - `id-token: write` - required for OIDC-based AWS credential exchange
  - `contents: none` - deploy job doesn't require repository read access

## Implementation Details
- The provenance attestation workflow follows GitHub's recommended pattern for SLSA compliance
- Build digests are captured from the push step output and used for attestation
- Attestations are pushed directly to the container registry for verifiable supply chain metadata
- Permission scoping follows the principle of least privilege for improved security posture

https://claude.ai/code/session_01HYLPc575WVNPCZMAzGhhq7