### PR TITLE
feat: add Playwright integration tests with auth bypass via mock Cernere

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,10 +1,6 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -15,29 +11,9 @@ permissions:
   contents: read
 
 jobs:
-  # パス変更検出
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      should_test: ${{ steps.filter.outputs.should_test }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            should_test:
-              - 'ars-editor/**'
-              - 'crates/**'
-              - 'tests/integration/**'
-
   integration:
     name: Integration Tests
-    needs: changes
-    if: needs.changes.outputs.should_test == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
 
     # ── Infisical シークレット ──

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,122 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # パス変更検出
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should_test: ${{ steps.filter.outputs.should_test }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            should_test:
+              - 'ars-editor/**'
+              - 'crates/**'
+              - 'tests/integration/**'
+
+  integration:
+    name: Integration Tests
+    needs: changes
+    if: needs.changes.outputs.should_test == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # ── Infisical シークレット ──
+    # Organization secrets: INFISICAL_CLIENT_ID, INFISICAL_CLIENT_SECRET
+    # Repository secrets:   INFISICAL_PROJECT_ID, INFISICAL_HOST, INFISICAL_ENVIRONMENT
+    env:
+      INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
+      INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+      INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
+      INFISICAL_HOST: ${{ secrets.INFISICAL_HOST }}
+      INFISICAL_ENVIRONMENT: ${{ secrets.INFISICAL_ENVIRONMENT }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── ツールチェーン ──
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            ars-editor/package-lock.json
+            tests/integration/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ars-editor/src-tauri -> target
+
+      # ── システム依存関係 ──
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang libclang-dev cmake
+
+      # ── フロントエンドビルド ──
+      - name: Build frontend
+        working-directory: ars-editor
+        run: |
+          npm ci
+          npm run build
+
+      # ── バックエンドビルド ──
+      - name: Build web server
+        working-directory: ars-editor/src-tauri
+        run: cargo build --features web-server --no-default-features --bin ars-web-server
+
+      # ── テスト準備 ──
+      - name: Install test dependencies
+        working-directory: tests/integration
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: tests/integration
+        run: npx playwright install chromium --with-deps
+
+      # ── テスト実行 ──
+      - name: Run integration tests
+        working-directory: tests/integration
+        env:
+          CI: true
+          ARS_SERVER_CMD: ../../ars-editor/src-tauri/target/debug/ars-web-server ../../ars-editor/dist 15173
+          CERNERE_URL: http://localhost:18080
+        run: npx playwright test
+
+      # ── アーティファクト ──
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/integration/playwright-report/
+          retention-days: 7
+
+      - name: Upload test traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: tests/integration/test-results/
+          retention-days: 7

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,60 +16,34 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
 
-    # ── Infisical シークレット ──
-    # Organization secrets: INFISICAL_CLIENT_ID, INFISICAL_CLIENT_SECRET
-    # Repository secrets:   INFISICAL_PROJECT_ID, INFISICAL_HOST, INFISICAL_ENVIRONMENT
-    env:
-      INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
-      INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
-      INFISICAL_PROJECT_ID: ${{ secrets.INFISICAL_PROJECT_ID }}
-      INFISICAL_HOST: ${{ secrets.INFISICAL_HOST }}
-      INFISICAL_ENVIRONMENT: ${{ secrets.INFISICAL_ENVIRONMENT }}
+    # ── Infisical シークレットは self-hosted 環境に配置済み ──
+    # secrets.toml を ~/.config/ars/secrets.toml または ./secrets.toml に配置すること
 
     steps:
       - uses: actions/checkout@v4
 
-      # ── ツールチェーン ──
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            ars-editor/package-lock.json
-            tests/integration/package-lock.json
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ars-editor/src-tauri -> target
-
-      # ── システム依存関係 ──
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends clang libclang-dev cmake
-
-      # ── フロントエンドビルド ──
-      - name: Build frontend
+      # ── インクリメンタルビルド: フロントエンド ──
+      - name: Install frontend dependencies
         working-directory: ars-editor
-        run: |
-          npm ci
-          npm run build
+        run: npm ci --prefer-offline
 
-      # ── バックエンドビルド ──
-      - name: Build web server
+      - name: Build frontend (incremental)
+        working-directory: ars-editor
+        run: npm run build
+
+      # ── インクリメンタルビルド: バックエンド (cargo は差分ビルド) ──
+      - name: Build web server (incremental)
         working-directory: ars-editor/src-tauri
         run: cargo build --features web-server --no-default-features --bin ars-web-server
 
       # ── テスト準備 ──
       - name: Install test dependencies
         working-directory: tests/integration
-        run: npm ci
+        run: npm ci --prefer-offline
 
-      - name: Install Playwright browsers
+      - name: Ensure Playwright chromium
         working-directory: tests/integration
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       # ── テスト実行 ──
       - name: Run integration tests

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+playwright-report/
+test-results/
+blob-report/

--- a/tests/integration/SECRETS.md
+++ b/tests/integration/SECRETS.md
@@ -1,0 +1,83 @@
+# GitHub Secrets 設定ガイド
+
+結合テストの CI 実行に必���な GitHub Secrets の設定方法。
+
+## シークレット一覧
+
+### Organization Secrets (ludiars org レベル)
+
+Infisical Machine Identity の認証情報。全リポジトリで共有。
+
+| シークレット名 | 説明 | 設定場所 |
+|---|---|---|
+| `INFISICAL_CLIENT_ID` | Machine Identity Client ID | GitHub Organization Settings → Secrets → Actions |
+| `INFISICAL_CLIENT_SECRET` | Machine Identity Client Secret | GitHub Organization Settings → Secrets → Actions |
+
+### Repository Secrets (ludiars/ars リポジトリレベル)
+
+プロジェクト固有の設定値。
+
+| シークレット名 | 説明 | 例 |
+|---|---|---|
+| `INFISICAL_PROJECT_ID` | Infisical プロジェクト ID | `proj_xxxxxxxx` |
+| `INFISICAL_HOST` | Infisical ホスト URL | `https://app.infisical.com` |
+| `INFISICAL_ENVIRONMENT` | 環境名 | `dev` / `staging` / `prod` |
+
+## 設定手順
+
+### 1. Organization Secrets
+
+```
+GitHub → ludiars org → Settings → Secrets and variables → Actions
+→ New organization secret
+```
+
+- **Visibility**: `Selected repositories` → `ludiars/ars` を選択
+- Machine Identity の Client ID / Client Secret を設定
+
+### 2. Repository Secrets
+
+```
+GitHub → ludiars/ars → Settings → Secrets and variables → Actions
+→ New repository secret
+```
+
+- Infisical のプロジェクト固有設定を登録
+
+## Infisical Machine Identity 作成手順
+
+1. Infisical ダッシュボード → Settings → Machine Identities
+2. `New Machine Identity` → 名前: `ars-ci`
+3. Authentication Method: `Universal Auth`
+4. `Client ID` と `Client Secret` をコピー
+5. Machine Identity にプロジェクトへの Read アクセスを付与
+
+## 結合テストでの使われ方
+
+現在の結合テストでは Mock Cernere サーバーを使用するため、
+実際の Infisical 接続は**不要**です。
+
+これらのシークレットは将来の以下のテストで使用予定:
+- Docker 環境での E2E テスト
+- ステージング環境への自動デプロイ後テスト
+- Cernere 実サーバーを使った認証フローテ��ト
+
+## ローカル開発
+
+ローカルでの結合テスト実行時は Infisical シークレット不要:
+
+```bash
+cd tests/integration
+npm ci
+npx playwright install chromium
+npx playwright test
+```
+
+バックエンドのビルドが必要:
+
+```bash
+cd ars-editor
+npm ci && npm run build
+cd src-tauri
+cargo build --features web-server --no-default-features --bin ars-web-server
+```

--- a/tests/integration/SECRETS.md
+++ b/tests/integration/SECRETS.md
@@ -1,83 +1,76 @@
-# GitHub Secrets 設定ガイド
+# Self-hosted Runner セットアップガイド
 
-結合テストの CI 実行に必���な GitHub Secrets の設定方法。
+結合テストは self-hosted runner 上で手動実行 (`workflow_dispatch`) する。
+Infisical のシークレットは **runner 環境に直接配置** し、GitHub Secrets は使用しない。
 
-## シークレット一覧
+## 前提条件
 
-### Organization Secrets (ludiars org レベル)
+Self-hosted runner に以下がインストール済みであること:
 
-Infisical Machine Identity の認証情報。全リポジトリで共有。
+- Node.js 20+
+- Rust toolchain (rustup)
+- clang, cmake (Rust ビルド用)
+- Chromium (Playwright 用、初回は自動インストール)
 
-| シークレット名 | 説明 | 設定場所 |
-|---|---|---|
-| `INFISICAL_CLIENT_ID` | Machine Identity Client ID | GitHub Organization Settings → Secrets → Actions |
-| `INFISICAL_CLIENT_SECRET` | Machine Identity Client Secret | GitHub Organization Settings → Secrets → Actions |
+## Infisical 設定
 
-### Repository Secrets (ludiars/ars リポジトリレベル)
+Runner 上に `secrets.toml` を配置する。アプリが自動検出する。
 
-プロジェクト固有の設定値。
+### 配置先 (優先順)
 
-| シークレット名 | 説明 | 例 |
-|---|---|---|
-| `INFISICAL_PROJECT_ID` | Infisical プロジェクト ID | `proj_xxxxxxxx` |
-| `INFISICAL_HOST` | Infisical ホスト URL | `https://app.infisical.com` |
-| `INFISICAL_ENVIRONMENT` | 環境名 | `dev` / `staging` / `prod` |
+1. `./secrets.toml` (リポジトリルート)
+2. `~/.config/ars/secrets.toml`
 
-## 設定手順
+### 設定ファイル例
 
-### 1. Organization Secrets
+```toml
+provider = "infisical"
 
-```
-GitHub → ludiars org → Settings → Secrets and variables → Actions
-→ New organization secret
-```
-
-- **Visibility**: `Selected repositories` → `ludiars/ars` を選択
-- Machine Identity の Client ID / Client Secret を設定
-
-### 2. Repository Secrets
-
-```
-GitHub → ludiars/ars → Settings → Secrets and variables → Actions
-→ New repository secret
+[infisical]
+host = "https://app.infisical.com"
+client_id = "<Machine Identity Client ID>"
+client_secret = "<Machine Identity Client Secret>"
+project_id = "<Project ID>"
+environment = "dev"
+shared_path = "/shared"
+personal_path_prefix = "/personal"
+cache_ttl_secs = 300
 ```
 
-- Infisical のプロジェクト固有設定を登録
-
-## Infisical Machine Identity 作成手順
+### Machine Identity 作成手順
 
 1. Infisical ダッシュボード → Settings → Machine Identities
-2. `New Machine Identity` → 名前: `ars-ci`
+2. `New Machine Identity` → 名前: `ars-ci-runner`
 3. Authentication Method: `Universal Auth`
 4. `Client ID` と `Client Secret` をコピー
 5. Machine Identity にプロジェクトへの Read アクセスを付与
+6. 上記の値を runner の `secrets.toml` に記入
 
-## 結合テストでの使われ方
+## テスト実行
 
-現在の結合テストでは Mock Cernere サーバーを使用するため、
-実際の Infisical 接続は**不要**です。
+### CI (GitHub Actions)
 
-これらのシークレットは将来の以下のテストで使用予定:
-- Docker 環境での E2E テスト
-- ステージング環境への自動デプロイ後テスト
-- Cernere 実サーバーを使った認証フローテ��ト
+Actions タブ → "Integration Tests" → "Run workflow" ボタン
 
-## ローカル開発
-
-ローカルでの結合テスト実行時は Infisical シークレット不要:
+### ローカル実行
 
 ```bash
-cd tests/integration
+# バックエンドビルド (差分ビルド)
+cd ars-editor
+npm ci && npm run build
+cd src-tauri
+cargo build --features web-server --no-default-features --bin ars-web-server
+
+# テスト実行
+cd ../../tests/integration
 npm ci
 npx playwright install chromium
 npx playwright test
 ```
 
-バックエンドのビルドが必要:
+## 注意事項
 
-```bash
-cd ars-editor
-npm ci && npm run build
-cd src-tauri
-cargo build --features web-server --no-default-features --bin ars-web-server
-```
+- `secrets.toml` は `.gitignore` に含まれておりリポジトリにコミットされない
+- Runner の `secrets.toml` はファイルパーミッション `600` を推奨
+- 結合テスト自体は Mock Cernere を使用するため Infisical 接続は不要
+- Infisical 設定は将来の Docker E2E テスト・ステージングデプロイ用

--- a/tests/integration/helpers/auth.ts
+++ b/tests/integration/helpers/auth.ts
@@ -1,0 +1,69 @@
+/**
+ * 認証バイパスヘルパー
+ *
+ * Playwright テストで認証状態を注入するためのユーティリティ。
+ *
+ * 認証バイパス方式:
+ * 1. ars_session Cookie をブラウザコンテキストに注入
+ *    → バックエンドが Mock Cernere に転送 → モックユーザーが返る
+ * 2. localStorage に accessToken/refreshToken を注入
+ *    → フロントエンドの fetchJson が Bearer トークンとして送信
+ */
+
+import type { BrowserContext, Page } from '@playwright/test';
+import { TEST_SESSION_TOKEN } from '../mock-cernere/data.js';
+
+const BASE_URL = 'http://localhost:15173';
+
+/**
+ * 認証済み状態の Cookie + localStorage をセットアップ
+ */
+export async function authenticateContext(context: BrowserContext): Promise<void> {
+  // ars_session Cookie を注入
+  await context.addCookies([
+    {
+      name: 'ars_session',
+      value: TEST_SESSION_TOKEN,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+/**
+ * ページに localStorage トークンを注入
+ * (ページが既に navigate 済みの状態で呼ぶ)
+ */
+export async function injectTokens(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    localStorage.setItem('accessToken', 'mock-access');
+    localStorage.setItem('refreshToken', 'mock-refresh');
+  });
+}
+
+/**
+ * 認証済み状態でページを開く
+ */
+export async function openAuthenticated(
+  page: Page,
+  path: string = '/',
+): Promise<void> {
+  // まず Cookie を設定するために一度アクセス
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: 'domcontentloaded' });
+  // localStorage にトークンを注入
+  await injectTokens(page);
+  // リロードして認証状態を反映
+  await page.reload({ waitUntil: 'networkidle' });
+}
+
+/**
+ * 未認証状態でページを開く (Cookie なし)
+ */
+export async function openUnauthenticated(
+  page: Page,
+  path: string = '/',
+): Promise<void> {
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: 'networkidle' });
+}

--- a/tests/integration/helpers/console-collector.ts
+++ b/tests/integration/helpers/console-collector.ts
@@ -1,0 +1,53 @@
+/**
+ * コンソールエラー収集ヘルパー
+ *
+ * ページのコンソールエラーとネットワークエラーを収集し、
+ * テスト終了時にエラーがないことを検証する。
+ */
+
+import type { Page, ConsoleMessage } from '@playwright/test';
+
+export interface CollectedError {
+  type: 'console' | 'network';
+  message: string;
+}
+
+/**
+ * ページのエラーを収集するリスナーを登録
+ */
+export function collectErrors(page: Page): CollectedError[] {
+  const errors: CollectedError[] = [];
+
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      // ネットワーク系の想定内エラーは除外
+      if (isExpectedError(text)) return;
+      errors.push({ type: 'console', message: text });
+    }
+  });
+
+  page.on('pageerror', (err: Error) => {
+    errors.push({ type: 'console', message: err.message });
+  });
+
+  return errors;
+}
+
+/**
+ * テストで想定されるエラー（無視してよいもの）
+ */
+function isExpectedError(message: string): boolean {
+  const expectedPatterns = [
+    // Mock Cernere が返す 401 (未認証テスト時)
+    /Failed to load resource.*401/,
+    // Setup API が存在しないため 404
+    /api\/setup\/status.*404/,
+    /Failed to load resource.*404/,
+    // favicon が存在しない場合
+    /favicon\.ico/,
+    // 開発時のHMR関連
+    /\[vite\]/,
+  ];
+  return expectedPatterns.some((p) => p.test(message));
+}

--- a/tests/integration/mock-cernere/data.ts
+++ b/tests/integration/mock-cernere/data.ts
@@ -1,0 +1,40 @@
+/**
+ * Mock Cernere テストデータ
+ *
+ * 結合テストで使用するモックユーザー・セッション・プロジェクトデータ。
+ */
+
+export const TEST_SESSION_TOKEN = 'test-session-token-12345';
+
+export const TEST_USER = {
+  id: 'user-test-001',
+  githubId: 99999,
+  login: 'test-user',
+  displayName: 'Test User',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/0?v=4',
+  email: 'test@example.com',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+};
+
+export const TEST_SESSION = {
+  id: 'session-test-001',
+  userId: TEST_USER.id,
+  expiresAt: '2099-12-31T23:59:59Z',
+  createdAt: '2025-01-01T00:00:00Z',
+  accessToken: 'mock-github-access-token',
+};
+
+export const TEST_PROJECT = {
+  name: 'Test Project',
+  scenes: {},
+  components: {},
+  activeSceneId: null,
+  version: '1.0.0',
+};
+
+export const TEST_PROJECT_SUMMARY = {
+  id: 'project-test-001',
+  name: 'Test Project',
+  updatedAt: '2025-01-01T00:00:00Z',
+};

--- a/tests/integration/mock-cernere/server.ts
+++ b/tests/integration/mock-cernere/server.ts
@@ -1,0 +1,209 @@
+/**
+ * Mock Cernere サーバー
+ *
+ * 結合テスト用の認証バイパスサーバー。
+ * 実際の Cernere サーバーのAPIを模倣し、テスト用のモックデータを返す。
+ *
+ * バイパス方式:
+ * - OAuth フロー: GitHub連携なしでトークンを直接発行
+ * - セッション検証: ars_session Cookie の存在のみ確認
+ * - プロジェクトAPI: インメモリストレージ
+ */
+
+import express from 'express';
+import {
+  TEST_SESSION_TOKEN,
+  TEST_USER,
+  TEST_SESSION,
+  TEST_PROJECT_SUMMARY,
+} from './data.js';
+
+const app = express();
+app.use(express.json());
+
+// インメモリプロジェクトストレージ
+const projects = new Map<string, { name: string; data: unknown }>([
+  [TEST_PROJECT_SUMMARY.id, { name: TEST_PROJECT_SUMMARY.name, data: null }],
+]);
+
+// ── Helper ─────────────────────────────────────────────
+
+function extractSessionCookie(req: express.Request): string | null {
+  const cookieHeader = req.headers.cookie ?? '';
+  const match = cookieHeader.match(/ars_session=([^;]+)/);
+  return match?.[1] ?? null;
+}
+
+function requireSession(
+  req: express.Request,
+  res: express.Response,
+): boolean {
+  const session = extractSessionCookie(req);
+  if (!session) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return false;
+  }
+  return true;
+}
+
+// ── Auth Routes ────────────────────────────────────────
+
+/**
+ * GET /auth/github/login
+ * OAuth バイパス: 直接コールバックにリダイレクトしトークンを付与
+ */
+app.get('/auth/github/login', (req, res) => {
+  const redirect = (req.query.redirect as string) ?? 'http://localhost:15173';
+  const callbackUrl = `${redirect}/auth/callback?accessToken=mock-access&refreshToken=mock-refresh`;
+  // ars_session Cookie をセット
+  res.cookie('ars_session', TEST_SESSION_TOKEN, {
+    httpOnly: true,
+    path: '/',
+    maxAge: 86400000,
+  });
+  res.redirect(302, callbackUrl);
+});
+
+/**
+ * GET /auth/github/callback
+ * Cernere callback のモック: セッション Cookie をセットしてリダイレクト
+ */
+app.get('/auth/github/callback', (req, res) => {
+  res.cookie('ars_session', TEST_SESSION_TOKEN, {
+    httpOnly: true,
+    path: '/',
+    maxAge: 86400000,
+  });
+  const origin = 'http://localhost:15173';
+  res.redirect(302, `${origin}/auth/callback?accessToken=mock-access&refreshToken=mock-refresh`);
+});
+
+/**
+ * GET /auth/me
+ * セッション検証 → モックユーザー返却
+ */
+app.get('/auth/me', (req, res) => {
+  if (!requireSession(req, res)) return;
+  res.json(TEST_USER);
+});
+
+/**
+ * GET /auth/session
+ * セッション情報返却（access_token 含む）
+ */
+app.get('/auth/session', (req, res) => {
+  if (!requireSession(req, res)) return;
+  res.json(TEST_SESSION);
+});
+
+/**
+ * POST /api/auth/refresh
+ * トークンリフレッシュのモック
+ */
+app.post('/api/auth/refresh', (_req, res) => {
+  res.json({
+    accessToken: 'mock-access-refreshed',
+    refreshToken: 'mock-refresh-refreshed',
+  });
+});
+
+/**
+ * POST /api/auth/logout
+ * ログアウトのモック
+ */
+app.post('/api/auth/logout', (_req, res) => {
+  res.json({ success: true });
+});
+
+// ── Project Routes ─────────────────────────────────────
+
+/**
+ * GET /api/projects
+ * プロジェクト一覧
+ */
+app.get('/api/projects', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const summaries = Array.from(projects.entries()).map(([id, p]) => ({
+    id,
+    name: p.name,
+    updatedAt: '2025-01-01T00:00:00Z',
+  }));
+  res.json(summaries);
+});
+
+/**
+ * POST /api/projects
+ * プロジェクト保存
+ */
+app.post('/api/projects', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const { projectId, name, data } = req.body;
+  projects.set(projectId, { name, data });
+  res.json({ success: true });
+});
+
+/**
+ * GET /api/projects/:id
+ * プロジェクト読み込み
+ */
+app.get('/api/projects/:id', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const project = projects.get(req.params.id);
+  if (!project || !project.data) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  res.json(project.data);
+});
+
+/**
+ * DELETE /api/projects/:id
+ * プロジェクト削除
+ */
+app.delete('/api/projects/:id', (req, res) => {
+  if (!requireSession(req, res)) return;
+  projects.delete(req.params.id);
+  res.json({ success: true });
+});
+
+// ── Settings Routes ────────────────────────────────────
+
+const settings = new Map<string, Map<string, string>>();
+
+app.get('/api/settings/all', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const projectId = req.query.projectId as string;
+  const projectSettings = settings.get(projectId) ?? new Map();
+  res.json(Object.fromEntries(projectSettings));
+});
+
+app.get('/api/settings', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const projectId = req.query.projectId as string;
+  const key = req.query.key as string;
+  const value = settings.get(projectId)?.get(key) ?? null;
+  res.json(value);
+});
+
+app.post('/api/settings', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const { projectId, key, value } = req.body;
+  if (!settings.has(projectId)) settings.set(projectId, new Map());
+  settings.get(projectId)!.set(key, value);
+  res.json({ success: true });
+});
+
+app.delete('/api/settings', (req, res) => {
+  if (!requireSession(req, res)) return;
+  const { projectId, key } = req.body;
+  settings.get(projectId)?.delete(key);
+  res.json({ success: true });
+});
+
+// ── Start ──────────────────────────────────────────────
+
+const PORT = parseInt(process.env.MOCK_CERNERE_PORT ?? '18080', 10);
+
+app.listen(PORT, () => {
+  console.log(`Mock Cernere server running on http://localhost:${PORT}`);
+});

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -1,0 +1,1618 @@
+{
+  "name": "ars-integration-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ars-integration-tests",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "@types/express": "^5.0.2",
+        "@types/node": "^24.10.1",
+        "express": "^5.1.0",
+        "tsx": "^4.19.0",
+        "typescript": "~5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ars-integration-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "test:report": "playwright show-report",
+    "mock-cernere": "tsx mock-cernere/server.ts"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "express": "^5.1.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.3",
+    "@types/express": "^5.0.2",
+    "@types/node": "^24.10.1"
+  }
+}

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Ars 結合テスト - Playwright 設定
+ *
+ * テストは以下のサーバーを起動して実行する:
+ * 1. Mock Cernere (port 18080) - 認証バイパス用モックサーバー
+ * 2. Ars Web Server (port 15173) - CERNERE_URL をモックに向けて起動
+ */
+export default defineConfig({
+  testDir: './specs',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: 'http://localhost:15173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: [
+    {
+      command: 'npx tsx mock-cernere/server.ts',
+      port: 18080,
+      reuseExistingServer: !process.env.CI,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      command: process.env.ARS_SERVER_CMD
+        ?? '../../ars-editor/src-tauri/target/debug/ars-web-server ../../ars-editor/dist 15173',
+      port: 15173,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        CERNERE_URL: 'http://localhost:18080',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 60_000,
+    },
+  ],
+});

