### PR TITLE
chore: remove separated module dependencies from Cargo.lock

### DIFF
--- a/ars-editor/src-tauri/Cargo.lock
+++ b/ars-editor/src-tauri/Cargo.lock
@@ -88,7 +88,6 @@ dependencies = [
  "axum-extra",
  "chrono",
  "dashmap",
- "data-organizer",
  "dirs",
  "dirs-next",
  "futures",
@@ -96,7 +95,6 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "reqwest 0.12.28",
- "resource-depot",
  "serde",
  "serde_json",
  "tauri",
@@ -1190,20 +1188,6 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "data-organizer"
-version = "0.1.0"
-dependencies = [
- "axum",
- "dirs",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tower-http 0.5.2",
- "uuid",
-]
 
 [[package]]
 name = "deranged"
@@ -3848,23 +3832,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "resource-depot"
-version = "0.1.0"
-dependencies = [
- "axum",
- "dirs",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.18",
- "tokio",
- "tower-http 0.5.2",
- "uuid",
- "walkdir",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Ars-Module リポジトリに分離済みの data-organizer, resource-depot の依存を Cargo.lock から削除

## Test plan
- [ ] ars-editor のビルドが正常に通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)