### PR TITLE
feat: 組織プロファイル管理 — Cernere/Infisical を組織ごとに切り替え

### DIFF
--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ required-features = ["web-server"]
 [dependencies]
 # Ars core crates
 ars-core = { path = "../../crates/ars-core" }
+ars-secrets = { path = "../../crates/ars-secrets" }
 ars-project = { path = "../../crates/ars-project" }
 # ars-secrets: removed — secrets management moved to Cernere server
 # Common

--- a/ars-editor/src-tauri/src/app_state.rs
+++ b/ars-editor/src-tauri/src/app_state.rs
@@ -1,19 +1,55 @@
+use ars_secrets::profile::{ProfileConfig, ProfileManager};
+
 use crate::cernere_client::CernereClient;
 
 #[derive(Clone)]
 pub struct AppState {
     pub cernere: CernereClient,
+    pub profile_name: String,
 }
 
 impl AppState {
-    /// Initialize with Cernere server URL.
+    /// プロファイルから初期化。
     ///
-    /// The URL is read from `CERNERE_URL` env var, defaulting to `http://localhost:8080`.
+    /// 解決順序:
+    /// 1. 環境変数 `ARS_PROFILE` で指定されたプロファイル
+    /// 2. `~/.config/ars/active_profile` に記録されたアクティブプロファイル
+    /// 3. 環境変数 `CERNERE_URL` (レガシー互換)
+    /// 4. デフォルト (localhost:8080)
     pub fn new() -> Self {
+        let manager = ProfileManager::new();
+
+        // 1. 環境変数で指定されたプロファイル
+        if let Ok(profile_name) = std::env::var("ARS_PROFILE") {
+            if let Ok(config) = manager.load(&profile_name) {
+                log::info!("Using profile '{}' ({})", profile_name, config.name);
+                return Self::from_profile(&profile_name, &config);
+            }
+            log::warn!("Profile '{}' not found, falling back", profile_name);
+        }
+
+        // 2. アクティブプロファイル
+        if let Ok(config) = manager.load_active() {
+            let name = manager.active_name().unwrap_or_default();
+            log::info!("Using active profile '{}' ({})", name, config.name);
+            return Self::from_profile(&name, &config);
+        }
+
+        // 3. レガシー: CERNERE_URL 環境変数
         let cernere_url = std::env::var("CERNERE_URL")
             .unwrap_or_else(|_| "http://localhost:8080".to_string());
+        log::info!("No profile found, using CERNERE_URL={}", cernere_url);
+
         Self {
             cernere: CernereClient::new(&cernere_url),
+            profile_name: "default".to_string(),
+        }
+    }
+
+    fn from_profile(name: &str, config: &ProfileConfig) -> Self {
+        Self {
+            cernere: CernereClient::new(&config.cernere.url),
+            profile_name: name.to_string(),
         }
     }
 }

--- a/crates/ars-secrets/src/lib.rs
+++ b/crates/ars-secrets/src/lib.rs
@@ -30,6 +30,7 @@ pub mod cache;
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod profile;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -37,6 +38,7 @@ use std::sync::Arc;
 use crate::cache::SecretCache;
 use crate::client::InfisicalClient;
 pub use crate::config::{InfisicalConfig, SecretsConfig, SecretsProvider};
+pub use crate::profile::{ProfileConfig, ProfileManager, CernereConfig};
 use crate::error::SecretsError;
 
 /// Scope for secret retrieval.

