### PR TITLE
feat: add git module install/management system

### DIFF
--- a/ars-editor/src-tauri/src/git_module_ops.rs
+++ b/ars-editor/src-tauri/src/git_module_ops.rs
@@ -1,0 +1,311 @@
+/// Git モジュールインストール管理
+///
+/// Gitリポジトリからモジュールをクローンし、ローカルにキャッシュする。
+/// インストール済みモジュールの一覧は `~/.ars/modules/registry.json` で管理する。
+use git2::{Cred, FetchOptions, RemoteCallbacks, Repository};
+use std::path::{Path, PathBuf};
+
+use ars_core::models::{InstalledModule, ModuleRegistry};
+
+const MODULES_DIR: &str = "modules";
+const REGISTRY_FILE: &str = "registry.json";
+
+fn get_ars_home() -> PathBuf {
+    let home = dirs_next::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(".ars")
+}
+
+fn get_modules_dir() -> PathBuf {
+    get_ars_home().join(MODULES_DIR)
+}
+
+fn get_registry_path() -> PathBuf {
+    get_ars_home().join(REGISTRY_FILE)
+}
+
+/// レジストリを読み込む（ファイルが無ければ空のレジストリを返す）
+pub fn load_registry() -> ModuleRegistry {
+    let path = get_registry_path();
+    if !path.exists() {
+        return ModuleRegistry { modules: vec![] };
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or(ModuleRegistry { modules: vec![] }),
+        Err(_) => ModuleRegistry { modules: vec![] },
+    }
+}
+
+/// レジストリを保存する
+fn save_registry(registry: &ModuleRegistry) -> Result<(), String> {
+    let path = get_registry_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create registry directory: {}", e))?;
+    }
+    let content = serde_json::to_string_pretty(registry)
+        .map_err(|e| format!("Failed to serialize registry: {}", e))?;
+    std::fs::write(&path, content)
+        .map_err(|e| format!("Failed to write registry: {}", e))
+}
+
+fn make_callbacks(token: &str) -> RemoteCallbacks<'_> {
+    let mut callbacks = RemoteCallbacks::new();
+    callbacks.credentials(move |_url, _username_from_url, _allowed_types| {
+        Cred::userpass_plaintext("x-access-token", token)
+    });
+    callbacks
+}
+
+/// Git URLからモジュール名を推測する
+fn module_name_from_url(git_url: &str) -> String {
+    let name = git_url
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or("unknown");
+    name.strip_suffix(".git").unwrap_or(name).to_string()
+}
+
+/// モジュール用のローカルディレクトリ名を生成
+fn local_dir_name(git_url: &str) -> String {
+    // URLからオーナー/リポ名を抽出してディレクトリ名にする
+    let cleaned = git_url
+        .trim_end_matches('/')
+        .strip_suffix(".git")
+        .unwrap_or(git_url);
+    // "https://github.com/owner/repo" -> "owner_repo"
+    let parts: Vec<&str> = cleaned.rsplitn(3, '/').collect();
+    if parts.len() >= 2 {
+        format!("{}_{}", parts[1], parts[0])
+    } else {
+        parts[0].to_string()
+    }
+}
+
+/// Gitリポジトリからモジュールをインストールする
+pub fn install_module(
+    access_token: &str,
+    git_url: &str,
+    git_ref: &str,
+) -> Result<InstalledModule, String> {
+    let mut registry = load_registry();
+
+    // 既にインストール済みか確認
+    if registry.modules.iter().any(|m| m.git_url == git_url) {
+        return Err(format!("Module already installed: {}", git_url));
+    }
+
+    let modules_dir = get_modules_dir();
+    let dir_name = local_dir_name(git_url);
+    let local_path = modules_dir.join(&dir_name);
+
+    std::fs::create_dir_all(&modules_dir)
+        .map_err(|e| format!("Failed to create modules directory: {}", e))?;
+
+    // クローン
+    if local_path.exists() {
+        // ディレクトリが既に存在する場合はpull
+        pull_module(access_token, &local_path, git_ref)?;
+    } else {
+        clone_module(access_token, git_url, &local_path, git_ref)?;
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let module = InstalledModule {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: module_name_from_url(git_url),
+        git_url: git_url.to_string(),
+        git_ref: git_ref.to_string(),
+        local_path: local_path.to_string_lossy().to_string(),
+        installed_at: now.clone(),
+        updated_at: now,
+        enabled: true,
+        description: None,
+    };
+
+    registry.modules.push(module.clone());
+    save_registry(&registry)?;
+
+    Ok(module)
+}
+
+/// モジュールをクローンする
+fn clone_module(
+    access_token: &str,
+    git_url: &str,
+    local_path: &Path,
+    git_ref: &str,
+) -> Result<(), String> {
+    let callbacks = make_callbacks(access_token);
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks);
+
+    let mut builder = git2::build::RepoBuilder::new();
+    builder.fetch_options(fo);
+    builder.branch(git_ref);
+
+    builder
+        .clone(git_url, local_path)
+        .map_err(|e| format!("Failed to clone module: {}", e))?;
+
+    Ok(())
+}
+
+/// モジュールをpullする（更新）
+fn pull_module(access_token: &str, local_path: &Path, git_ref: &str) -> Result<(), String> {
+    let repo = Repository::open(local_path)
+        .map_err(|e| format!("Failed to open repository: {}", e))?;
+
+    let mut remote = repo
+        .find_remote("origin")
+        .map_err(|e| format!("Failed to find remote: {}", e))?;
+
+    let callbacks = make_callbacks(access_token);
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks);
+
+    remote
+        .fetch(&[git_ref], Some(&mut fo), None)
+        .map_err(|e| format!("Failed to fetch: {}", e))?;
+
+    // Fast-forward merge
+    let fetch_head = repo
+        .find_reference("FETCH_HEAD")
+        .map_err(|e| format!("Failed to find FETCH_HEAD: {}", e))?;
+    let fetch_commit = repo
+        .reference_to_annotated_commit(&fetch_head)
+        .map_err(|e| format!("Failed to get commit: {}", e))?;
+
+    let (analysis, _) = repo
+        .merge_analysis(&[&fetch_commit])
+        .map_err(|e| format!("Merge analysis failed: {}", e))?;
+
+    if analysis.is_up_to_date() {
+        return Ok(());
+    }
+
+    if analysis.is_fast_forward() {
+        let refname = format!("refs/heads/{}", git_ref);
+        if let Ok(mut reference) = repo.find_reference(&refname) {
+            reference
+                .set_target(fetch_commit.id(), "Fast-forward")
+                .map_err(|e| format!("Failed to set target: {}", e))?;
+        }
+        repo.set_head(&format!("refs/heads/{}", git_ref))
+            .or_else(|_| repo.set_head("HEAD"))
+            .map_err(|e| format!("Failed to set HEAD: {}", e))?;
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))
+            .map_err(|e| format!("Failed to checkout: {}", e))?;
+    }
+
+    Ok(())
+}
+
+/// インストール済みモジュールを更新する（git pull）
+pub fn update_module(access_token: &str, module_id: &str) -> Result<InstalledModule, String> {
+    let mut registry = load_registry();
+    let module = registry
+        .modules
+        .iter_mut()
+        .find(|m| m.id == module_id)
+        .ok_or_else(|| format!("Module not found: {}", module_id))?;
+
+    let local_path = PathBuf::from(&module.local_path);
+    if !local_path.exists() {
+        // ディレクトリが消えている場合は再クローン
+        clone_module(access_token, &module.git_url, &local_path, &module.git_ref)?;
+    } else {
+        pull_module(access_token, &local_path, &module.git_ref)?;
+    }
+
+    module.updated_at = chrono::Utc::now().to_rfc3339();
+    let updated = module.clone();
+    save_registry(&registry)?;
+
+    Ok(updated)
+}
+
+/// モジュールをアンインストールする
+pub fn uninstall_module(module_id: &str) -> Result<(), String> {
+    let mut registry = load_registry();
+    let idx = registry
+        .modules
+        .iter()
+        .position(|m| m.id == module_id)
+        .ok_or_else(|| format!("Module not found: {}", module_id))?;
+
+    let module = registry.modules.remove(idx);
+
+    // ローカルディレクトリを削除
+    let local_path = PathBuf::from(&module.local_path);
+    if local_path.exists() {
+        std::fs::remove_dir_all(&local_path)
+            .map_err(|e| format!("Failed to remove module directory: {}", e))?;
+    }
+
+    save_registry(&registry)?;
+    Ok(())
+}
+
+/// モジュールの有効/無効を切り替える
+pub fn set_module_enabled(module_id: &str, enabled: bool) -> Result<InstalledModule, String> {
+    let mut registry = load_registry();
+    let module = registry
+        .modules
+        .iter_mut()
+        .find(|m| m.id == module_id)
+        .ok_or_else(|| format!("Module not found: {}", module_id))?;
+
+    module.enabled = enabled;
+    let updated = module.clone();
+    save_registry(&registry)?;
+
+    Ok(updated)
+}
+
+/// インストール済みモジュール一覧を取得する
+pub fn list_installed_modules() -> Vec<InstalledModule> {
+    load_registry().modules
+}
+
+/// インストール済みモジュールのディレクトリ内のMarkdownファイルを一覧する
+pub fn list_module_files(module_id: &str) -> Result<Vec<String>, String> {
+    let registry = load_registry();
+    let module = registry
+        .modules
+        .iter()
+        .find(|m| m.id == module_id)
+        .ok_or_else(|| format!("Module not found: {}", module_id))?;
+
+    let local_path = PathBuf::from(&module.local_path);
+    if !local_path.exists() {
+        return Err("Module directory not found. Try updating the module.".to_string());
+    }
+
+    let mut files = Vec::new();
+    collect_markdown_files(&local_path, &local_path, &mut files);
+    Ok(files)
+}
+
+fn collect_markdown_files(base: &Path, dir: &Path, results: &mut Vec<String>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // skip hidden dirs and common non-content dirs
+        if name_str.starts_with('.') || name_str == "node_modules" || name_str == "target" {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            collect_markdown_files(base, &path, results);
+        } else if name_str.ends_with(".md") {
+            if let Ok(rel) = path.strip_prefix(base) {
+                results.push(rel.to_string_lossy().to_string());
+            }
+        }
+    }
+}

