### PR TITLE
fix: resolve Dependabot security alerts (picomatch, git2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2405,9 +2405,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",

--- a/ars-editor/package-lock.json
+++ b/ars-editor/package-lock.json
@@ -2208,9 +2208,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3824,9 +3824,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ars-editor/package.json
+++ b/ars-editor/package.json
@@ -20,6 +20,9 @@
     "react-dom": "^19.2.0",
     "zustand": "^5.0.11"
   },
+  "overrides": {
+    "picomatch": ">=4.0.4"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.2.1",

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ axum-extra = { version = "0.9", features = ["cookie"], optional = true }
 time = { version = "0.3", optional = true }
 urlencoding = { version = "2", optional = true }
 # Git operations
-git2 = { version = "0.19", optional = true }
+git2 = { version = "0.20", optional = true }
 dirs = { version = "6", optional = true }
 # Collaboration (WebSocket + shared state)
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
## Summary
- Dependabot セキュリティアラートのうち修正可能なものを対応
- npm audit: 0 vulnerabilities 達成

## Changes

### npm
- `picomatch`: `overrides` で `>=4.0.4` に固定 (Method Injection fix, #17)
- `brace-expansion`: `npm audit fix` で解消

### Rust
- `git2`: `0.19` → `0.20` (UB in Buf deref fix, #15/#5)

### 残りのアラート (対応不可)
- `glib` (#13/#1): Tauri の間接依存 (`tauri → gtk → glib`)。upstream の更新待ち。Linux 限定のリスク
- `jsonwebtoken` (#14/#3): Cernere 移行 (`feature/migrate-auth-to-cernere`) で解消予定
- `path-to-regexp` (#21/#20): 実際にはプロジェクトで使用されていない (npm ls で未検出)。Dependabot の誤検知の可能性

## Test plan
- [x] `npm audit` → 0 vulnerabilities
- [x] `cargo check --features web-server` → ビルド成功 (git2 0.20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)