### PR TITLE
feat: 統合テスト自動修正エージェントを追加

### DIFF
--- a/.claude/agents/integration-test.md
+++ b/.claude/agents/integration-test.md
@@ -1,0 +1,91 @@
+---
+model: sonnet
+---
+
+# Integration Test Agent
+
+統合テストを実行し、エラーがあれば自動修正してPRを発行するエージェント。
+
+## 動作フロー
+
+### Phase 1: 初回テスト実行
+
+1. 現在のブランチと状態を確認 (`git status`, `git branch --show-current`)
+2. 以下の統合テストを順番に実行する:
+
+**Frontend (ars-editor/):**
+```bash
+cd ars-editor && npm ci --ignore-scripts && npm run lint && npx tsc -b && npm run build
+```
+
+**Rust Backend (ars-editor/src-tauri/):**
+```bash
+cd ars-editor/src-tauri && cargo clippy --features web-server --no-default-features --bin ars-web-server -- -D warnings && cargo test
+```
+
+3. **全テスト成功 → 終了。** 「統合テスト: 全項目パス」と報告する。
+
+### Phase 2: エラー修正 + PR
+
+テストにエラーがある場合:
+
+1. エラー内容を解析し、修正を実施する
+2. fix ブランチを作成する:
+   ```bash
+   git checkout -b fix/integration-test-$(date +%Y%m%d-%H%M%S)
+   ```
+3. 修正をコミットする:
+   ```bash
+   git add <修正ファイル>
+   git commit -m "fix: 統合テストエラーを修正 (<エラー概要>)"
+   ```
+4. push してPRを発行する:
+   ```bash
+   git push -u origin HEAD
+   gh pr create --title "fix: 統合テストエラー修正" \
+     --body "## 修正内容\n<修正概要>\n\n## テスト結果\n<テスト結果>" \
+     --label "Test"
+   ```
+5. PRのCI完了を待機する:
+   ```bash
+   gh pr checks --watch
+   ```
+
+### Phase 3: CI結果の監視とリトライ
+
+CI結果を確認し、以下のルールで繰り返す:
+
+- **CIが成功** → 終了。PRのURLを報告する。
+- **CIが失敗** → エラーを修正し、新しいコミットをpush。再度CI完了を待機。
+- **同一エラーが3回連続** → 「自動修正不可」として終了。エラー内容を報告する。
+- **修正回数が15回に達した** → 「修正上限到達」として終了。
+
+### リトライ管理
+
+以下の変数を追跡する:
+- `attempt_count`: 修正試行回数 (初期値: 0, 上限: 15)
+- `last_error`: 直前のエラーメッセージ
+- `same_error_count`: 同一エラーの連続回数 (初期値: 0, 上限: 3)
+
+エラーが前回と同一かどうかは、エラーメッセージの先頭100文字で比較する。
+
+## 終了時レポート
+
+```
+## 統合テスト結果
+
+| 項目 | 結果 |
+|------|------|
+| ステータス | 成功 / 失敗 (自動修正不可) / 失敗 (上限到達) |
+| 修正回数 | N回 |
+| PR | <PR URL> (あれば) |
+| 残存エラー | <あれば記載> |
+```
+
+## 注意事項
+
+- 修正は最小限にとどめる。関係ないコードに触れない。
+- lint エラーの修正時、既存のコードスタイルに合わせる。
+- Rust の修正では `unwrap()` を使わない。
+- TypeScript の修正では `any` 型を使わない。
+- テスト自体の削除やスキップは行わない。

--- a/.claude/commands/integration_test.md
+++ b/.claude/commands/integration_test.md
@@ -1,0 +1,17 @@
+統合テストを実行し、エラーがあれば自動修正します。
+
+## 実行内容
+
+`integration-test` エージェント (Sonnet) を起動して以下を実行:
+
+1. Frontend (lint + tsc + build) と Rust Backend (clippy + test) の統合テスト
+2. エラーがなければ完了
+3. エラーがあれば fix ブランチを作成し、修正コミット → push → PR発行 (Test ラベル付き)
+4. CI完了を待機し、失敗なら再修正 (同一エラー3回 or 15回で打ち切り)
+
+## エージェント起動
+
+このコマンドは `integration-test` エージェントを起動します。
+エージェントの定義: `.claude/agents/integration-test.md`
+
+$ARGUMENTS

--- a/.claude/skills/integration-test.md
+++ b/.claude/skills/integration-test.md
@@ -1,0 +1,29 @@
+# 統合テストスキル
+
+Ars プロジェクトの統合テストを実行し、エラーを自動修正するスキル。
+
+## 起動方法
+
+- `/integration_test` コマンド
+- 「統合テスト」と入力
+
+## テスト対象
+
+| セクション | コマンド | 対象 |
+|-----------|---------|------|
+| Frontend | `cd ars-editor && npm run lint && npx tsc -b && npm run build` | ESLint + TypeScript + Vite ビルド |
+| Rust Backend | `cd ars-editor/src-tauri && cargo clippy --features web-server --no-default-features --bin ars-web-server -- -D warnings && cargo test` | Clippy + ユニットテスト |
+
+## 自動修正フロー
+
+1. テスト実行
+2. エラーあり → `fix/integration-test-YYYYMMDD-HHMMSS` ブランチ作成
+3. 修正コミット → push → PR 発行 (`Test` ラベル)
+4. CI 待機 → 失敗なら再修正
+5. 終了条件: 成功 / 同一エラー 3 回 / 修正 15 回到達
+
+## エージェント
+
+- 定義: `.claude/agents/integration-test.md`
+- モデル: Sonnet
+- 最小修正のみ。テストの削除・スキップは禁止。


### PR DESCRIPTION
## Summary
- `.claude/agents/integration-test.md` — Sonnet エージェント (テスト実行→修正→PR→CI待機→リトライ)
- `.claude/commands/integration_test.md` — `/integration_test` コマンド
- `.claude/skills/integration-test.md` — スキル定義

## 動作
1. Frontend (lint + tsc + build) と Rust Backend (clippy + test) を実行
2. エラーあれば fix ブランチ作成 → 修正 → PR発行 (Test ラベル)
3. CI待機 → 失敗なら再修正 (同一エラー3回 or 15回で打ち切り)

## Test plan
- [ ] `/integration_test` コマンドで起動確認
- [ ] エラーなし時に正常終了することを確認
- [ ] エラーあり時に fix ブランチ + PR が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)