--- a/crates/ars-secrets/src/profile.rs
+++ b/crates/ars-secrets/src/profile.rs
@@ -1,0 +1,232 @@
+//! 組織プロファイル管理
+//!
+//! 組織ごとに Cernere URL や Infisical 設定を切り替えるための仕組み。
+//!
+//! ```
+//! ~/.config/ars/
+//! ├── active_profile        # 現在選択中のプロファイル名
+//! └── profiles/
+//!     ├── ludiars.toml
+//!     ├── client-a.toml
+//!     └── local.toml
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::InfisicalConfig;
+use crate::error::SecretsError;
+
+// ── Profile config ───────────────────────────────────────────
+
+/// 組織プロファイル設定
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProfileConfig {
+    /// プロファイル表示名
+    pub name: String,
+
+    /// Cernere 接続設定
+    pub cernere: CernereConfig,
+
+    /// シークレット管理設定
+    #[serde(default)]
+    pub secrets: SecretsSection,
+}
+
+/// Cernere サーバー接続設定
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CernereConfig {
+    /// Cernere サーバー URL
+    pub url: String,
+}
+
+/// シークレット管理設定
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SecretsSection {
+    /// プロバイダー: "infisical" | "none"
+    #[serde(default = "default_provider")]
+    pub provider: String,
+
+    /// Infisical 設定 (provider = "infisical" 時のみ使用)
+    #[serde(default)]
+    pub infisical: Option<InfisicalConfig>,
+}
+
+impl Default for SecretsSection {
+    fn default() -> Self {
+        Self {
+            provider: "none".to_string(),
+            infisical: None,
+        }
+    }
+}
+
+fn default_provider() -> String {
+    "none".to_string()
+}
+
+// ── Profile manager ──────────────────────────────────────────
+
+/// プロファイルの読み込み・切り替えを管理
+pub struct ProfileManager {
+    profiles_dir: PathBuf,
+    active_profile_path: PathBuf,
+}
+
+impl ProfileManager {
+    /// デフォルトのプロファイルディレクトリで初期化
+    pub fn new() -> Self {
+        let base = config_dir().join("ars");
+        Self {
+            profiles_dir: base.join("profiles"),
+            active_profile_path: base.join("active_profile"),
+        }
+    }
+
+    /// カスタムディレクトリで初期化
+    pub fn with_dir(base: &Path) -> Self {
+        Self {
+            profiles_dir: base.join("profiles"),
+            active_profile_path: base.join("active_profile"),
+        }
+    }
+
+    /// 利用可能なプロファイル名一覧
+    pub fn list(&self) -> Vec<String> {
+        let mut profiles = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&self.profiles_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().map(|e| e == "toml").unwrap_or(false) {
+                    if let Some(stem) = path.file_stem() {
+                        profiles.push(stem.to_string_lossy().to_string());
+                    }
+                }
+            }
+        }
+        profiles.sort();
+        profiles
+    }
+
+    /// 現在アクティブなプロファイル名を取得
+    pub fn active_name(&self) -> Option<String> {
+        std::fs::read_to_string(&self.active_profile_path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+
+    /// アクティブなプロファイルを切り替え
+    pub fn set_active(&self, name: &str) -> Result<(), SecretsError> {
+        // プロファイルが存在するか確認
+        let path = self.profile_path(name);
+        if !path.exists() {
+            return Err(SecretsError::ConfigNotFound(path));
+        }
+        if let Some(parent) = self.active_profile_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&self.active_profile_path, name)?;
+        log::info!("Active profile set to: {}", name);
+        Ok(())
+    }
+
+    /// プロファイルを読み込む
+    pub fn load(&self, name: &str) -> Result<ProfileConfig, SecretsError> {
+        let path = self.profile_path(name);
+        if !path.exists() {
+            return Err(SecretsError::ConfigNotFound(path));
+        }
+        let content = std::fs::read_to_string(&path)?;
+        let config: ProfileConfig = toml::from_str(&content)
+            .map_err(|e| SecretsError::Io(std::io::Error::other(e.to_string())))?;
+        Ok(config)
+    }
+
+    /// アクティブなプロファイルを読み込む
+    pub fn load_active(&self) -> Result<ProfileConfig, SecretsError> {
+        let name = self.active_name().ok_or_else(|| {
+            SecretsError::ConfigNotFound(self.active_profile_path.clone())
+        })?;
+        self.load(&name)
+    }
+
+    /// アクティブなプロファイルを読み込む。未設定の場合はデフォルトを返す。
+    pub fn load_active_or_default(&self) -> ProfileConfig {
+        match self.load_active() {
+            Ok(config) => config,
+            Err(_) => {
+                log::info!("No active profile found, using default (local)");
+                ProfileConfig {
+                    name: "local".to_string(),
+                    cernere: CernereConfig {
+                        url: "http://localhost:8080".to_string(),
+                    },
+                    secrets: SecretsSection::default(),
+                }
+            }
+        }
+    }
+
+    /// プロファイルを保存
+    pub fn save(&self, name: &str, config: &ProfileConfig) -> Result<(), SecretsError> {
+        let path = self.profile_path(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(config)
+            .map_err(|e| SecretsError::Io(std::io::Error::other(e.to_string())))?;
+        std::fs::write(&path, content)?;
+        log::info!("Profile saved: {} ({})", name, path.display());
+        Ok(())
+    }
+
+    /// プロファイルを削除
+    pub fn delete(&self, name: &str) -> Result<(), SecretsError> {
+        let path = self.profile_path(name);
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        // アクティブプロファイルだった場合はクリア
+        if self.active_name().as_deref() == Some(name) {
+            let _ = std::fs::remove_file(&self.active_profile_path);
+        }
+        Ok(())
+    }
+
+    fn profile_path(&self, name: &str) -> PathBuf {
+        self.profiles_dir.join(format!("{}.toml", name))
+    }
+}
+
+impl Default for ProfileManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+fn config_dir() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var("APPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        PathBuf::from(home).join(".config")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                PathBuf::from(home).join(".config")
+            })
+    }
+}

