### PR TITLE
Add development Docker setup and improve dev scripts

### DIFF
--- a/ars-editor/package.json
+++ b/ars-editor/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:web": "vite",
+    "dev:server": "cd src-tauri && cargo watch -x 'run --features web-server --no-default-features --bin ars-web-server -- ../dist'",
+    "dev:full": "npm run dev & npm run dev:server & wait",
     "build": "tsc -b && vite build",
     "build:web-server": "cd src-tauri && cargo build --features web-server --no-default-features --bin ars-web-server",
     "serve:web": "cd src-tauri && cargo run --features web-server --no-default-features --bin ars-web-server -- ../dist",

--- a/ars-editor/vite.config.ts
+++ b/ars-editor/vite.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
         target: 'http://localhost:5173',
         changeOrigin: true,
       },
+      '/ws': {
+        target: 'ws://localhost:5173',
+        ws: true,
+      },
     },
   },
   envPrefix: ['VITE_', 'TAURI_'],

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,35 @@
+# =============================================================================
+# Ars - Docker Compose (開発用)
+#
+# インフラサービス（Redis）のみ Docker で起動し、
+# Ars 本体はホスト上で直接実行する構成。
+#
+# フロントエンド: Vite HMR (port 5174)
+# バックエンド:   cargo-watch で自動リビルド (port 5173)
+#
+# 使用方法:
+#   # 1. インフラ起動
+#   docker compose -f docker-compose.dev.yaml up -d
+#
+#   # 2. アプリ起動（ars-editor/ ディレクトリで）
+#   npm run dev:full        # フロントエンド + バックエンド同時起動
+#   npm run dev             # フロントエンドのみ（Vite HMR）
+#   npm run dev:server      # バックエンドのみ（cargo-watch）
+#
+#   # 停止
+#   docker compose -f docker-compose.dev.yaml down
+# =============================================================================
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: ars-redis-dev
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-dev-data:/data
+    command: redis-server --appendonly yes
+    restart: unless-stopped
+
+volumes:
+  redis-dev-data:


### PR DESCRIPTION
## Summary
This PR enhances the development experience by introducing a Docker Compose configuration for development and improving npm scripts for running the application during development.

## Key Changes
- **Added `docker-compose.dev.yaml`**: A development-focused Docker Compose file that runs only Redis as an infrastructure service, allowing the Ars application to run directly on the host machine. This enables faster iteration with hot-reload capabilities.
  - Redis service configured with persistent volume
  - Clear documentation on usage patterns for frontend-only, backend-only, and full-stack development

- **Updated `ars-editor/package.json`**:
  - Added `dev:server` script: Runs the backend with `cargo-watch` for automatic rebuilding on file changes
  - Added `dev:full` script: Concurrently runs both frontend (Vite) and backend (cargo-watch) for full-stack development
  - Replaced `dev:web` with `dev:server` for clarity

- **Updated `ars-editor/vite.config.ts`**:
  - Added WebSocket proxy configuration (`/ws` endpoint) to forward WebSocket connections to the backend server, enabling real-time communication during development

## Implementation Details
The development setup now supports three workflows:
1. **Frontend only**: `npm run dev` - Vite HMR on port 5174
2. **Backend only**: `npm run dev:server` - cargo-watch with auto-rebuild
3. **Full stack**: `npm run dev:full` - Both frontend and backend running simultaneously

The WebSocket proxy ensures that frontend WebSocket connections are properly routed to the backend during development.

https://claude.ai/code/session_015qz2BJuU6T7KZsPnEc9DEh