### PR TITLE
Add multi-platform backend support (Unity, Unreal, Godot)

### DIFF
--- a/ars-codegen/src/prompt-generator.ts
+++ b/ars-codegen/src/prompt-generator.ts
@@ -1,4 +1,4 @@
-import type { Project, Scene, Actor, Component, Connection, CodegenTask } from './types.js';
+import type { Project, Scene, Actor, Component, Connection, CodegenTask, BackendPlatform } from './types.js';
 
 /** Ergoモジュール定義カテゴリのマッピング */
 const CATEGORY_MAP: Record<string, string> = {
@@ -14,15 +14,56 @@ function isPictorDomain(domain: string): boolean {
   return pictorDomains.some(d => domain.toLowerCase().includes(d));
 }
 
+/** プラットフォームごとの言語・ファイル拡張子・規約定義 */
+const PLATFORM_INFO: Record<BackendPlatform, {
+  language: string;
+  fileExtension: string;
+  stubExtension: string;
+  testExtension: string;
+  modulePattern: string;
+}> = {
+  'ars-native': {
+    language: 'TypeScript',
+    fileExtension: '.ts',
+    stubExtension: '.stub.ts',
+    testExtension: '.test.ts',
+    modulePattern: 'Ergoモジュール (TypeScript)',
+  },
+  'unity': {
+    language: 'C#',
+    fileExtension: '.cs',
+    stubExtension: '.Stub.cs',
+    testExtension: '.Tests.cs',
+    modulePattern: 'Ergoモジュール (Unity C# MonoBehaviour)',
+  },
+  'unreal': {
+    language: 'C++',
+    fileExtension: '.cpp',
+    stubExtension: '.Stub.cpp',
+    testExtension: '.Test.cpp',
+    modulePattern: 'Ergoモジュール (Unreal C++ UObject)',
+  },
+  'godot': {
+    language: 'GDScript',
+    fileExtension: '.gd',
+    stubExtension: '_stub.gd',
+    testExtension: '_test.gd',
+    modulePattern: 'Ergoモジュール (Godot GDScript Node)',
+  },
+};
+
 /**
  * Arsプロジェクトのシーン/コンポーネント設計データから
  * Ergoモジュール定義フォーマット + Pictor連携を含むコード生成プロンプトを組み立てる
+ * バックエンドプラットフォームに応じて生成言語・規約を切り替える
  */
 export class PromptGenerator {
   private project: Project;
+  private platform: BackendPlatform;
 
-  constructor(project: Project) {
+  constructor(project: Project, platform: BackendPlatform = 'ars-native') {
     this.project = project;
+    this.platform = platform;
   }
 
   /** プロジェクト全体からコード生成タスク一覧を生成 */
@@ -171,55 +212,171 @@ export class PromptGenerator {
       '',
       '## Pictor連携 (レンダリングパイプライン)',
       '',
-      'このモジュールはPictorレンダリングパイプラインと連携する。以下の規約に従うこと。',
-      '',
-      '### ObjectDescriptor登録',
-      '描画対象はObjectDescriptorを介してPictorのSceneRegistryに登録する:',
-      '- transform: Transform行列 (64B, キャッシュライン整列)',
-      '- bounds: AABB (min/max)',
-      '- flags: 16bitフラグ (Static/Dynamic/GPU_Driven/Cast_Shadow/Receive_Shadow/Transparent/Two_Sided/Instanced)',
-      '- shaderKey: シェーダー識別子',
-      '- materialKey: マテリアル識別子',
-      '- lodLevel: LODレベル',
-      '',
-      '### データレイアウト (SoA)',
-      'Pictorはデータ指向設計(DOD)のStructure-of-Arraysを採用する:',
-      '- Group A (Hot - Culling): bounds, visibility flags',
-      '- Group B (Hot - Sorting): shader keys, sort keys, material keys',
-      '- Group C (Hot - Transform): world transforms, previous frames',
-      '- Group D (Cold - Metadata): mesh handles, LOD levels, flags',
-      '',
-      '### マテリアル',
-      'BaseMaterialBuilderのfluent APIでPBRマテリアルを構築し、パス別バリアントを自動生成:',
-      '- Shadow/Depth: alpha test + two-sided のみ',
-      '- GI: albedo, emissive, alpha test, two-sided, vertex color',
-      '- Opaque/Transparent: 全機能',
-      '',
-      '### プール分類',
-      'ObjectClassifierがオブジェクトをプールに振り分ける:',
-      '- Static: 静的ジオメトリ (BVH最適化)',
-      '- Dynamic: 毎フレーム更新 (CPU並列 or Compute Shader)',
-      '- GPU-Driven: GPU駆動パイプライン (Compute更新・カリング・LOD選択・描画コンパクション)',
     ];
+
+    // プラットフォームごとのPictor連携指示
+    switch (this.platform) {
+      case 'unity':
+        lines.push(
+          'このモジュールはUnityのレンダリングパイプライン (URP/HDRP) と連携する。以下の規約に従うこと。',
+          '',
+          '### 描画オブジェクト登録',
+          '描画対象はMeshRenderer + MeshFilterでシーンに登録する:',
+          '- transform: UnityのTransformコンポーネント',
+          '- bounds: Renderer.boundsで自動計算',
+          '- flags: StaticBatchingUtility / ShadowCastingMode / MotionVectorGenerationMode等で設定',
+          '- shader: Shader Graphベースシェーダー',
+          '- material: Material / MaterialPropertyBlock',
+          '- LOD: LODGroupコンポーネント',
+          '',
+          '### バッチング・描画最適化',
+          'UnityのSRP Batcher / GPU Instancing / Static Batching を活用する:',
+          '- 静的オブジェクト: Static Batching',
+          '- 動的オブジェクト: GPU Instancing / SRP Batcher',
+          '- 大量オブジェクト: DrawMeshInstanced / DrawMeshInstancedIndirect',
+          '',
+          '### マテリアル',
+          'Shader Graphで定義し、MaterialPropertyBlockでインスタンス個別パラメータを制御する。',
+        );
+        break;
+      case 'unreal':
+        lines.push(
+          'このモジュールはUnreal EngineのNanite/Lumenレンダリングパイプラインと連携する。以下の規約に従うこと。',
+          '',
+          '### 描画オブジェクト登録',
+          '描画対象はUStaticMeshComponent / USkeletalMeshComponentでワールドに登録する:',
+          '- transform: FTransform (Relative / World)',
+          '- bounds: CalcBounds()で自動計算',
+          '- flags: bCastShadow, bAffectDynamicIndirectLighting, bNeverDistanceCull等',
+          '- material: UMaterialInterface / UMaterialInstanceDynamic',
+          '- LOD: FStaticMeshLODResources / LODScreenSize',
+          '',
+          '### 描画最適化',
+          '- Nanite: 自動LODメッシュ (Static Meshに設定)',
+          '- ISM/HISM: UInstancedStaticMeshComponent / UHierarchicalInstancedStaticMeshComponent',
+          '- Lumen: ソフトウェアレイトレーシングGI',
+          '',
+          '### マテリアル',
+          'UMaterialでマテリアルを定義し、UMaterialInstanceDynamicでランタイムパラメータを制御する。',
+        );
+        break;
+      case 'godot':
+        lines.push(
+          'このモジュールはGodotのVulkanレンダリングパイプラインと連携する。以下の規約に従うこと。',
+          '',
+          '### 描画オブジェクト登録',
+          '描画対象はMeshInstance3D / MultiMeshInstance3Dでシーンツリーに登録する:',
+          '- transform: Node3DのTransform3D',
+          '- bounds: AABB (自動計算)',
+          '- flags: cast_shadow, gi_mode, visibility_range等',
+          '- material: ShaderMaterial / StandardMaterial3D',
+          '- LOD: visibility_range_begin / visibility_range_end',
+          '',
+          '### 描画最適化',
+          '- MultiMesh: 大量同一オブジェクト描画',
+          '- OccluderInstance3D: オクルージョンカリング',
+          '- VisibilityNotifier3D: 可視性ベース処理',
+          '',
+          '### マテリアル',
+          '.gdshaderファイルでシェーダーを定義し、ShaderMaterialでパラメータを制御する。',
+        );
+        break;
+      case 'ars-native':
+      default:
+        lines.push(
+          'このモジュールはPictorレンダリングパイプラインと連携する。以下の規約に従うこと。',
+          '',
+          '### ObjectDescriptor登録',
+          '描画対象はObjectDescriptorを介してPictorのSceneRegistryに登録する:',
+          '- transform: Transform行列 (64B, キャッシュライン整列)',
+          '- bounds: AABB (min/max)',
+          '- flags: 16bitフラグ (Static/Dynamic/GPU_Driven/Cast_Shadow/Receive_Shadow/Transparent/Two_Sided/Instanced)',
+          '- shaderKey: シェーダー識別子',
+          '- materialKey: マテリアル識別子',
+          '- lodLevel: LODレベル',
+          '',
+          '### データレイアウト (SoA)',
+          'Pictorはデータ指向設計(DOD)のStructure-of-Arraysを採用する:',
+          '- Group A (Hot - Culling): bounds, visibility flags',
+          '- Group B (Hot - Sorting): shader keys, sort keys, material keys',
+          '- Group C (Hot - Transform): world transforms, previous frames',
+          '- Group D (Cold - Metadata): mesh handles, LOD levels, flags',
+          '',
+          '### マテリアル',
+          'BaseMaterialBuilderのfluent APIでPBRマテリアルを構築し、パス別バリアントを自動生成:',
+          '- Shadow/Depth: alpha test + two-sided のみ',
+          '- GI: albedo, emissive, alpha test, two-sided, vertex color',
+          '- Opaque/Transparent: 全機能',
+          '',
+          '### プール分類',
+          'ObjectClassifierがオブジェクトをプールに振り分ける:',
+          '- Static: 静的ジオメトリ (BVH最適化)',
+          '- Dynamic: 毎フレーム更新 (CPU並列 or Compute Shader)',
+          '- GPU-Driven: GPU駆動パイプライン (Compute更新・カリング・LOD選択・描画コンパクション)',
+        );
+        break;
+    }
 
     // ドメイン固有の追加指示
     const domainLower = component.domain.toLowerCase();
     if (domainLower.includes('lighting') || domainLower.includes('gi') || domainLower.includes('light')) {
-      lines.push(
-        '',
-        '### GI連携',
-        'GILightingSystemの事前パス結果 (Shadow → SSAO → GI Probes) をread-onlyテクスチャ/SSBOとして参照すること。',
-        '静的ジオメトリにはGIBakeSystemによるオフラインベイク (static shadow maps, AO, Light Probe SH L2, lightmaps) を利用可能。',
-      );
+      lines.push('', '### GI連携');
+      switch (this.platform) {
+        case 'unity':
+          lines.push(
+            'Enlighten / Progressive LightmapperでGIベイクを行い、Light Probeで動的オブジェクトにGIを適用すること。',
+            'リアルタイムGIはScreen Space Global Illumination (SSGI) またはLight Probe Proxyで補完する。',
+          );
+          break;
+        case 'unreal':
+          lines.push(
+            'Lumenによるリアルタイム Global Illumination を活用すること。',
+            '静的ジオメトリにはLightmassによるオフラインベイクも利用可能。',
+          );
+          break;
+        case 'godot':
+          lines.push(
+            'VoxelGI / SDFGI / LightmapGIノードでGIを設定すること。',
+            '動的オブジェクトにはReflectionProbe / VoxelGIを使用する。',
+          );
+          break;
+        default:
+          lines.push(
+            'GILightingSystemの事前パス結果 (Shadow → SSAO → GI Probes) をread-onlyテクスチャ/SSBOとして参照すること。',
+            '静的ジオメトリにはGIBakeSystemによるオフラインベイク (static shadow maps, AO, Light Probe SH L2, lightmaps) を利用可能。',
+          );
+          break;
+      }
     }
 
     if (domainLower.includes('material') || domainLower.includes('shader')) {
-      lines.push(
-        '',
-        '### マテリアルレジストリ',
-        'MaterialRegistryのO(1)ルックアップでBuiltMaterialを取得する。',
-        'パス固有バリアントは自動生成されるため、ベースマテリアル定義のみ行うこと。',
-      );
+      lines.push('', '### マテリアルレジストリ');
+      switch (this.platform) {
+        case 'unity':
+          lines.push(
+            'Addressablesまたはリソースフォルダからマテリアルをロードし、MaterialPropertyBlockでインスタンス化する。',
+            'シェーダーバリアント管理にはShaderVariantCollectionを活用する。',
+          );
+          break;
+        case 'unreal':
+          lines.push(
+            'UMaterialInterface::FindOrCreateMaterialInstanceDynamic()でマテリアルインスタンスを取得する。',
+            'マスターマテリアルからMaterial Instance経由でバリアントを自動生成する。',
+          );
+          break;
+        case 'godot':
+          lines.push(
+            'preload() / load()でマテリアルリソースを取得し、duplicate()でインスタンス化する。',
+            'シェーダーパラメータはset_shader_parameter()で制御する。',
+          );
+          break;
+        default:
+          lines.push(
+            'MaterialRegistryのO(1)ルックアップでBuiltMaterialを取得する。',
+            'パス固有バリアントは自動生成されるため、ベースマテリアル定義のみ行うこと。',
+          );
+          break;
+      }
     }
 
     return lines.join('\n');
@@ -228,11 +385,15 @@ export class PromptGenerator {
   /** コンポーネント用プロンプトを構築 */
   private buildComponentPrompt(component: Component): string {
     const needsPictor = isPictorDomain(component.domain);
+    const info = PLATFORM_INFO[this.platform];
 
     const lines: string[] = [
       `# コード生成指示: ${component.name} コンポーネント`,
       '',
-      `以下のErgoモジュール定義に基づいて、Ergoモジュールとして実装コードを生成してください。`,
+      `## ターゲットプラットフォーム: ${this.platform}`,
+      `## 実装言語: ${info.language}`,
+      '',
+      `以下のErgoモジュール定義に基づいて、${info.modulePattern}として実装コードを生成してください。`,
       '',
       '---',
       '',
@@ -245,6 +406,9 @@ export class PromptGenerator {
     if (needsPictor) {
       lines.push(this.buildPictorIntegration(component));
     }
+
+    // プラットフォーム固有の規約
+    lines.push(this.buildPlatformConventions(component));
 
     // 生成ルール
     lines.push(
@@ -265,9 +429,9 @@ export class PromptGenerator {
       '9. テストはモノリシック結合時の複合テスト条件として参照される前提で記述すること',
       '',
       '### ファイル構成',
-      `10. モジュール実装: \`${this.toKebabCase(component.name)}.ts\``,
-      `11. ダミープラグ: \`${this.toKebabCase(component.name)}.stub.ts\` (インターフェースのみ、実装なし)`,
-      `12. テスト: \`${this.toKebabCase(component.name)}.test.ts\``,
+      `10. モジュール実装: \`${this.toKebabCase(component.name)}${info.fileExtension}\``,
+      `11. ダミープラグ: \`${this.toKebabCase(component.name)}${info.stubExtension}\` (インターフェースのみ、実装なし)`,
+      `12. テスト: \`${this.toKebabCase(component.name)}${info.testExtension}\``,
       `13. モジュール定義書: \`spec.md\` (上記のErgoモジュール定義をそのまま格納)`,
     );
 
@@ -275,19 +439,104 @@ export class PromptGenerator {
       lines.push(
         '',
         '### Pictor統合',
-        '14. RenderObjectの登録・更新・削除はObjectDescriptorを介してPictorのSceneRegistryに対して行うこと',
-        '15. データレイアウトはSoA (Structure-of-Arrays) に従い、Hot/Coldのグループ分けを意識すること',
-        '16. ISurfaceProviderを直接参照せず、Ergoのモジュール依存経由でレンダリング機能にアクセスすること',
+        ...this.buildPictorRules(),
       );
     }
 
     return lines.join('\n');
   }
 
+  /** プラットフォーム固有の規約セクションを構築 */
+  private buildPlatformConventions(component: Component): string {
+    const lines: string[] = ['', `## プラットフォーム規約 (${this.platform})`];
+
+    switch (this.platform) {
+      case 'unity':
+        lines.push(
+          '',
+          '### Unity規約',
+          '- コンポーネントはMonoBehaviourまたはScriptableObjectを継承すること',
+          '- アクターモデルのメッセージパッシングはUnityEvent / C# eventで実装すること',
+          '- 変数は[SerializeField]属性でインスペクター公開すること',
+          '- タスクはpublicメソッドとしてコルーチンまたはasync/awaitで実装すること',
+          '- 依存モジュールは[RequireComponent]属性またはDI (Zenject/VContainer) で解決すること',
+          '- namespaceは Ars.Ergo.{Domain} とすること',
+        );
+        break;
+      case 'unreal':
+        lines.push(
+          '',
+          '### Unreal規約',
+          '- コンポーネントはUActorComponentまたはUObjectを継承すること',
+          '- アクターモデルのメッセージパッシングはDelegate / Event Dispatcherで実装すること',
+          '- 変数はUPROPERTY(EditAnywhere)でエディタ公開すること',
+          '- タスクはUFUNCTION(BlueprintCallable)でBP連携可能にすること',
+          '- ヘッダファイル (.h) と実装ファイル (.cpp) を分離すること',
+          '- モジュールは ArsErgo{Domain} モジュールに配置すること',
+        );
+        break;
+      case 'godot':
+        lines.push(
+          '',
+          '### Godot規約',
+          '- コンポーネントはNodeまたはResourceを継承すること',
+          '- アクターモデルのメッセージパッシングはsignal / call_group()で実装すること',
+          '- 変数は@exportアノテーションでインスペクター公開すること',
+          '- タスクはpublicメソッド (func) として実装すること',
+          '- class_nameを Ergo{ComponentName} とすること',
+        );
+        break;
+      case 'ars-native':
+      default:
+        lines.push(
+          '',
+          '### Ars Native規約',
+          '- TypeScriptモジュールとして実装すること',
+          '- アクターモデルのメッセージパッシングはErgo標準のポートベースインターフェースに従うこと',
+          '- 型安全なインターフェースを定義すること',
+        );
+        break;
+    }
+
+    return lines.join('\n');
+  }
+
+  /** プラットフォーム対応のPictor統合ルールを構築 */
+  private buildPictorRules(): string[] {
+    switch (this.platform) {
+      case 'unity':
+        return [
+          '14. 描画オブジェクトはMeshRenderer / MeshFilterコンポーネント経由でUnityのレンダリングパイプラインに登録すること',
+          '15. URP/HDRPのRenderFeatureでカスタムパスが必要な場合はScriptableRenderPassを実装すること',
+          '16. マテリアルはShaderGraphまたはShader Labで定義し、MaterialPropertyBlockでインスタンス化すること',
+        ];
+      case 'unreal':
+        return [
+          '14. 描画オブジェクトはUStaticMeshComponent / USkeletalMeshComponent経由でレンダリングパイプラインに登録すること',
+          '15. カスタムレンダリングパスはFSceneViewExtensionまたはMeshMaterialShaderで実装すること',
+          '16. マテリアルはUMaterialInstanceDynamic経由でランタイム制御すること',
+        ];
+      case 'godot':
+        return [
+          '14. 描画オブジェクトはMeshInstance3D / MultiMeshInstance3D経由でレンダリングパイプラインに登録すること',
+          '15. カスタムシェーダーは.gdshaderファイルで定義すること',
+          '16. マテリアルはShaderMaterial / StandardMaterial3Dで定義すること',
+        ];
+      case 'ars-native':
+      default:
+        return [
+          '14. RenderObjectの登録・更新・削除はObjectDescriptorを介してPictorのSceneRegistryに対して行うこと',
+          '15. データレイアウトはSoA (Structure-of-Arrays) に従い、Hot/Coldのグループ分けを意識すること',
+          '16. ISurfaceProviderを直接参照せず、Ergoのモジュール依存経由でレンダリング機能にアクセスすること',
+        ];
+    }
+  }
+
   /** シーン用プロンプトを構築 */
   private buildScenePrompt(scene: Scene): string {
     const actors = Object.values(scene.actors);
     const rootActor = scene.actors[scene.rootActorId];
+    const info = PLATFORM_INFO[this.platform];
 
     // シーン内のPictor連携コンポーネントを検出
     const hasPictorComponents = actors.some(actor =>
@@ -300,7 +549,10 @@ export class PromptGenerator {
     const lines: string[] = [
       `# コード生成指示: ${scene.name} シーン`,
       '',
-      `以下のArsシーン設計に基づいて、Ergoモジュールの結合・配線コードを生成してください。`,
+      `## ターゲットプラットフォーム: ${this.platform}`,
+      `## 実装言語: ${info.language}`,
+      '',
+      `以下のArsシーン設計に基づいて、${info.modulePattern}の結合・配線コードを生成してください。`,
       '',
       `## シーン情報`,
       `- 名前: ${scene.name}`,
@@ -351,21 +603,57 @@ export class PromptGenerator {
 
     // Pictor連携シーンの場合、レンダリングパイプライン指示を追加
     if (hasPictorComponents) {
-      lines.push(
-        '',
-        '## Pictorレンダリングパイプライン結合',
-        '',
-        'このシーンにはPictor連携モジュールが含まれる。以下の順序でフレーム実行を配線すること:',
-        '1. BeginFrame: GPU同期',
-        '2. UpdateScheduler: プール別戦略で更新 (Static=スキップ, Dynamic=CPU並列, GPU-Driven=Compute)',
-        '3. CullingSystem: Frustumカリング → オクルージョンカリング → Hi-Zカリング',
-        '4. BatchBuilder: シェーダーキーでRadix Sort、RenderBatchを生成',
-        '5. RenderPassScheduler: PipelineProfile (Forward/Forward+/Deferred/Hybrid) に基づくパス実行',
-        '6. EndFrame: サブミット・プレゼント',
-        '',
-        'RenderObject登録はObjectDescriptorを介してSceneRegistryへ。各アクターのErgoモジュールが保持するデータを',
-        'SoAストリームに展開し、Pictorの3層パイプライン (Front-End→Middle→Back-End) で処理する。',
-      );
+      lines.push('', '## Pictorレンダリングパイプライン結合', '');
+      switch (this.platform) {
+        case 'unity':
+          lines.push(
+            'このシーンにはPictor連携 (Unity URP/HDRP) モジュールが含まれる。以下の構成で配線すること:',
+            '1. シーン初期化時にMeshRenderer/MeshFilter付きGameObjectを生成',
+            '2. URP/HDRP RenderPipelineAssetでレンダリング品質を制御',
+            '3. カスタムレンダーパスが必要な場合はScriptableRenderPass/ScriptableRenderFeatureを実装',
+            '4. BatchRendererGroupで大量オブジェクト描画を最適化',
+            '',
+            'Ergoモジュール間のデータ受け渡しはUnityEvent / C# eventベースで配線する。',
+          );
+          break;
+        case 'unreal':
+          lines.push(
+            'このシーンにはPictor連携 (Unreal Nanite/Lumen) モジュールが含まれる。以下の構成で配線すること:',
+            '1. BeginPlay時にActorComponentを初期化しワールドに登録',
+            '2. Nanite対応メッシュはNanite設定を有効化',
+            '3. Lumen GIを活用し、リアルタイム間接照明を適用',
+            '4. World Partition / Level Streamingでストリーミング制御',
+            '',
+            'Ergoモジュール間のデータ受け渡しはDelegate / EventDispatcherベースで配線する。',
+          );
+          break;
+        case 'godot':
+          lines.push(
+            'このシーンにはPictor連携 (Godot Vulkan) モジュールが含まれる。以下の構成で配線すること:',
+            '1. _ready()でMeshInstance3D/MultiMeshInstance3Dを生成しシーンツリーに追加',
+            '2. Environment / WorldEnvironmentノードでレンダリング品質を制御',
+            '3. VisualServerのRID APIで低レベルレンダリング最適化が可能',
+            '4. OccluderInstance3Dでオクルージョンカリングを設定',
+            '',
+            'Ergoモジュール間のデータ受け渡しはsignal / call_group()ベースで配線する。',
+          );
+          break;
+        case 'ars-native':
+        default:
+          lines.push(
+            'このシーンにはPictor連携モジュールが含まれる。以下の順序でフレーム実行を配線すること:',
+            '1. BeginFrame: GPU同期',
+            '2. UpdateScheduler: プール別戦略で更新 (Static=スキップ, Dynamic=CPU並列, GPU-Driven=Compute)',
+            '3. CullingSystem: Frustumカリング → オクルージョンカリング → Hi-Zカリング',
+            '4. BatchBuilder: シェーダーキーでRadix Sort、RenderBatchを生成',
+            '5. RenderPassScheduler: PipelineProfile (Forward/Forward+/Deferred/Hybrid) に基づくパス実行',
+            '6. EndFrame: サブミット・プレゼント',
+            '',
+            'RenderObject登録はObjectDescriptorを介してSceneRegistryへ。各アクターのErgoモジュールが保持するデータを',
+            'SoAストリームに展開し、Pictorの3層パイプライン (Front-End→Middle→Back-End) で処理する。',
+          );
+          break;
+      }
     }
 
     // 生成ルール

--- a/ars-codegen/src/types.ts
+++ b/ars-codegen/src/types.ts
@@ -65,12 +65,23 @@ export interface Project {
   activeSceneId: string | null;
 }
 
+// === バックエンドプラットフォーム ===
+
+export type BackendPlatform = 'ars-native' | 'unity' | 'unreal' | 'godot';
+
+export interface BackendPlatformConfig {
+  platform: BackendPlatform;
+  platformOptions?: Record<string, unknown>;
+}
+
 // === コード生成固有の型 ===
 
 export interface CodegenConfig {
   projectFile: string;
   outputDir: string;
   targetPlatform?: string;
+  /** バックエンドプラットフォーム (デフォルト: ars-native) */
+  backendPlatform?: BackendPlatform;
   sceneIds?: string[];
   componentIds?: string[];
   dryRun?: boolean;

--- a/platforms.md
+++ b/platforms.md
@@ -1,0 +1,79 @@
+# バックエンドプラットフォーム定義
+
+プロジェクト全体設定でバックエンドプラットフォームを選択する。
+ErgoモジュールとPictorモジュールは、選択されたプラットフォームに応じた言語・規約でコード生成される。
+
+## 対応プラットフォーム
+
+### ars-native (デフォルト)
+
+Ars独自ランタイム。TypeScript JIT / WASMベースで動作する。
+
+- **言語**: TypeScript
+- **ファイル拡張子**: `.ts`
+- **Ergoモジュール形式**: TypeScriptモジュール (ポートベースメッセージパッシング)
+- **Pictor連携**: Pictor SoA Rendering Pipeline (WebGL / WASM)
+- **ビルドターゲット**: WebGL, PC (Tauri)
+- **ビルド方式**: TypeScript JIT, WASM Bundle
+
+### unity
+
+Unity Engine (URP / HDRP) をバックエンドとして使用する。
+
+- **言語**: C#
+- **ファイル拡張子**: `.cs`
+- **Ergoモジュール形式**: MonoBehaviour / ScriptableObject
+- **Pictor連携**: Unity URP/HDRP Rendering Pipeline
+- **メッセージパッシング**: UnityEvent / C# event / Delegate
+- **依存解決**: [RequireComponent] / DI (Zenject / VContainer)
+- **namespace**: `Ars.Ergo.{Domain}`
+
+### unreal
+
+Unreal Engine (Nanite / Lumen) をバックエンドとして使用する。
+
+- **言語**: C++
+- **ファイル拡張子**: `.cpp` / `.h`
+- **Ergoモジュール形式**: UActorComponent / UObject
+- **Pictor連携**: Unreal Nanite/Lumen Rendering Pipeline
+- **メッセージパッシング**: Delegate / Event Dispatcher
+- **変数公開**: UPROPERTY(EditAnywhere) / UFUNCTION(BlueprintCallable)
+- **モジュール配置**: `ArsErgo{Domain}` モジュール
+
+### godot
+
+Godot Engine (Vulkan) をバックエンドとして使用する。
+
+- **言語**: GDScript
+- **ファイル拡張子**: `.gd`
+- **Ergoモジュール形式**: Node / Resource
+- **Pictor連携**: Godot Vulkan Rendering Pipeline
+- **メッセージパッシング**: signal / call_group()
+- **変数公開**: @export アノテーション
+- **クラス名**: `Ergo{ComponentName}`
+
+## プラットフォーム選択の影響範囲
+
+| 機能 | 影響 |
+|------|------|
+| コード生成 (ars-codegen) | 生成言語・規約・ファイル構成が切り替わる |
+| Ergoモジュール | メッセージパッシング実装方式が変わる |
+| Pictor連携 | レンダリングAPI・パイプライン指示が変わる |
+| コアアセンブリ | プラットフォーム対応ライブラリが変わる |
+| ビルドターゲット | プラットフォーム固有のビルドフローになる |
+
+## 設定方法
+
+プロジェクトの `assembly.config.json` の `backend_platform` フィールドで設定する:
+
+```json
+{
+  "backend_platform": {
+    "platform": "unity",
+    "platform_options": {
+      "unity_project_path": "/path/to/unity/project",
+      "render_pipeline": "urp"
+    }
+  }
+}
+```

--- a/src-tauri/src/commands/assembly.rs
+++ b/src-tauri/src/commands/assembly.rs
@@ -221,6 +221,28 @@ pub fn get_app_assemblies_by_scene(
     AssemblyCommandResult::ok(results)
 }
 
+// ─── バックエンドプラットフォーム ───
+
+#[tauri::command]
+pub fn get_backend_platform(
+    state: State<'_, AssemblyState>,
+) -> AssemblyCommandResult<BackendPlatformConfig> {
+    let service = state.0.lock().unwrap();
+    AssemblyCommandResult::ok(service.get_backend_platform().clone())
+}
+
+#[tauri::command]
+pub fn set_backend_platform(
+    state: State<'_, AssemblyState>,
+    platform_config: BackendPlatformConfig,
+) -> AssemblyCommandResult<()> {
+    let mut service = state.0.lock().unwrap();
+    match service.set_backend_platform(platform_config) {
+        Ok(()) => AssemblyCommandResult::ok(()),
+        Err(e) => AssemblyCommandResult::err(e.to_string()),
+    }
+}
+
 // ─── 外部システム参照 ───
 
 #[tauri::command]

--- a/src-tauri/src/models/assembly.rs
+++ b/src-tauri/src/models/assembly.rs
@@ -1,5 +1,44 @@
 use serde::{Deserialize, Serialize};
 
+/// バックエンドプラットフォーム
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackendPlatform {
+    /// Ars独自ランタイム (TypeScript JIT / WASM)
+    ArsNative,
+    /// Unity (C#)
+    Unity,
+    /// Unreal Engine (C++)
+    Unreal,
+    /// Godot (GDScript)
+    Godot,
+}
+
+impl Default for BackendPlatform {
+    fn default() -> Self {
+        Self::ArsNative
+    }
+}
+
+/// バックエンドプラットフォーム設定
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendPlatformConfig {
+    /// 選択中のバックエンドプラットフォーム
+    pub platform: BackendPlatform,
+    /// プラットフォーム固有の設定
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform_options: Option<serde_json::Value>,
+}
+
+impl Default for BackendPlatformConfig {
+    fn default() -> Self {
+        Self {
+            platform: BackendPlatform::default(),
+            platform_options: None,
+        }
+    }
+}
+
 /// ビルドターゲットプラットフォーム
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -121,6 +160,9 @@ pub struct DataOrganizerRef {
 /// プロジェクトのアセンブリ管理設定
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectAssemblyConfig {
+    /// バックエンドプラットフォーム設定
+    #[serde(default)]
+    pub backend_platform: BackendPlatformConfig,
     pub release_depots: Vec<ReleaseDepotConfig>,
     pub core_assemblies: Vec<CoreAssembly>,
     pub application_assemblies: Vec<ApplicationAssembly>,
@@ -133,6 +175,7 @@ pub struct ProjectAssemblyConfig {
 impl Default for ProjectAssemblyConfig {
     fn default() -> Self {
         Self {
+            backend_platform: BackendPlatformConfig::default(),
             release_depots: Vec::new(),
             core_assemblies: Vec::new(),
             application_assemblies: Vec::new(),

--- a/src-tauri/src/services/assembly_manager.rs
+++ b/src-tauri/src/services/assembly_manager.rs
@@ -233,6 +233,22 @@ impl AssemblyManagerService {
             .collect()
     }
 
+    // ─── バックエンドプラットフォーム設定 ───
+
+    /// バックエンドプラットフォーム設定を取得
+    pub fn get_backend_platform(&self) -> &BackendPlatformConfig {
+        &self.config.backend_platform
+    }
+
+    /// バックエンドプラットフォームを設定
+    pub fn set_backend_platform(
+        &mut self,
+        platform_config: BackendPlatformConfig,
+    ) -> Result<(), AssemblyError> {
+        self.config.backend_platform = platform_config;
+        self.save()
+    }
+
     // ─── 外部システム参照設定 ───
 
     /// リソースデポ参照を設定

--- a/src/types/assembly.ts
+++ b/src/types/assembly.ts
@@ -1,6 +1,50 @@
 // === アセンブリ管理型定義 ===
 // プログラムをコアアセンブリとアプリケーションアセンブリに分離管理する
 
+/** バックエンドプラットフォーム */
+export type BackendPlatform = 'ars-native' | 'unity' | 'unreal' | 'godot';
+
+/** バックエンドプラットフォーム設定 */
+export interface BackendPlatformConfig {
+  /** 選択中のバックエンドプラットフォーム */
+  platform: BackendPlatform;
+  /** プラットフォーム固有の設定 (Unity: C#プロジェクトパス等) */
+  platformOptions?: Record<string, unknown>;
+}
+
+/** プラットフォームごとのErgo/Pictorモジュール言語・規約マッピング */
+export const PLATFORM_DEFAULTS: Record<BackendPlatform, {
+  language: string;
+  fileExtension: string;
+  ergoModulePattern: string;
+  pictorIntegration: string;
+}> = {
+  'ars-native': {
+    language: 'TypeScript',
+    fileExtension: '.ts',
+    ergoModulePattern: 'Ergo TypeScript Module',
+    pictorIntegration: 'Pictor SoA Rendering Pipeline (WebGL/WASM)',
+  },
+  'unity': {
+    language: 'C#',
+    fileExtension: '.cs',
+    ergoModulePattern: 'Ergo Unity MonoBehaviour/ScriptableObject',
+    pictorIntegration: 'Unity URP/HDRP Rendering Pipeline',
+  },
+  'unreal': {
+    language: 'C++',
+    fileExtension: '.cpp',
+    ergoModulePattern: 'Ergo Unreal UObject/AActor',
+    pictorIntegration: 'Unreal Nanite/Lumen Rendering Pipeline',
+  },
+  'godot': {
+    language: 'GDScript',
+    fileExtension: '.gd',
+    ergoModulePattern: 'Ergo Godot Node/Resource',
+    pictorIntegration: 'Godot Vulkan Rendering Pipeline',
+  },
+};
+
 /** ビルドターゲットプラットフォーム */
 export type BuildTarget = 'webgl' | 'pc';
 
@@ -120,6 +164,8 @@ export interface DataOrganizerRef {
 
 /** プロジェクトのアセンブリ管理設定 */
 export interface ProjectAssemblyConfig {
+  /** バックエンドプラットフォーム設定 */
+  backendPlatform: BackendPlatformConfig;
   /** リリースデポ設定一覧 */
   releaseDepots: ReleaseDepotConfig[];
   /** コアアセンブリ一覧 */
@@ -135,6 +181,7 @@ export interface ProjectAssemblyConfig {
 /** デフォルトのプロジェクトアセンブリ設定 */
 export function createDefaultAssemblyConfig(): ProjectAssemblyConfig {
   return {
+    backendPlatform: { platform: 'ars-native' },
     releaseDepots: [],
     coreAssemblies: [],
     applicationAssemblies: [],


### PR DESCRIPTION
## Summary

This PR adds support for multiple backend platforms to the Ars code generation system. Previously, the system only supported the native Ars runtime. Now it can generate code for Unity (C#), Unreal Engine (C++), and Godot (GDScript) in addition to the default Ars Native (TypeScript).

## Key Changes

- **Platform abstraction layer**: Added `BackendPlatform` type and `PLATFORM_INFO` configuration mapping that defines language, file extensions, and naming conventions for each platform (ars-native, unity, unreal, godot)

- **PromptGenerator platform awareness**: Modified `PromptGenerator` class to accept a `BackendPlatform` parameter and generate platform-specific code generation instructions, including:
  - Language-specific syntax and conventions
  - Platform-specific rendering pipeline integration (Pictor for ars-native, URP/HDRP for Unity, Nanite/Lumen for Unreal, Vulkan for Godot)
  - Platform-specific GI and material registry patterns
  - File naming conventions per platform

- **Platform-specific code generation rules**: Implemented conditional logic in prompt generation to output different instructions for:
  - Component implementation patterns (MonoBehaviour vs UObject vs Node)
  - Message passing mechanisms (UnityEvent vs Delegate vs signal)
  - Dependency resolution patterns
  - Rendering integration approaches

- **Assembly configuration**: Added `BackendPlatformConfig` to project assembly settings with getter/setter commands in the Tauri backend

- **Type definitions**: Extended TypeScript and Rust type definitions to include `BackendPlatform` and `BackendPlatformConfig` across the codebase

- **Documentation**: Added `platforms.md` documenting each platform's language, conventions, and configuration options

## Implementation Details

- Platform information is centralized in `PLATFORM_INFO` constant for maintainability
- Scene and component prompt generation both respect the selected platform
- Pictor integration instructions are customized per platform (e.g., ObjectDescriptor for ars-native, MeshRenderer for Unity, UStaticMeshComponent for Unreal)
- Default platform is `ars-native` for backward compatibility
- Platform selection affects file extensions, module patterns, and all generated code conventions

https://claude.ai/code/session_01CcPbqbv3JuYHhsZyspCaJf