### PR TITLE
fix: add Docker platform specification to resolve exec format error

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,15 @@ on:
         description: 'Version tag (e.g. v0.2.0). Leave empty to use git SHA.'
         required: false
         type: string
+      platform:
+        description: 'Target platform'
+        required: false
+        type: choice
+        default: 'all'
+        options:
+          - all
+          - linux/amd64
+          - linux/arm64
 
 concurrency:
   group: docker-publish-${{ github.ref }}
@@ -94,6 +103,17 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
+      - name: Resolve target platforms
+        id: platforms
+        shell: bash
+        run: |
+          INPUT="${{ inputs.platform }}"
+          if [ -z "$INPUT" ] || [ "$INPUT" = "all" ]; then
+            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+          else
+            echo "platforms=$INPUT" >> "$GITHUB_OUTPUT"
+          fi
+
       # Linux: マルチプラットフォーム (amd64 + arm64)
       - name: Build and push (Linux)
         if: runner.os == 'Linux'
@@ -101,7 +121,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.platforms.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -115,6 +135,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: ${{ steps.platforms.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,11 +15,14 @@
 #
 # 環境変数:
 #   IMAGE_TAG (default: latest) - 使用するイメージのタグ
+#   DOCKER_PLATFORM (default: linux/arm64) - ターゲットプラットフォーム
+#     例: DOCKER_PLATFORM=linux/amd64 docker compose up -d --build
 # =============================================================================
 
 services:
   redis:
     image: redis:7-alpine
+    platform: ${DOCKER_PLATFORM:-linux/arm64}
     container_name: ars-redis
     ports:
       - "${REDIS_PORT:-6379}:6379"
@@ -30,7 +33,11 @@ services:
 
   ars:
     image: ghcr.io/ludiars/ars:${IMAGE_TAG:-latest}
-    build: .
+    build:
+      context: .
+      platforms:
+        - ${DOCKER_PLATFORM:-linux/arm64}
+    platform: ${DOCKER_PLATFORM:-linux/arm64}
     container_name: ars
     ports:
       - "${ARS_PORT:-5173}:5173"


### PR DESCRIPTION
## Summary
- docker-compose.yamlに `platform` と `build.platforms` を追加し、ターゲットプラットフォームを明示的に指定
- デフォルトは `linux/arm64`、環境変数 `DOCKER_PLATFORM` で切り替え可能
- `exec format error`（amd64イメージをarm64ホストで実行）を解消

## Test plan
- [ ] `docker compose up -d --build` でarm64環境にて正常起動を確認
- [ ] `DOCKER_PLATFORM=linux/amd64 docker compose up -d --build` でamd64ビルドも動作確認

https://claude.ai/code/session_014QZkAMFBW4mJfxoT5rYCfd