--- a/tests/integration/specs/api-endpoints.spec.ts
+++ b/tests/integration/specs/api-endpoints.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * バックエンド API エンドポイント結合テスト
+ *
+ * Playwright の request context を使って API エンドポイントを直接テスト。
+ * 認証が必要なエンドポイントは ars_session Cookie を付与して呼び出す。
+ */
+
+import { test, expect } from '@playwright/test';
+import { TEST_SESSION_TOKEN } from '../mock-cernere/data.js';
+
+const BASE = 'http://localhost:15173';
+
+function authHeaders(): Record<string, string> {
+  return {
+    Cookie: `ars_session=${TEST_SESSION_TOKEN}`,
+  };
+}
+
+test.describe('API - ローカルプロジェクト', () => {
+  test('GET /api/project/default-path がパスを返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/project/default-path`);
+    expect(res.status()).toBe(200);
+    const path = await res.json();
+    expect(typeof path).toBe('string');
+    expect(path.length).toBeGreaterThan(0);
+  });
+
+  test('GET /api/project/list がリストを返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/project/list`);
+    expect(res.status()).toBe(200);
+    const list = await res.json();
+    expect(Array.isArray(list)).toBe(true);
+  });
+
+  test('POST /api/project/save + GET /api/project/load のラウンドトリップ', async ({ request }) => {
+    // デフォルトパスを取得
+    const pathRes = await request.get(`${BASE}/api/project/default-path`);
+    const defaultPath = await pathRes.json();
+    const savePath = `${defaultPath}/integration-test-project.json`;
+
+    const project = {
+      name: 'Integration Test',
+      scenes: {},
+      components: {},
+      activeSceneId: null,
+    };
+
+    // 保存
+    const saveRes = await request.post(`${BASE}/api/project/save`, {
+      data: { path: savePath, project },
+    });
+    expect(saveRes.status()).toBe(200);
+
+    // 読み込み
+    const loadRes = await request.get(
+      `${BASE}/api/project/load?path=${encodeURIComponent(savePath)}`,
+    );
+    expect(loadRes.status()).toBe(200);
+    const loaded = await loadRes.json();
+    expect(loaded.name).toBe('Integration Test');
+  });
+});
+
+test.describe('API - 認証', () => {
+  test('GET /auth/me が未認証で 401 を返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/auth/me`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('GET /auth/me が認証済みでユーザー情報を返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/auth/me`, {
+      headers: authHeaders(),
+    });
+    expect(res.status()).toBe(200);
+    const user = await res.json();
+    expect(user.login).toBe('test-user');
+    expect(user.displayName).toBe('Test User');
+  });
+
+  test('GET /auth/github/login がリダイレクトを返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/auth/github/login`, {
+      maxRedirects: 0,
+    });
+    // 302 リダイレクト
+    expect([301, 302, 307, 308]).toContain(res.status());
+  });
+
+  test('POST /auth/logout が成功する', async ({ request }) => {
+    const res = await request.post(`${BASE}/auth/logout`, {
+      headers: authHeaders(),
+    });
+    expect(res.status()).toBe(200);
+  });
+});
+
+test.describe('API - クラウドプロジェクト (認証必須)', () => {
+  test('GET /api/cloud/project/list が未認証で 401', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/cloud/project/list`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('GET /api/cloud/project/list が認証済みでリストを返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/cloud/project/list`, {
+      headers: authHeaders(),
+    });
+    expect(res.status()).toBe(200);
+    const list = await res.json();
+    expect(Array.isArray(list)).toBe(true);
+  });
+});
+
+test.describe('API - モジュール管理 (認証必須)', () => {
+  test('GET /api/modules が未認証で 401', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/modules`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('GET /api/modules が認証済みでリストを返す', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/modules`, {
+      headers: authHeaders(),
+    });
+    expect(res.status()).toBe(200);
+    const modules = await res.json();
+    expect(Array.isArray(modules)).toBe(true);
+  });
+});
+
+test.describe('API - WebSocket', () => {
+  test('GET /ws/collab が WebSocket upgrade に応答する', async ({ request }) => {
+    // 通常のHTTPリクエストではWebSocketハンドシェイクは完了しないが
+    // エンドポイントが存在し 4xx 系でないことを確認
+    const res = await request.get(`${BASE}/ws/collab`, {
+      headers: {
+        Upgrade: 'websocket',
+        Connection: 'Upgrade',
+      },
+    });
+    // WebSocket upgrade の場合、通常リクエストでは 400 or UpgradeRequired
+    // エンドポイントが存在すること（404 でない）を確認
+    expect(res.status()).not.toBe(404);
+  });
+});

