### PR TITLE
Refactor history system to use Command/Memento pattern

### DIFF
--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -26,6 +26,8 @@ export function Toolbar() {
   const setMobileSceneMenu = useEditorStore((s) => s.setMobileSceneMenu);
   const mobileBottomSheetOpen = useEditorStore((s) => s.mobileBottomSheetOpen);
   const setMobileBottomSheet = useEditorStore((s) => s.setMobileBottomSheet);
+  const isGenerating = useEditorStore((s) => s.isGenerating);
+  const abortGeneration = useEditorStore((s) => s.abortGeneration);
   const activeGitRepo = useAuthStore((s) => s.activeGitRepo);
   const [status, setStatus] = useState<string>('');
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -154,7 +156,7 @@ export function Toolbar() {
 
         {/* Undo/Redo */}
         <button
-          onClick={() => { undo(); markDirty(); }}
+          onClick={() => { if (isGenerating) abortGeneration(); undo(); markDirty(); }}
           disabled={!canUndo()}
           className="px-2 py-1 text-zinc-300 hover:bg-zinc-700 rounded transition-colors disabled:opacity-30"
           title="Undo"

--- a/ars-editor/src/features/node-editor/hooks/useUndoRedo.ts
+++ b/ars-editor/src/features/node-editor/hooks/useUndoRedo.ts
@@ -1,32 +1,42 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { useProjectStore } from '@/stores/projectStore';
-import { pushHistory, undo, redo } from '@/stores/historyMiddleware';
+import { useEditorStore } from '@/stores/editorStore';
+import { pushHistory, undo, redo, canUndo, canRedo, isRestoring } from '@/stores/historyMiddleware';
 
 export function useUndoRedo() {
   const project = useProjectStore((s) => s.project);
+  const isGenerating = useEditorStore((s) => s.isGenerating);
+  const abortGeneration = useEditorStore((s) => s.abortGeneration);
   const prevProjectRef = useRef(project);
 
-  // Track project changes for history
+  // Track project changes and create snapshot commands automatically
   useEffect(() => {
     const prev = prevProjectRef.current;
-    if (prev !== project) {
-      // Only push to history if it's a real user change (not undo/redo load)
+    if (prev !== project && !isRestoring()) {
       const prevJson = JSON.stringify(prev);
       const currJson = JSON.stringify(project);
       if (prevJson !== currJson) {
         pushHistory(prev);
       }
-      prevProjectRef.current = project;
     }
+    prevProjectRef.current = project;
   }, [project]);
 
   const handleUndo = useCallback(() => {
-    undo();
-  }, []);
+    // If AI code generation is running, abort it before undoing
+    if (isGenerating) {
+      abortGeneration();
+    }
+    if (canUndo()) {
+      undo();
+    }
+  }, [isGenerating, abortGeneration]);
 
   const handleRedo = useCallback(() => {
-    redo();
+    if (canRedo()) {
+      redo();
+    }
   }, []);
 
-  return { handleUndo, handleRedo };
+  return { handleUndo, handleRedo, canUndo, canRedo };
 }

--- a/ars-editor/src/hooks/useKeyboardShortcuts.ts
+++ b/ars-editor/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { undo, redo } from '@/stores/historyMiddleware';
+import { useEditorStore } from '@/stores/editorStore';
 
 interface KeyboardShortcutOptions {
   onSave?: () => void;
@@ -20,6 +21,11 @@ export function useKeyboardShortcuts(options: KeyboardShortcutOptions = {}) {
 
       if (isCtrl && e.key === 'z' && !e.shiftKey) {
         e.preventDefault();
+        // Abort AI code generation if running before undo
+        const { isGenerating, abortGeneration } = useEditorStore.getState();
+        if (isGenerating) {
+          abortGeneration();
+        }
         undo();
       } else if (isCtrl && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
         e.preventDefault();

--- a/ars-editor/src/stores/editorStore.ts
+++ b/ars-editor/src/stores/editorStore.ts
@@ -23,6 +23,10 @@ interface EditorState {
   mobileSceneMenuOpen: boolean;
   mobileBottomSheetOpen: boolean;
 
+  /** AI code generation state */
+  isGenerating: boolean;
+  generationAbortController: AbortController | null;
+
   setSelectedNodes: (ids: string[]) => void;
   openContextMenu: (pos: { x: number; y: number }) => void;
   closeContextMenu: () => void;
@@ -42,6 +46,13 @@ interface EditorState {
   setProjectPath: (path: string | null) => void;
   setMobileSceneMenu: (open: boolean) => void;
   setMobileBottomSheet: (open: boolean) => void;
+
+  /** Start AI code generation, returns an AbortController to cancel it */
+  startGeneration: () => AbortController;
+  /** Mark AI code generation as finished */
+  finishGeneration: () => void;
+  /** Abort running AI code generation */
+  abortGeneration: () => void;
 }
 
 export const useEditorStore = create<EditorState>()((set) => ({
@@ -65,6 +76,8 @@ export const useEditorStore = create<EditorState>()((set) => ({
   projectPath: null,
   mobileSceneMenuOpen: false,
   mobileBottomSheetOpen: false,
+  isGenerating: false,
+  generationAbortController: null,
 
   setSelectedNodes: (ids) => set({ selectedNodeIds: ids }),
   openContextMenu: (pos) => set({ contextMenu: pos }),
@@ -105,4 +118,19 @@ export const useEditorStore = create<EditorState>()((set) => ({
   setProjectPath: (path) => set({ projectPath: path }),
   setMobileSceneMenu: (open) => set({ mobileSceneMenuOpen: open }),
   setMobileBottomSheet: (open) => set({ mobileBottomSheetOpen: open }),
+
+  startGeneration: () => {
+    const controller = new AbortController();
+    set({ isGenerating: true, generationAbortController: controller });
+    return controller;
+  },
+  finishGeneration: () =>
+    set({ isGenerating: false, generationAbortController: null }),
+  abortGeneration: () => {
+    const { generationAbortController } = useEditorStore.getState();
+    if (generationAbortController) {
+      generationAbortController.abort();
+    }
+    set({ isGenerating: false, generationAbortController: null });
+  },
 }));

--- a/ars-editor/src/stores/historyMiddleware.ts
+++ b/ars-editor/src/stores/historyMiddleware.ts
@@ -1,37 +1,115 @@
 import { useProjectStore } from './projectStore';
 import type { Project } from '@/types/domain';
+import { SnapshotCommand, type Command } from './memento';
 
 const MAX_HISTORY = 50;
 
-const past: Project[] = [];
-const future: Project[] = [];
+/**
+ * CommandHistory (Caretaker): Manages the undo/redo stacks of Command objects.
+ * Each command encapsulates mementos (before/after snapshots) for state restoration.
+ */
+class CommandHistory {
+  private undoStack: Command[] = [];
+  private redoStack: Command[] = [];
+  private isRestoring = false;
 
-export function pushHistory(snapshot: Project) {
-  past.push(JSON.parse(JSON.stringify(snapshot)));
-  if (past.length > MAX_HISTORY) past.shift();
-  future.length = 0;
+  /** True while undo/redo is restoring state — prevents re-entry */
+  get restoring(): boolean {
+    return this.isRestoring;
+  }
+
+  /** Push a pre-built command onto the undo stack */
+  push(command: Command): void {
+    this.undoStack.push(command);
+    if (this.undoStack.length > MAX_HISTORY) this.undoStack.shift();
+    this.redoStack.length = 0;
+  }
+
+  /** Undo the most recent command */
+  undo(): void {
+    if (this.undoStack.length === 0) return;
+    const command = this.undoStack.pop()!;
+    this.isRestoring = true;
+    try {
+      command.undo();
+      this.redoStack.unshift(command);
+    } finally {
+      this.isRestoring = false;
+    }
+  }
+
+  /** Redo the most recently undone command */
+  redo(): void {
+    if (this.redoStack.length === 0) return;
+    const command = this.redoStack.shift()!;
+    this.isRestoring = true;
+    try {
+      command.redo();
+      this.undoStack.push(command);
+    } finally {
+      this.isRestoring = false;
+    }
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  clear(): void {
+    this.undoStack.length = 0;
+    this.redoStack.length = 0;
+  }
 }
 
-export function undo() {
-  if (past.length === 0) return;
-  const current = useProjectStore.getState().project;
-  future.unshift(JSON.parse(JSON.stringify(current)));
-  const prev = past.pop()!;
-  useProjectStore.getState().loadProject(prev);
+/** Singleton caretaker instance */
+const history = new CommandHistory();
+
+/**
+ * Push a snapshot-based command for an already-applied state change.
+ * @param snapshot The project state BEFORE the change was applied
+ */
+export function pushHistory(snapshot: Project): void {
+  if (history.restoring) return;
+  const restoreProject = (project: Project) =>
+    useProjectStore.getState().loadProject(project);
+  const command = new SnapshotCommand('edit', snapshot, restoreProject);
+  command.setAfter(useProjectStore.getState().project);
+  history.push(command);
 }
 
-export function redo() {
-  if (future.length === 0) return;
-  const current = useProjectStore.getState().project;
-  past.push(JSON.parse(JSON.stringify(current)));
-  const next = future.shift()!;
-  useProjectStore.getState().loadProject(next);
+/**
+ * Execute a command and record it in the history.
+ * The command captures before/after mementos automatically.
+ */
+export function executeCommand(command: Command): void {
+  command.execute();
+  history.push(command);
 }
 
-export function canUndo() {
-  return past.length > 0;
+export function undo(): void {
+  history.undo();
 }
 
-export function canRedo() {
-  return future.length > 0;
+export function redo(): void {
+  history.redo();
+}
+
+export function canUndo(): boolean {
+  return history.canUndo();
+}
+
+export function canRedo(): boolean {
+  return history.canRedo();
+}
+
+export function clearHistory(): void {
+  history.clear();
+}
+
+export function isRestoring(): boolean {
+  return history.restoring;
 }

--- a/ars-editor/src/stores/memento.ts
+++ b/ars-editor/src/stores/memento.ts
@@ -1,0 +1,112 @@
+import type { Project } from '@/types/domain';
+
+/**
+ * Memento: Immutable snapshot of project state.
+ * Stores a deep-cloned copy of the project at a given point in time.
+ */
+export class ProjectMemento {
+  private readonly state: string;
+  readonly label: string;
+  readonly timestamp: number;
+
+  constructor(project: Project, label: string) {
+    this.state = JSON.stringify(project);
+    this.label = label;
+    this.timestamp = Date.now();
+  }
+
+  getState(): Project {
+    return JSON.parse(this.state);
+  }
+}
+
+/**
+ * Command: Represents an executable & undoable operation.
+ * Each command captures a before-memento on execute and an after-memento for redo.
+ */
+export interface Command {
+  readonly label: string;
+  execute(): void;
+  undo(): void;
+  redo(): void;
+}
+
+/**
+ * MementoCommand: A generic command that captures project snapshots (mementos)
+ * before and after execution for undo/redo support.
+ */
+export class MementoCommand implements Command {
+  readonly label: string;
+  private beforeMemento: ProjectMemento | null = null;
+  private afterMemento: ProjectMemento | null = null;
+  private readonly getProject: () => Project;
+  private readonly restoreProject: (project: Project) => void;
+  private readonly action: () => void;
+
+  constructor(
+    label: string,
+    getProject: () => Project,
+    restoreProject: (project: Project) => void,
+    action: () => void,
+  ) {
+    this.label = label;
+    this.getProject = getProject;
+    this.restoreProject = restoreProject;
+    this.action = action;
+  }
+
+  execute(): void {
+    this.beforeMemento = new ProjectMemento(this.getProject(), this.label);
+    this.action();
+    this.afterMemento = new ProjectMemento(this.getProject(), this.label);
+  }
+
+  undo(): void {
+    if (!this.beforeMemento) return;
+    this.restoreProject(this.beforeMemento.getState());
+  }
+
+  redo(): void {
+    if (!this.afterMemento) return;
+    this.restoreProject(this.afterMemento.getState());
+  }
+}
+
+/**
+ * SnapshotCommand: A simplified command created from already-captured
+ * before/after snapshots. Used by the automatic history tracking.
+ */
+export class SnapshotCommand implements Command {
+  readonly label: string;
+  private readonly beforeMemento: ProjectMemento;
+  private afterMemento: ProjectMemento | null = null;
+  private readonly restoreProject: (project: Project) => void;
+
+  constructor(
+    label: string,
+    before: Project,
+    restoreProject: (project: Project) => void,
+  ) {
+    this.label = label;
+    this.beforeMemento = new ProjectMemento(before, label);
+    this.restoreProject = restoreProject;
+  }
+
+  setAfter(after: Project): void {
+    this.afterMemento = new ProjectMemento(after, this.label);
+  }
+
+  execute(): void {
+    // Already executed — snapshot was taken after the fact
+  }
+
+  undo(): void {
+    this.restoreProject(this.beforeMemento.getState());
+  }
+
+  redo(): void {
+    if (this.afterMemento) {
+      this.restoreProject(this.afterMemento.getState());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Refactored the undo/redo history system from a simple snapshot-based approach to implement the Command and Memento design patterns. This provides better encapsulation, supports both automatic and explicit command execution, and adds AI generation state management with abort capabilities.

## Key Changes

- **New Memento Pattern Implementation** (`memento.ts`):
  - `ProjectMemento`: Immutable snapshots of project state with timestamps and labels
  - `Command` interface: Defines executable/undoable operations
  - `MementoCommand`: Generic command that captures before/after snapshots automatically
  - `SnapshotCommand`: Simplified command for already-applied state changes

- **Refactored History Middleware** (`historyMiddleware.ts`):
  - Replaced simple `past`/`future` arrays with `CommandHistory` class (Caretaker pattern)
  - Added `isRestoring` flag to prevent re-entry during undo/redo operations
  - New `executeCommand()` function for explicit command execution
  - Added `clearHistory()` and `isRestoring()` utility functions
  - Improved `pushHistory()` to create `SnapshotCommand` objects with before/after mementos

- **Enhanced Editor Store** (`editorStore.ts`):
  - Added AI code generation state tracking: `isGenerating` and `generationAbortController`
  - New methods: `startGeneration()`, `finishGeneration()`, `abortGeneration()`
  - Enables cancellation of long-running AI operations

- **Updated Undo/Redo Hook** (`useUndoRedo.ts`):
  - Integrated `isRestoring()` check to prevent duplicate history entries
  - Added generation abort logic before undo/redo operations
  - Exported `canUndo` and `canRedo` for UI state management
  - Improved callback dependencies

- **Keyboard Shortcuts** (`useKeyboardShortcuts.ts`):
  - Added AI generation abort before undo operation via Ctrl+Z

- **Toolbar Component** (`Toolbar.tsx`):
  - Integrated generation state and abort functionality for UI controls

## Implementation Details

- The `CommandHistory` class uses a `restoring` flag to prevent re-entry, ensuring that undo/redo operations don't trigger new history entries
- `SnapshotCommand` captures the before-state when `pushHistory()` is called and the after-state from the current project store state
- AI generation can be aborted before undo/redo operations to maintain consistency
- The pattern supports both automatic history tracking (via `pushHistory`) and explicit command execution (via `executeCommand`)

https://claude.ai/code/session_01CrnHSreNe7cmdymjwHFntQ