--- a/ars-editor/src-tauri/src/lib.rs
+++ b/ars-editor/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ pub mod auth;
 #[cfg(feature = "web-server")]
 pub mod git_ops;
 #[cfg(feature = "web-server")]
+pub mod git_module_ops;
+#[cfg(feature = "web-server")]
 pub mod web_server;
 #[cfg(feature = "web-server")]
 pub mod web_modules;

--- a/ars-editor/src-tauri/src/web_modules/mod.rs
+++ b/ars-editor/src-tauri/src/web_modules/mod.rs
@@ -1,1 +1,2 @@
 pub mod editor;
+pub mod module_manager;

--- a/ars-editor/src-tauri/src/web_modules/module_manager.rs
+++ b/ars-editor/src-tauri/src/web_modules/module_manager.rs
@@ -1,0 +1,170 @@
+/// モジュール管理モジュール
+///
+/// Gitリポジトリからモジュールをインストール・管理するAPIルートを提供する。
+/// 設定画面からインストール済みモジュールの一覧表示・有効無効切替・更新・削除が可能。
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::Json,
+    routing::{delete, get, post, put},
+    Router,
+};
+use axum_extra::extract::cookie::CookieJar;
+use serde::Deserialize;
+
+use crate::app_state::AppState;
+use crate::auth;
+use crate::git_module_ops;
+use crate::models::InstalledModule;
+
+// ========== Request types ==========
+
+#[derive(Deserialize)]
+struct InstallModuleRequest {
+    /// Git clone URL (e.g. "https://github.com/user/ars-module-foo.git")
+    #[serde(rename = "gitUrl")]
+    git_url: String,
+    /// Branch or tag (default: "main")
+    #[serde(rename = "gitRef")]
+    git_ref: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SetEnabledRequest {
+    enabled: bool,
+}
+
+// ========== API handlers ==========
+
+/// インストール済みモジュール一覧を取得
+async fn api_list_modules(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<Json<Vec<InstalledModule>>, (StatusCode, String)> {
+    let _session = auth::extract_session(&state, &jar).await?;
+
+    let modules = tokio::task::spawn_blocking(git_module_ops::list_installed_modules)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?;
+
+    Ok(Json(modules))
+}
+
+/// Gitリポジトリからモジュールをインストール
+async fn api_install_module(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(req): Json<InstallModuleRequest>,
+) -> Result<Json<InstalledModule>, (StatusCode, String)> {
+    let session = auth::extract_session(&state, &jar).await?;
+    let token = session.access_token.clone();
+    let git_url = req.git_url;
+    let git_ref = req.git_ref.unwrap_or_else(|| "main".to_string());
+
+    let module = tokio::task::spawn_blocking(move || {
+        git_module_ops::install_module(&token, &git_url, &git_ref)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+    .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+
+    Ok(Json(module))
+}
+
+/// モジュールを更新（git pull）
+async fn api_update_module(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Path(module_id): Path<String>,
+) -> Result<Json<InstalledModule>, (StatusCode, String)> {
+    let session = auth::extract_session(&state, &jar).await?;
+    let token = session.access_token.clone();
+
+    let module = tokio::task::spawn_blocking(move || {
+        git_module_ops::update_module(&token, &module_id)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(module))
+}
+
+/// モジュールをアンインストール
+async fn api_uninstall_module(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Path(module_id): Path<String>,
+) -> Result<Json<()>, (StatusCode, String)> {
+    let _session = auth::extract_session(&state, &jar).await?;
+
+    tokio::task::spawn_blocking(move || git_module_ops::uninstall_module(&module_id))
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(()))
+}
+
+/// モジュールの有効/無効を切り替え
+async fn api_set_module_enabled(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Path(module_id): Path<String>,
+    Json(req): Json<SetEnabledRequest>,
+) -> Result<Json<InstalledModule>, (StatusCode, String)> {
+    let _session = auth::extract_session(&state, &jar).await?;
+
+    let module = tokio::task::spawn_blocking(move || {
+        git_module_ops::set_module_enabled(&module_id, req.enabled)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(module))
+}
+
+/// モジュール内のMarkdownファイル一覧を取得
+async fn api_list_module_files(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Path(module_id): Path<String>,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let _session = auth::extract_session(&state, &jar).await?;
+
+    let files = tokio::task::spawn_blocking(move || {
+        git_module_ops::list_module_files(&module_id)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Task failed: {}", e)))?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    Ok(Json(files))
+}
+
+/// モジュール管理のルーターを構築
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/api/modules",
+            get(api_list_modules).post(api_install_module),
+        )
+        .route(
+            "/api/modules/:module_id",
+            delete(api_uninstall_module),
+        )
+        .route(
+            "/api/modules/:module_id/update",
+            post(api_update_module),
+        )
+        .route(
+            "/api/modules/:module_id/enabled",
+            put(api_set_module_enabled),
+        )
+        .route(
+            "/api/modules/:module_id/files",
+            get(api_list_module_files),
+        )
+        .with_state(state)
+}

--- a/ars-editor/src-tauri/src/web_server.rs
+++ b/ars-editor/src-tauri/src/web_server.rs
@@ -16,7 +16,8 @@ pub async fn serve(port: u16, static_dir: Option<String>) -> Result<(), Box<dyn 
     let state = AppState::from_env().await?;
     let collab_state = CollabState::new();
 
-    let editor_router = web_modules::editor::router(state);
+    let editor_router = web_modules::editor::router(state.clone());
+    let module_router = web_modules::module_manager::router(state);
 
     // コラボレーションWebSocketルート
     let collab_router = Router::new()
@@ -24,6 +25,7 @@ pub async fn serve(port: u16, static_dir: Option<String>) -> Result<(), Box<dyn 
         .with_state(collab_state);
 
     let app = editor_router
+        .merge(module_router)
         .merge(collab_router)
         .layer(CorsLayer::permissive());
 
@@ -36,6 +38,7 @@ pub async fn serve(port: u16, static_dir: Option<String>) -> Result<(), Box<dyn 
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
     println!("Ars web server listening on http://localhost:{}", port);
     println!("  Editor:        /api/project/*, /api/cloud/*, /api/git/*");
+    println!("  Modules:       /api/modules/*");
     println!("  Collaboration: /ws/collab (WebSocket)");
 
     let listener = tokio::net::TcpListener::bind(addr).await

--- a/crates/ars-core/src/models/project.rs
+++ b/crates/ars-core/src/models/project.rs
@@ -196,6 +196,49 @@ pub struct ProjectSummary {
     pub updated_at: String,
 }
 
+// ── Installed Module ────────────────────────────────
+
+/// Gitリポジトリからインストールされたモジュールの管理情報
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct InstalledModule {
+    pub id: String,
+    /// モジュール名
+    pub name: String,
+    /// Git clone URL
+    #[serde(rename = "gitUrl")]
+    pub git_url: String,
+    /// ブランチまたはタグ
+    #[serde(rename = "gitRef")]
+    #[serde(default = "default_git_ref")]
+    pub git_ref: String,
+    /// ローカルのクローン先パス
+    #[serde(rename = "localPath")]
+    pub local_path: String,
+    /// インストール日時 (RFC3339)
+    #[serde(rename = "installedAt")]
+    pub installed_at: String,
+    /// 最終更新日時 (RFC3339)
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    /// 有効/無効
+    pub enabled: bool,
+    /// リポジトリの説明
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+fn default_git_ref() -> String {
+    "main".to_string()
+}
+
+/// インストール済みモジュール一覧を管理する設定ファイル
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct ModuleRegistry {
+    pub modules: Vec<InstalledModule>,
+}
+
 // ── Git ─────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]


### PR DESCRIPTION
## Summary
- Gitリポジトリからモジュールをインストール・管理する機能を追加
- `InstalledModule` / `ModuleRegistry` モデルをars-coreに追加し、インストール状態を `~/.ars/registry.json` で永続管理
- 設定画面からモジュールの一覧表示・有効無効切替・更新・削除が可能なREST APIを提供

## API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/modules` | インストール済みモジュール一覧 |
| POST | `/api/modules` | Gitリポジトリからモジュールをインストール |
| DELETE | `/api/modules/:id` | モジュールをアンインストール |
| POST | `/api/modules/:id/update` | モジュールを更新（git pull） |
| PUT | `/api/modules/:id/enabled` | モジュールの有効/無効切替 |
| GET | `/api/modules/:id/files` | モジュール内のMarkdownファイル一覧 |

## Changed Files
- `crates/ars-core/src/models/project.rs` — `InstalledModule`, `ModuleRegistry` モデル追加
- `ars-editor/src-tauri/src/git_module_ops.rs` — Git clone/pull/remove操作（新規）
- `ars-editor/src-tauri/src/web_modules/module_manager.rs` — APIルート（新規）
- `ars-editor/src-tauri/src/web_modules/mod.rs` — module_manager登録
- `ars-editor/src-tauri/src/lib.rs` — git_module_ops登録
- `ars-editor/src-tauri/src/web_server.rs` — モジュール管理ルーター統合

## Test plan
- [ ] `cargo check --features web-server --no-default-features -p app` でコンパイル確認
- [ ] POST `/api/modules` でGitリポジトリからモジュールインストールを確認
- [ ] GET `/api/modules` でインストール済み一覧が返ることを確認
- [ ] PUT `/api/modules/:id/enabled` で有効/無効切替を確認
- [ ] POST `/api/modules/:id/update` でgit pullによる更新を確認
- [ ] DELETE `/api/modules/:id` でアンインストールとディレクトリ削除を確認

https://claude.ai/code/session_01R7KoVwQh8RmDX1QfyKedQ1