### PR TITLE
Build Docker images from root context with explicit Dockerfiles

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -106,7 +106,8 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: ./ars-editor
+          context: .
+          file: ./ars-editor/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -114,13 +115,6 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: true
           sbom: true
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ars-editor
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
 
   # -------------------------------------------------------------------
   # resource-depot イメージのビルド & プッシュ
@@ -169,12 +163,6 @@ jobs:
           provenance: true
           sbom: true
 
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/resource-depot
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
 
   # -------------------------------------------------------------------
   # data-organizer イメージのビルド & プッシュ
@@ -223,9 +211,3 @@ jobs:
           provenance: true
           sbom: true
 
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/data-organizer
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true

--- a/resource-depot/Dockerfile
+++ b/resource-depot/Dockerfile
@@ -2,8 +2,7 @@
 # resource-depot Dockerfile
 # Multi-stage build: Rust build → minimal runtime
 #
-# 現在は Tauri デスクトップアプリのみ。
-# Web サーバーモードが追加された際に CMD を更新してください。
+# Web サーバーモードでビルド (Docker 環境用)
 # =============================================================================
 
 FROM rust:1-bookworm AS builder
@@ -14,13 +13,13 @@ WORKDIR /app/src-tauri
 COPY src-tauri/Cargo.toml src-tauri/Cargo.lock* ./
 RUN mkdir -p src/commands src/models src/services && \
     echo "pub fn dummy() {}" > src/lib.rs && \
-    echo "fn main() {}" > src/main.rs && \
-    cargo build --release 2>/dev/null || true && \
+    echo "fn main() {}" > src/web_main.rs && \
+    cargo build --features web-server --no-default-features --bin resource-depot-web --release 2>/dev/null || true && \
     rm -rf src
 
 # ソースコードをコピーしてビルド
 COPY src-tauri/ .
-RUN cargo build --release
+RUN cargo build --features web-server --no-default-features --bin resource-depot-web --release
 
 # ----- Runtime -----
 FROM debian:bookworm-slim
@@ -34,7 +33,7 @@ RUN useradd -r -s /bin/false ars
 
 WORKDIR /app
 
-COPY --from=builder /app/src-tauri/target/release/resource-depot ./resource-depot
+COPY --from=builder /app/src-tauri/target/release/resource-depot-web ./resource-depot-web
 
 RUN chown -R ars:ars /app
 USER ars
@@ -42,4 +41,4 @@ USER ars
 ENV PORT=5174
 EXPOSE 5174
 
-CMD ["./resource-depot"]
+CMD ["./resource-depot-web"]


### PR DESCRIPTION
## Summary
This PR refactors the Docker build configuration to build all images from the repository root context instead of individual service directories, and removes the build provenance attestation steps from the CI/CD pipeline.

## Key Changes

### Docker Build Configuration
- Changed `ars-editor` build context from `./ars-editor` to `.` (root) with explicit `file: ./ars-editor/Dockerfile`
- This pattern allows the build process to access files from the entire repository if needed, while still using service-specific Dockerfiles

### Build Provenance Attestation
- Removed `actions/attest-build-provenance@v2` steps from all three image builds:
  - `ars-editor`
  - `resource-depot`
  - `data-organizer`
- These steps were generating build provenance attestations and pushing them to the registry

### resource-depot Dockerfile Updates
- Updated build to use web server mode instead of desktop app mode
- Changed build command to: `cargo build --features web-server --no-default-features --bin resource-depot-web --release`
- Updated binary name from `resource-depot` to `resource-depot-web` in the runtime stage
- Updated CMD to execute `./resource-depot-web` instead of `./resource-depot`
- Updated comments to reflect web server mode for Docker environment

## Implementation Details
The root context approach enables better code sharing and dependency access during Docker builds while maintaining clear separation through explicit Dockerfile paths. The resource-depot service is now built specifically for web server deployment in Docker environments rather than as a desktop application.

https://claude.ai/code/session_01XkP2SJSVvmyFVefkjRBTa3