--- a/profiles/local.toml.example
+++ b/profiles/local.toml.example
@@ -1,0 +1,10 @@
+# ローカル開発用プロファイル
+# コピー先: ~/.config/ars/profiles/local.toml
+
+name = "ローカル開発"
+
+[cernere]
+url = "http://localhost:8080"
+
+[secrets]
+provider = "none"

--- a/profiles/organization.toml.example
+++ b/profiles/organization.toml.example
@@ -1,0 +1,17 @@
+# 組織プロファイルのテンプレート
+# コピー先: ~/.config/ars/profiles/<org-name>.toml
+
+name = "My Organization"
+
+[cernere]
+url = "https://cernere.example.com"
+
+[secrets]
+provider = "infisical"
+
+[secrets.infisical]
+host = "https://app.infisical.com"
+client_id = ""
+client_secret = ""
+project_id = ""
+environment = "dev"


### PR DESCRIPTION
## Summary
組織ごとに Cernere サーバーと Infisical の接続先を切り替えるプロファイル機能を追加。

## 使い方

```bash
# プロファイルを配置
cp profiles/local.toml.example ~/.config/ars/profiles/local.toml
cp profiles/organization.toml.example ~/.config/ars/profiles/ludiars.toml

# アクティブプロファイルを設定
echo "ludiars" > ~/.config/ars/active_profile

# または環境変数で指定
ARS_PROFILE=ludiars npx tauri dev
```

## 解決順序
1. `ARS_PROFILE` 環境変数
2. `~/.config/ars/active_profile` ファイル
3. `CERNERE_URL` 環境変数 (レガシー互換)
4. デフォルト (`http://localhost:8080`)

## Changes
- `crates/ars-secrets/src/profile.rs` — ProfileConfig / ProfileManager (list/load/save/delete/set_active)
- `ars-editor/src-tauri/src/app_state.rs` — プロファイル対応に書き換え
- `ars-editor/src-tauri/Cargo.toml` — ars-secrets 依存を復活
- `profiles/*.toml.example` — テンプレート

## Test plan
- [ ] プロファイルなしで起動 → localhost:8080 に接続
- [ ] `ARS_PROFILE=local` で起動 → local.toml の URL に接続
- [ ] active_profile 設定で起動 → 該当プロファイルの URL に接続
- [ ] 存在しないプロファイル指定 → フォールバックで起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)