--- a/tests/integration/specs/auth-flow.spec.ts
+++ b/tests/integration/specs/auth-flow.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * 認証フロー結合テスト
+ *
+ * OAuth ログイン・ログアウトのフロー全体を検証する。
+ * Mock Cernere を介して GitHub OAuth をバイパスし、
+ * Cookie/Token の設定・クリアが正しく行われることを確認する。
+ *
+ * フロー:
+ *   未認証 → Sign In クリック → OAuth popup → Mock Cernere → callback → 認証済��
+ *   認証済み → Logout クリック → 未認証
+ */
+
+import { test, expect } from '@playwright/test';
+import { collectErrors } from '../helpers/console-collector.js';
+import { authenticateContext, openAuthenticated, openUnauthenticated } from '../helpers/auth.js';
+
+test.describe('認証フロー', () => {
+  test('未認証状態で Sign In ボタンが表示される', async ({ page }) => {
+    await openUnauthenticated(page, '/');
+
+    // サインインボタンが表示される
+    const signInButton = page.getByText(/Sign in/i);
+    await expect(signInButton).toBeVisible();
+
+    // ユーザー名は表示されない
+    await expect(page.getByText('Test User')).not.toBeVisible();
+  });
+
+  test('認証済み状態でユーザー情報とログアウトボタンが表示される', async ({ context, page }) => {
+    await authenticateContext(context);
+    await openAuthenticated(page, '/');
+
+    // ユーザー名が表示
+    await expect(page.getByText('Test User')).toBeVisible();
+    // ログアウトボタンが表示
+    await expect(page.getByText(/Logout|ログアウト/i)).toBeVisible();
+    // サインインボタンは非���示
+    await expect(page.getByText(/Sign in with GitHub/i)).not.toBeVisible();
+  });
+
+  test('ログアウトで未認証状態に戻る', async ({ context, page }) => {
+    const errors = collectErrors(page);
+    await authenticateContext(context);
+    await openAuthenticated(page, '/');
+
+    // 認証済み確認
+    await expect(page.getByText('Test User')).toBeVisible();
+
+    // ログアウト
+    const logoutButton = page.getByText(/Logout|ログアウト/i);
+    await logoutButton.click();
+
+    // ログアウト後、サインインボタンが表示される
+    await expect(page.getByText(/Sign in/i)).toBeVisible({ timeout: 5000 });
+    // ユーザー名は消える
+    await expect(page.getByText('Test User')).not.toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('未認証で /settings アクセス → サインインプロンプト → 認証後に設定表示', async ({ context, page }) => {
+    // 未認証でアクセス
+    await openUnauthenticated(page, '/settings');
+    await expect(page.getByText('Sign in to manage project settings')).toBeVisible();
+
+    // 認証状態を注入してリロード
+    await authenticateContext(context);
+    await page.evaluate(() => {
+      localStorage.setItem('accessToken', 'mock-access');
+      localStorage.setItem('refreshToken', 'mock-refresh');
+    });
+    await page.reload({ waitUntil: 'networkidle' });
+
+    // 認証後は Project Settings が表��
+    await expect(page.getByText('Project Settings')).toBeVisible();
+  });
+});
+
+test.describe('認証状態の永続性', () => {
+  test('ページ遷移後も認証状態が維持される', async ({ context, page }) => {
+    await authenticateContext(context);
+    await openAuthenticated(page, '/');
+    await expect(page.getByText('Test User')).toBeVisible();
+
+    // /settings に遷移
+    await page.locator('nav a', { hasText: 'Settings' }).click();
+    await expect(page.getByText('Test User')).toBeVisible();
+
+    // / に戻る
+    await page.locator('nav a', { hasText: 'Editor' }).click();
+    await expect(page.getByText('Test User')).toBeVisible();
+  });
+
+  test('リロード後も認証状態が維持される', async ({ context, page }) => {
+    await authenticateContext(context);
+    await openAuthenticated(page, '/');
+    await expect(page.getByText('Test User')).toBeVisible();
+
+    // リロー��
+    await page.reload({ waitUntil: 'networkidle' });
+    await expect(page.getByText('Test User')).toBeVisible();
+  });
+});

--- a/tests/integration/specs/editor.spec.ts
+++ b/tests/integration/specs/editor.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * エディタページ結合テスト
+ *
+ * エディタページの主要コンポーネントが正しく描画されることを確認する。
+ * ツールバー、キャンバス、パネルの表示を検証する。
+ */
+
+import { test, expect } from '@playwright/test';
+import { collectErrors } from '../helpers/console-collector.js';
+import { openUnauthenticated } from '../helpers/auth.js';
+
+test.describe('Editor ページ', () => {
+  test('ツールバーが表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/');
+
+    // Toolbar コンポーネントの存在確認
+    // Toolbar は EditorPage の最初の子要素
+    const toolbar = page.locator('[data-help-target="nodeCanvas"]').locator('..');
+    await expect(toolbar).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('ノードキャンバスが表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/');
+
+    // NodeCanvas または DomainDiagramCanvas のいずれかが表示
+    const canvas = page.locator('[data-help-target="nodeCanvas"]');
+    await expect(canvas).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('シーンマネージャパネルが表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/');
+
+    // SceneList パネル（デフォルトで表示）
+    const scenePanel = page.locator('[data-help-target="sceneList"]');
+    await expect(scenePanel).toBeVisible();
+
+    // "New Component" ボタンが存在
+    await expect(page.getByText('+ New Component')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('レイアウト全体が画面いっぱいに表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/');
+
+    // メインコンテナが画面サイズ
+    const main = page.locator('.flex.flex-col.h-screen.w-screen');
+    await expect(main).toBeVisible();
+
+    // ナビゲーションバーが上部に存在
+    const nav = page.locator('nav');
+    await expect(nav).toBeVisible();
+    const navBox = await nav.boundingBox();
+    expect(navBox).not.toBeNull();
+    expect(navBox!.y).toBeLessThan(50);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/tests/integration/specs/navigation.spec.ts
+++ b/tests/integration/specs/navigation.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * ナビゲーション結合テスト
+ *
+ * SPA の全遷移パターンを辿り、各ページが正しく描画されることを確認する。
+ *
+ * 遷移マップ:
+ *   / (Editor) ←→ /settings (Settings)
+ *   / (Editor)  → /auth/callback → / (redirect)
+ *   /settings   → / (Editor)
+ *   /settings tabs: General ↔ Members ↔ Google Drive ↔ Resource Depot
+ */
+
+import { test, expect } from '@playwright/test';
+import { collectErrors } from '../helpers/console-collector.js';
+import { authenticateContext, openAuthenticated, openUnauthenticated } from '../helpers/auth.js';
+
+test.describe('ナビゲーション - 未認証', () => {
+  test('/ → /settings → / の往復遷移', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/');
+
+    // Editor ページ確認
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    const editorLink = page.locator('nav a', { hasText: 'Editor' });
+    const settingsLink = page.locator('nav a', { hasText: 'Settings' });
+
+    // / → /settings
+    await settingsLink.click();
+    await expect(page).toHaveURL(/\/settings/);
+    await expect(page.getByText('Sign in to manage project settings')).toBeVisible();
+
+    // /settings → /
+    await editorLink.click();
+    await expect(page).toHaveURL(/\/$/);
+    // Editor コンテンツが再描画される
+    await expect(page.locator('[data-help-target="nodeCanvas"], .flex.flex-col.h-full')).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('ナビゲーションリンクのアクティブ状態が正しく切り替わる', async ({ page }) => {
+    await openUnauthenticated(page, '/');
+
+    const editorLink = page.locator('nav a', { hasText: 'Editor' });
+    const settingsLink = page.locator('nav a', { hasText: 'Settings' });
+
+    // / ではEditorがアクティブ
+    await expect(editorLink).toHaveClass(/bg-zinc-800/);
+    await expect(settingsLink).not.toHaveClass(/bg-zinc-800/);
+
+    // /settings に遷移
+    await settingsLink.click();
+    await expect(page).toHaveURL(/\/settings/);
+
+    // Settings がアクティブ
+    await expect(settingsLink).toHaveClass(/bg-zinc-800/);
+    await expect(editorLink).not.toHaveClass(/bg-zinc-800/);
+  });
+});
+
+test.describe('ナビゲーション - 認証済み', () => {
+  test.beforeEach(async ({ context }) => {
+    await authenticateContext(context);
+  });
+
+  test('/ → /settings → / の往復 (認証済み)', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/');
+
+    // 認証済みユーザーが表示
+    await expect(page.getByText('Test User')).toBeVisible();
+
+    // /settings に遷移
+    await page.locator('nav a', { hasText: 'Settings' }).click();
+    await expect(page).toHaveURL(/\/settings/);
+    // 認証済みなので Project Settings が表示
+    await expect(page.getByText('Project Settings')).toBeVisible();
+
+    // / に戻る
+    await page.locator('nav a', { hasText: 'Editor' }).click();
+    await expect(page).toHaveURL(/\/$/);
+    // Editor が再描画
+    await expect(page.locator('[data-help-target="nodeCanvas"], .flex.flex-col.h-full')).toBeVisible();
+    // 認証状態が維持されている
+    await expect(page.getByText('Test User')).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('Settings タブ間遷移: General → Members → Google Drive → Resource Depot', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/settings');
+
+    // プロジェクトを選択（モックの Test Project）
+    const selector = page.locator('select');
+    await selector.selectOption({ label: 'Test Project' });
+
+    // General タブ (デフォルト)
+    await expect(page.getByText('Save Method')).toBeVisible();
+
+    // Members タブ
+    await page.getByRole('button', { name: 'Members' }).click();
+    await expect(page.getByText('Project Members')).toBeVisible();
+
+    // Google Drive タブ
+    await page.getByRole('button', { name: 'Google Drive' }).click();
+    await expect(page.getByText('Google Drive Integration')).toBeVisible();
+
+    // Resource Depot タブ
+    await page.getByRole('button', { name: 'Resource Depot' }).click();
+    await expect(page.getByText('Resource Depot Connection')).toBeVisible();
+
+    // General に戻る
+    await page.getByRole('button', { name: 'General' }).click();
+    await expect(page.getByText('Save Method')).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('高速な連続遷移でも安定する', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/');
+
+    const editorLink = page.locator('nav a', { hasText: 'Editor' });
+    const settingsLink = page.locator('nav a', { hasText: 'Settings' });
+
+    // 素早く5回往復
+    for (let i = 0; i < 5; i++) {
+      await settingsLink.click();
+      await editorLink.click();
+    }
+
+    // 最終的に Editor ページにいる
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('ナビゲーション - ブラウザ履歴', () => {
+  test('ブラウザの戻る・進むが SPA 遷移と整合する', async ({ page }) => {
+    await openUnauthenticated(page, '/');
+
+    // / → /settings
+    await page.locator('nav a', { hasText: 'Settings' }).click();
+    await expect(page).toHaveURL(/\/settings/);
+
+    // ブラウザの「戻る」
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+
+    // ブラウザの「進む」
+    await page.goForward();
+    await expect(page).toHaveURL(/\/settings/);
+  });
+});

--- a/tests/integration/specs/settings.spec.ts
+++ b/tests/integration/specs/settings.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * 設定ページ結合テスト
+ *
+ * Project Settings ページの各タブコンテンツと
+ * 認証ガードの動作を検証する。
+ */
+
+import { test, expect } from '@playwright/test';
+import { collectErrors } from '../helpers/console-collector.js';
+import { authenticateContext, openAuthenticated, openUnauthenticated } from '../helpers/auth.js';
+
+test.describe('Settings - 認証ガード', () => {
+  test('未認証ではサインインプロンプトのみ表示', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/settings');
+
+    await expect(page.getByText('Sign in to manage project settings')).toBeVisible();
+    // タブやフォームは表示さ��ない
+    await expect(page.getByText('Save Method')).not.toBeVisible();
+    await expect(page.getByText('Project Members')).not.toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('認証済みでは Project Settings UI が表示', async ({ context, page }) => {
+    const errors = collectErrors(page);
+    await authenticateContext(context);
+    await openAuthenticated(page, '/settings');
+
+    await expect(page.getByText('Project Settings')).toBeVisible();
+    // プロジェクトセレクタ
+    await expect(page.locator('select')).toBeVisible();
+    // Save Settings ボタン
+    await expect(page.getByRole('button', { name: 'Save Settings' })).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('Settings - General タブ', () => {
+  test.beforeEach(async ({ context }) => {
+    await authenticateContext(context);
+  });
+
+  test('Save Method の3オプションが表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/settings');
+
+    // プロジェクトを選択
+    await page.locator('select').selectOption({ label: 'Test Project' });
+    await expect(page.getByText('Save Method')).toBeVisible();
+
+    // 3つの保存方法
+    await expect(page.getByText('Local')).toBeVisible();
+    await expect(page.getByText('Cloud')).toBeVisible();
+    await expect(page.getByText('Git')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('Save Method ラジオボタンが切り替えられる', async ({ page }) => {
+    await openAuthenticated(page, '/settings');
+    await page.locator('select').selectOption({ label: 'Test Project' });
+
+    // Cloud を選択
+    const cloudLabel = page.locator('label', { hasText: 'Cloud' });
+    await cloudLabel.click();
+    const cloudRadio = cloudLabel.locator('input[type="radio"]');
+    await expect(cloudRadio).toBeChecked();
+
+    // Git を選択
+    const gitLabel = page.locator('label', { hasText: 'Git' });
+    await gitLabel.click();
+    const gitRadio = gitLabel.locator('input[type="radio"]');
+    await expect(gitRadio).toBeChecked();
+
+    // Cloud は非選択に
+    await expect(cloudRadio).not.toBeChecked();
+  });
+});
+
+test.describe('Settings - Members タブ', () => {
+  test.beforeEach(async ({ context }) => {
+    await authenticateContext(context);
+  });
+
+  test('メンバー追加フォームが表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/settings');
+    await page.locator('select').selectOption({ label: 'Test Project' });
+
+    await page.getByRole('button', { name: 'Members' }).click();
+    await expect(page.getByText('Project Members')).toBeVisible();
+
+    // 追加フォーム
+    await expect(page.getByPlaceholder('GitHub username...')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add' })).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('メンバーを追加・削除できる', async ({ page }) => {
+    await openAuthenticated(page, '/settings');
+    await page.locator('select').selectOption({ label: 'Test Project' });
+    await page.getByRole('button', { name: 'Members' }).click();
+
+    // メンバー��加
+    await page.getByPlaceholder('GitHub username...').fill('new-member');
+    await page.getByRole('button', { name: 'Add' }).click();
+
+    // 追加されたメンバーが表示
+    await expect(page.getByText('new-member')).toBeVisible();
+
+    // メンバー削除
+    const removeButton = page.locator('button', { hasText: 'x' });
+    await removeButton.click();
+    await expect(page.getByText('new-member')).not.toBeVisible();
+  });
+});
+
+test.describe('Settings - Google Drive タブ', () => {
+  test.beforeEach(async ({ context }) => {
+    await authenticateContext(context);
+  });
+
+  test('Google Drive 設定フォームが表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/settings');
+    await page.locator('select').selectOption({ label: 'Test Project' });
+
+    await page.getByRole('button', { name: 'Google Drive' }).click();
+    await expect(page.getByText('Google Drive Integration')).toBeVisible();
+
+    // Enable トグル
+    await expect(page.getByText('Enable Google Drive')).toBeVisible();
+    // 入力フィールド
+    await expect(page.getByText('Folder ID')).toBeVisible();
+    await expect(page.getByText('Folder Name')).toBeVisible();
+    await expect(page.getByText('Auto-sync resources')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('Settings - Resource Depot タブ', () => {
+  test.beforeEach(async ({ context }) => {
+    await authenticateContext(context);
+  });
+
+  test('Resource Depot 設定フォー��が表示される', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/settings');
+    await page.locator('select').selectOption({ label: 'Test Project' });
+
+    await page.getByRole('button', { name: 'Resource Depot' }).click();
+    await expect(page.getByText('Resource Depot Connection')).toBeVisible();
+
+    // Enable トグル
+    await expect(page.getByText('Enable Resource Depot')).toBeVisible();
+    // 入力フィールド
+    await expect(page.getByText('Depot URL')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});

--- a/tests/integration/specs/smoke.spec.ts
+++ b/tests/integration/specs/smoke.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * スモークテスト
+ *
+ * 全ページが致命的エラーなしでロードされることを確認する。
+ * 認証なし・認証ありの両方の状態でテスト。
+ */
+
+import { test, expect } from '@playwright/test';
+import { collectErrors } from '../helpers/console-collector.js';
+import { authenticateContext, openAuthenticated, openUnauthenticated } from '../helpers/auth.js';
+
+test.describe('Smoke Tests - 未認証', () => {
+  test('/ (Editor) がエラーなしでロードされる', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/');
+
+    // ARS ロゴが表示される
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    // Editor ページのコンテンツが存在する
+    await expect(page.locator('[data-help-target="nodeCanvas"], .flex.flex-col.h-full')).toBeVisible();
+    // 致命的エラーなし
+    expect(errors).toEqual([]);
+  });
+
+  test('/settings がエラーなしでロードされる', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openUnauthenticated(page, '/settings');
+
+    // ナビゲーションバーが表示
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    // 未認証時はサインインプロンプト
+    await expect(page.getByText('Sign in to manage project settings')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('/auth/callback が直接アクセスで / にリダイレクトされる', async ({ page }) => {
+    await page.goto('http://localhost:15173/auth/callback');
+    // ポップアップ外からのアクセスは / にリダイレクト
+    await page.waitForURL('http://localhost:15173/');
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+  });
+
+  test('存在しないパスが index.html にフォールバックする (SPA)', async ({ page }) => {
+    const errors = collectErrors(page);
+    await page.goto('http://localhost:15173/nonexistent-path', { waitUntil: 'networkidle' });
+
+    // SPA フォールバックにより AppLayout がレンダリングされる
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('Smoke Tests - 認証済み', () => {
+  test.beforeEach(async ({ context }) => {
+    await authenticateContext(context);
+  });
+
+  test('/ (Editor) が認証済みでロードされる', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/');
+
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    // ユーザー名が表示される
+    await expect(page.getByText('Test User')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
+  test('/settings が認証済みで Project Settings を表示する', async ({ page }) => {
+    const errors = collectErrors(page);
+    await openAuthenticated(page, '/settings');
+
+    await expect(page.locator('nav >> text=ARS')).toBeVisible();
+    // Settings ヘッダーが表示
+    await expect(page.getByText('Project Settings')).toBeVisible();
+    // プロジェクトセレクタが存在
+    await expect(page.locator('select')).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+});

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Design a comprehensive integration test suite that traverses all SPA
transitions while bypassing OAuth authentication and Infisical secrets.

Architecture:
- Mock Cernere server (Express) replaces real auth backend at port 18080
- Cookie injection (ars_session) + localStorage tokens bypass OAuth flow
- Setup wizard auto-bypassed (no /api/setup routes → catch → needsSetup=false)
- Playwright drives Chromium through all page transitions

Test coverage:
- Smoke: all pages load without console errors (auth/unauth)
- Navigation: / ↔ /settings, browser history, rapid transitions
- Auth flow: login/logout, auth guards, session persistence
- Editor: toolbar, canvas, panels render correctly
- Settings: all 4 tabs (General/Members/GoogleDrive/ResourceDepot)
- API: local project CRUD, auth endpoints, cloud/module auth guards

CI: GitHub Actions workflow with org secrets (INFISICAL_CLIENT_ID/SECRET)
and repo secrets (PROJECT_ID/HOST/ENVIRONMENT) for future Docker E2E.

https://claude.ai/code/session_01GnRKreZAx9zavv7R2GZEYw