### PR TITLE
feat: UIビューを実装 — uGUI風キャンバスレイアウトエディタ

### DIFF
--- a/ars-editor/src/features/editor-page/index.tsx
+++ b/ars-editor/src/features/editor-page/index.tsx
@@ -21,6 +21,7 @@ import { useAutoSave } from '@/hooks/useAutoSave';
 import { StatusBar } from '@/components/StatusBar';
 import { ViewTabs } from '@/components/ViewTabs';
 import { ActionListView } from '@/features/action-editor/ActionListView';
+import { UIViewLayout } from '@/features/ui-view';
 import { safeLoadProject, getLastProjectPath } from '@/lib/project-loader';
 
 export function EditorPage() {
@@ -151,11 +152,7 @@ export function EditorPage() {
           </div>
         );
       case 'ui':
-        return (
-          <div className="flex-1 flex items-center justify-center" style={{ color: 'var(--text-muted)' }}>
-            UI ビュー (準備中)
-          </div>
-        );
+        return <UIViewLayout />;
     }
   };
 

--- a/ars-editor/src/features/ui-view/components/UICanvas.tsx
+++ b/ars-editor/src/features/ui-view/components/UICanvas.tsx
@@ -1,0 +1,611 @@
+import { useCallback, useEffect, useRef, useState, memo } from 'react';
+import { useUIViewStore } from '../uiViewStore';
+import { useProjectStore } from '@/stores/projectStore';
+import type { UIElement, UICanvasData, RectTransform, ResizeHandle, Vec2 } from '../types';
+import { getAbsolutePosition } from '../types';
+
+// ── Drag state (kept in ref for performance) ────────
+
+type DragMode =
+  | { type: 'move'; elementId: string; startX: number; startY: number; origX: number; origY: number }
+  | { type: 'resize'; elementId: string; handle: ResizeHandle; startX: number; startY: number; origRect: RectTransform }
+  | { type: 'pan'; startX: number; startY: number; origPanX: number; origPanY: number };
+
+const MIN_SIZE = 20;
+
+// ── Element rendering ───────────────────────────────
+
+function renderElementVisual(element: UIElement) {
+  const { type, props } = element;
+
+  switch (type) {
+    case 'Panel':
+      return (
+        <div
+          className="absolute inset-0 overflow-hidden"
+          style={{
+            backgroundColor: props.backgroundColor ?? 'rgba(30, 41, 59, 0.8)',
+            borderRadius: props.borderRadius ?? 0,
+            border: props.borderWidth
+              ? `${props.borderWidth}px solid ${props.borderColor ?? 'rgba(255,255,255,0.2)'}`
+              : undefined,
+            opacity: props.opacity ?? 1,
+          }}
+        />
+      );
+    case 'Text':
+      return (
+        <div
+          className="absolute inset-0 flex items-center px-1 overflow-hidden"
+          style={{
+            justifyContent:
+              props.textAlign === 'left'
+                ? 'flex-start'
+                : props.textAlign === 'right'
+                  ? 'flex-end'
+                  : 'center',
+            fontSize: props.fontSize ?? 16,
+            color: props.fontColor ?? '#e6edf3',
+            fontWeight: props.fontWeight ?? 'normal',
+            opacity: props.opacity ?? 1,
+          }}
+        >
+          <span className="whitespace-pre-wrap leading-tight">{props.text ?? 'Text'}</span>
+        </div>
+      );
+    case 'Image':
+      return (
+        <div
+          className="absolute inset-0 flex items-center justify-center overflow-hidden"
+          style={{
+            backgroundColor: props.backgroundColor ?? 'rgba(100, 116, 139, 0.3)',
+            borderRadius: props.borderRadius ?? 0,
+            opacity: props.opacity ?? 1,
+          }}
+        >
+          {props.imageUrl ? (
+            <img
+              src={props.imageUrl}
+              alt=""
+              className="max-w-full max-h-full"
+              style={{ objectFit: props.imageFit ?? 'contain' }}
+            />
+          ) : (
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.3)" strokeWidth="1.5">
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <circle cx="8.5" cy="8.5" r="1.5" />
+              <path d="M21 15l-5-5L5 21" />
+            </svg>
+          )}
+        </div>
+      );
+    case 'Button':
+      return (
+        <div
+          className="absolute inset-0 flex items-center justify-center overflow-hidden cursor-pointer"
+          style={{
+            backgroundColor: props.buttonColor ?? '#3b82f6',
+            borderRadius: props.borderRadius ?? 6,
+            color: props.textColor ?? '#ffffff',
+            fontSize: props.fontSize ?? 14,
+            fontWeight: 'bold',
+            opacity: props.opacity ?? 1,
+          }}
+        >
+          {props.label ?? 'Button'}
+        </div>
+      );
+    default:
+      return null;
+  }
+}
+
+// ── Resize handles ──────────────────────────────────
+
+const HANDLE_POSITIONS: { handle: ResizeHandle; style: React.CSSProperties; cursor: string }[] = [
+  { handle: 'nw', style: { top: -4, left: -4 }, cursor: 'nwse-resize' },
+  { handle: 'n', style: { top: -4, left: '50%', marginLeft: -4 }, cursor: 'ns-resize' },
+  { handle: 'ne', style: { top: -4, right: -4 }, cursor: 'nesw-resize' },
+  { handle: 'e', style: { top: '50%', right: -4, marginTop: -4 }, cursor: 'ew-resize' },
+  { handle: 'se', style: { bottom: -4, right: -4 }, cursor: 'nwse-resize' },
+  { handle: 's', style: { bottom: -4, left: '50%', marginLeft: -4 }, cursor: 'ns-resize' },
+  { handle: 'sw', style: { bottom: -4, left: -4 }, cursor: 'nesw-resize' },
+  { handle: 'w', style: { top: '50%', left: -4, marginTop: -4 }, cursor: 'ew-resize' },
+];
+
+// ── Canvas Element (recursive) ──────────────────────
+
+const CanvasElement = memo(function CanvasElement({
+  element,
+  canvas,
+  onStartDrag,
+}: {
+  element: UIElement;
+  canvas: UICanvasData;
+  onStartDrag: (elementId: string, e: React.MouseEvent) => void;
+}) {
+  const selectedId = useUIViewStore((s) => s.selectedElementId);
+  const hoveredId = useUIViewStore((s) => s.hoveredElementId);
+  const selectElement = useUIViewStore((s) => s.selectElement);
+  const setHovered = useUIViewStore((s) => s.setHovered);
+
+  const isSelected = selectedId === element.id;
+  const isHovered = hoveredId === element.id;
+
+  if (!element.visible) return null;
+
+  return (
+    <div
+      data-ui-element={element.id}
+      style={{
+        position: 'absolute',
+        left: element.rect.x,
+        top: element.rect.y,
+        width: element.rect.width,
+        height: element.rect.height,
+        transform: element.rect.rotation ? `rotate(${element.rect.rotation}deg)` : undefined,
+      }}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        selectElement(element.id);
+        onStartDrag(element.id, e);
+      }}
+      onMouseEnter={() => setHovered(element.id)}
+      onMouseLeave={() => setHovered(null)}
+    >
+      {renderElementVisual(element)}
+
+      {/* Hover outline */}
+      {isHovered && !isSelected && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{ border: '1px solid var(--accent)', opacity: 0.5 }}
+        />
+      )}
+
+      {/* Children */}
+      {element.childIds.map((childId) => {
+        const child = canvas.elements[childId];
+        if (!child) return null;
+        return (
+          <CanvasElement
+            key={childId}
+            element={child}
+            canvas={canvas}
+            onStartDrag={onStartDrag}
+          />
+        );
+      })}
+    </div>
+  );
+});
+
+// ── Selection overlay ───────────────────────────────
+
+function SelectionOverlay({
+  elementId,
+  canvas,
+  zoom,
+  panOffset,
+  onStartResize,
+}: {
+  elementId: string;
+  canvas: UICanvasData;
+  zoom: number;
+  panOffset: Vec2;
+  onStartResize: (elementId: string, handle: ResizeHandle, e: React.MouseEvent) => void;
+}) {
+  const element = canvas.elements[elementId];
+  if (!element) return null;
+
+  const abs = getAbsolutePosition(elementId, canvas.elements);
+  const x = abs.x * zoom + panOffset.x;
+  const y = abs.y * zoom + panOffset.y;
+  const w = element.rect.width * zoom;
+  const h = element.rect.height * zoom;
+
+  return (
+    <div
+      className="pointer-events-none absolute"
+      style={{
+        left: x,
+        top: y,
+        width: w,
+        height: h,
+        border: '2px solid var(--accent)',
+        zIndex: 999,
+      }}
+    >
+      {/* Element name label */}
+      <div
+        className="absolute text-xs px-1 whitespace-nowrap pointer-events-none"
+        style={{
+          top: -20,
+          left: 0,
+          color: 'var(--accent)',
+          fontSize: 11,
+        }}
+      >
+        {element.name}
+      </div>
+
+      {/* Resize handles */}
+      {HANDLE_POSITIONS.map(({ handle, style, cursor }) => (
+        <div
+          key={handle}
+          className="absolute pointer-events-auto"
+          style={{
+            ...style,
+            width: 8,
+            height: 8,
+            backgroundColor: 'var(--accent)',
+            border: '1px solid var(--bg)',
+            cursor,
+            zIndex: 1000,
+          }}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            onStartResize(elementId, handle, e);
+          }}
+        />
+      ))}
+
+      {/* Size label */}
+      <div
+        className="absolute text-xs px-1 whitespace-nowrap pointer-events-none"
+        style={{
+          bottom: -18,
+          right: 0,
+          color: 'var(--text-muted)',
+          fontSize: 10,
+        }}
+      >
+        {Math.round(element.rect.width)} x {Math.round(element.rect.height)}
+      </div>
+    </div>
+  );
+}
+
+// ── Main Canvas ─────────────────────────────────────
+
+export function UICanvas() {
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const sceneId = activeSceneId ?? '';
+
+  const canvas = useUIViewStore((s) => s.getCanvas(sceneId));
+  const selectedId = useUIViewStore((s) => s.selectedElementId);
+  const zoom = useUIViewStore((s) => s.zoom);
+  const panOffset = useUIViewStore((s) => s.panOffset);
+  const selectElement = useUIViewStore((s) => s.selectElement);
+  const updateRect = useUIViewStore((s) => s.updateRect);
+  const setZoom = useUIViewStore((s) => s.setZoom);
+  const setPan = useUIViewStore((s) => s.setPan);
+
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<DragMode | null>(null);
+  const zoomRef = useRef(zoom);
+  const panRef = useRef(panOffset);
+  zoomRef.current = zoom;
+  panRef.current = panOffset;
+
+  // Refs for store actions (stable across renders)
+  const updateRectRef = useRef(updateRect);
+  const setPanRef = useRef(setPan);
+  updateRectRef.current = updateRect;
+  setPanRef.current = setPan;
+
+  const sceneIdRef = useRef(sceneId);
+  sceneIdRef.current = sceneId;
+
+  const canvasRef = useRef(canvas);
+  canvasRef.current = canvas;
+
+  // ── Fit canvas to viewport on mount ────────────
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (initialized || !viewportRef.current) return;
+    const vp = viewportRef.current.getBoundingClientRect();
+    const fitZoom = Math.min(
+      (vp.width - 80) / canvas.width,
+      (vp.height - 80) / canvas.height,
+      1,
+    );
+    const z = Math.max(0.1, fitZoom);
+    setZoom(z);
+    setPan({
+      x: (vp.width - canvas.width * z) / 2,
+      y: (vp.height - canvas.height * z) / 2,
+    });
+    setInitialized(true);
+  }, [initialized, canvas.width, canvas.height, setZoom, setPan]);
+
+  // ── Mouse drag handlers ────────────────────────
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+
+      const z = zoomRef.current;
+
+      if (drag.type === 'move') {
+        const dx = (e.clientX - drag.startX) / z;
+        const dy = (e.clientY - drag.startY) / z;
+        updateRectRef.current(sceneIdRef.current, drag.elementId, {
+          x: Math.round(drag.origX + dx),
+          y: Math.round(drag.origY + dy),
+        });
+      } else if (drag.type === 'resize') {
+        const dx = (e.clientX - drag.startX) / z;
+        const dy = (e.clientY - drag.startY) / z;
+        const r = drag.origRect;
+        const updates: Partial<RectTransform> = {};
+
+        const h = drag.handle;
+        if (h.includes('w')) {
+          const newW = Math.max(MIN_SIZE, r.width - dx);
+          updates.x = r.x + (r.width - newW);
+          updates.width = newW;
+        }
+        if (h.includes('e')) {
+          updates.width = Math.max(MIN_SIZE, r.width + dx);
+        }
+        if (h.includes('n')) {
+          const newH = Math.max(MIN_SIZE, r.height - dy);
+          updates.y = r.y + (r.height - newH);
+          updates.height = newH;
+        }
+        if (h.includes('s')) {
+          updates.height = Math.max(MIN_SIZE, r.height + dy);
+        }
+
+        // Round values
+        for (const k of Object.keys(updates) as (keyof typeof updates)[]) {
+          (updates as Record<string, number>)[k] = Math.round(updates[k] as number);
+        }
+
+        updateRectRef.current(sceneIdRef.current, drag.elementId, updates);
+      } else if (drag.type === 'pan') {
+        setPanRef.current({
+          x: drag.origPanX + (e.clientX - drag.startX),
+          y: drag.origPanY + (e.clientY - drag.startY),
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      dragRef.current = null;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, []);
+
+  // ── Zoom with wheel ────────────────────────────
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      e.preventDefault();
+      const rect = viewportRef.current?.getBoundingClientRect();
+      if (!rect) return;
+
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+
+      const delta = -e.deltaY * 0.001;
+      const newZoom = Math.max(0.1, Math.min(3, zoom + delta));
+      const scale = newZoom / zoom;
+
+      setPan({
+        x: mouseX - (mouseX - panOffset.x) * scale,
+        y: mouseY - (mouseY - panOffset.y) * scale,
+      });
+      setZoom(newZoom);
+    },
+    [zoom, panOffset, setZoom, setPan],
+  );
+
+  // ── Start element move drag ────────────────────
+
+  const handleStartDrag = useCallback(
+    (elementId: string, e: React.MouseEvent) => {
+      const el = canvas.elements[elementId];
+      if (!el) return;
+      dragRef.current = {
+        type: 'move',
+        elementId,
+        startX: e.clientX,
+        startY: e.clientY,
+        origX: el.rect.x,
+        origY: el.rect.y,
+      };
+      document.body.style.cursor = 'move';
+      document.body.style.userSelect = 'none';
+    },
+    [canvas.elements],
+  );
+
+  // ── Start resize drag ─────────────────────────
+
+  const handleStartResize = useCallback(
+    (elementId: string, handle: ResizeHandle, e: React.MouseEvent) => {
+      const el = canvas.elements[elementId];
+      if (!el) return;
+      dragRef.current = {
+        type: 'resize',
+        elementId,
+        handle,
+        startX: e.clientX,
+        startY: e.clientY,
+        origRect: { ...el.rect },
+      };
+      document.body.style.userSelect = 'none';
+    },
+    [canvas.elements],
+  );
+
+  // ── Background click: deselect or pan ──────────
+
+  const handleViewportMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Only handle left/middle clicks on the viewport itself
+      if (e.target !== e.currentTarget && !(e.target as HTMLElement).dataset.canvasBg) return;
+
+      if (e.button === 1 || e.button === 0) {
+        // Left click on background → deselect + start pan
+        if (e.button === 0) selectElement(null);
+
+        dragRef.current = {
+          type: 'pan',
+          startX: e.clientX,
+          startY: e.clientY,
+          origPanX: panOffset.x,
+          origPanY: panOffset.y,
+        };
+        document.body.style.cursor = 'grabbing';
+        document.body.style.userSelect = 'none';
+      }
+    },
+    [selectElement, panOffset],
+  );
+
+  // ── Delete key ─────────────────────────────────
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        const target = e.target as HTMLElement;
+        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+        const sel = useUIViewStore.getState().selectedElementId;
+        if (sel) {
+          useUIViewStore.getState().removeElement(sceneIdRef.current, sel);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  if (!activeSceneId) {
+    return (
+      <div
+        className="flex-1 flex items-center justify-center"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        Select a scene to edit UI layout
+      </div>
+    );
+  }
+
+  // Grid line spacing (in canvas pixels)
+  const gridSize = 50;
+  const gridColor = 'rgba(255,255,255,0.04)';
+
+  return (
+    <div
+      ref={viewportRef}
+      className="flex-1 overflow-hidden relative"
+      style={{ background: '#0a0a12', cursor: dragRef.current?.type === 'pan' ? 'grabbing' : 'default' }}
+      onWheel={handleWheel}
+      onMouseDown={handleViewportMouseDown}
+    >
+      {/* Transformed canvas layer */}
+      <div
+        style={{
+          transform: `translate(${panOffset.x}px, ${panOffset.y}px) scale(${zoom})`,
+          transformOrigin: '0 0',
+          position: 'absolute',
+          width: canvas.width,
+          height: canvas.height,
+        }}
+      >
+        {/* Canvas background with grid */}
+        <div
+          data-canvas-bg="true"
+          style={{
+            width: canvas.width,
+            height: canvas.height,
+            backgroundColor: '#1a1a2e',
+            backgroundImage: `
+              linear-gradient(${gridColor} 1px, transparent 1px),
+              linear-gradient(90deg, ${gridColor} 1px, transparent 1px)
+            `,
+            backgroundSize: `${gridSize}px ${gridSize}px`,
+            position: 'relative',
+            boxShadow: '0 0 0 1px rgba(255,255,255,0.1)',
+          }}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            selectElement(null);
+            dragRef.current = {
+              type: 'pan',
+              startX: e.clientX,
+              startY: e.clientY,
+              origPanX: panOffset.x,
+              origPanY: panOffset.y,
+            };
+            document.body.style.cursor = 'grabbing';
+            document.body.style.userSelect = 'none';
+          }}
+        >
+          {/* Canvas size label */}
+          <div
+            className="absolute pointer-events-none select-none"
+            style={{
+              top: -24,
+              left: 0,
+              fontSize: 12,
+              color: 'rgba(255,255,255,0.3)',
+            }}
+          >
+            {canvas.width} x {canvas.height}
+          </div>
+
+          {/* Root elements */}
+          {canvas.rootIds.map((id) => {
+            const el = canvas.elements[id];
+            if (!el) return null;
+            return (
+              <CanvasElement
+                key={id}
+                element={el}
+                canvas={canvas}
+                onStartDrag={handleStartDrag}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Selection overlay (screen space) */}
+      {selectedId && canvas.elements[selectedId] && (
+        <SelectionOverlay
+          elementId={selectedId}
+          canvas={canvas}
+          zoom={zoom}
+          panOffset={panOffset}
+          onStartResize={handleStartResize}
+        />
+      )}
+
+      {/* Zoom indicator */}
+      <div
+        className="absolute bottom-3 right-3 text-xs px-2 py-1 rounded select-none"
+        style={{
+          color: 'var(--text-muted)',
+          background: 'rgba(0,0,0,0.5)',
+        }}
+      >
+        {Math.round(zoom * 100)}%
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/ui-view/components/UICanvas.tsx
+++ b/ars-editor/src/features/ui-view/components/UICanvas.tsx
@@ -324,28 +324,30 @@ export function UICanvas() {
 
   const viewportRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<DragMode | null>(null);
+  const [isDraggingPan, setIsDraggingPan] = useState(false);
   const zoomRef = useRef(zoom);
   const panRef = useRef(panOffset);
-  zoomRef.current = zoom;
-  panRef.current = panOffset;
 
   // Refs for store actions (stable across renders)
   const updateRectRef = useRef(updateRect);
   const setPanRef = useRef(setPan);
-  updateRectRef.current = updateRect;
-  setPanRef.current = setPan;
 
   const sceneIdRef = useRef(sceneId);
-  sceneIdRef.current = sceneId;
-
   const canvasRef = useRef(canvas);
-  canvasRef.current = canvas;
+
+  useEffect(() => { zoomRef.current = zoom; }, [zoom]);
+  useEffect(() => { panRef.current = panOffset; }, [panOffset]);
+  useEffect(() => { updateRectRef.current = updateRect; }, [updateRect]);
+  useEffect(() => { setPanRef.current = setPan; }, [setPan]);
+  useEffect(() => { sceneIdRef.current = sceneId; }, [sceneId]);
+  useEffect(() => { canvasRef.current = canvas; }, [canvas]);
 
   // ── Fit canvas to viewport on mount ────────────
-  const [initialized, setInitialized] = useState(false);
+  const initializedRef = useRef(false);
 
   useEffect(() => {
-    if (initialized || !viewportRef.current) return;
+    if (initializedRef.current || !viewportRef.current) return;
+    initializedRef.current = true;
     const vp = viewportRef.current.getBoundingClientRect();
     const fitZoom = Math.min(
       (vp.width - 80) / canvas.width,
@@ -358,8 +360,7 @@ export function UICanvas() {
       x: (vp.width - canvas.width * z) / 2,
       y: (vp.height - canvas.height * z) / 2,
     });
-    setInitialized(true);
-  }, [initialized, canvas.width, canvas.height, setZoom, setPan]);
+  }, [canvas.width, canvas.height, setZoom, setPan]);
 
   // ── Mouse drag handlers ────────────────────────
 
@@ -417,6 +418,7 @@ export function UICanvas() {
 
     const handleMouseUp = () => {
       dragRef.current = null;
+      setIsDraggingPan(false);
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
@@ -510,6 +512,7 @@ export function UICanvas() {
           origPanX: panOffset.x,
           origPanY: panOffset.y,
         };
+        setIsDraggingPan(true);
         document.body.style.cursor = 'grabbing';
         document.body.style.userSelect = 'none';
       }
@@ -553,7 +556,7 @@ export function UICanvas() {
     <div
       ref={viewportRef}
       className="flex-1 overflow-hidden relative"
-      style={{ background: '#0a0a12', cursor: dragRef.current?.type === 'pan' ? 'grabbing' : 'default' }}
+      style={{ background: '#0a0a12', cursor: isDraggingPan ? 'grabbing' : 'default' }}
       onWheel={handleWheel}
       onMouseDown={handleViewportMouseDown}
     >
@@ -592,6 +595,7 @@ export function UICanvas() {
               origPanX: panOffset.x,
               origPanY: panOffset.y,
             };
+            setIsDraggingPan(true);
             document.body.style.cursor = 'grabbing';
             document.body.style.userSelect = 'none';
           }}

--- a/ars-editor/src/features/ui-view/components/UICanvas.tsx
+++ b/ars-editor/src/features/ui-view/components/UICanvas.tsx
@@ -95,6 +95,46 @@ function renderElementVisual(element: UIElement) {
           {props.label ?? 'Button'}
         </div>
       );
+    case 'Custom': {
+      const borderCol = props.borderColor ?? 'var(--purple)';
+      return (
+        <div
+          className="absolute inset-0 overflow-hidden"
+          style={{
+            backgroundColor: props.backgroundColor ?? 'transparent',
+            border: `2px dashed ${borderCol}`,
+            borderRadius: props.borderRadius ?? 0,
+            opacity: props.opacity ?? 1,
+          }}
+        >
+          {/* Type name badge (top-left) */}
+          <div
+            className="absolute flex items-center gap-1 px-1.5 py-0.5"
+            style={{
+              top: 0,
+              left: 0,
+              background: borderCol,
+              color: '#fff',
+              fontSize: 10,
+              fontWeight: 'bold',
+              lineHeight: 1,
+              borderBottomRightRadius: 4,
+              maxWidth: '100%',
+            }}
+          >
+            <span style={{ fontSize: 8 }}>{'\u2726'}</span>
+            <span className="truncate">{props.typeName || element.name}</span>
+          </div>
+          {/* Center label showing instance name */}
+          <div
+            className="absolute inset-0 flex items-center justify-center pointer-events-none"
+            style={{ color: borderCol, fontSize: 12, opacity: 0.6 }}
+          >
+            {element.name}
+          </div>
+        </div>
+      );
+    }
     default:
       return null;
   }

--- a/ars-editor/src/features/ui-view/components/UIHierarchy.tsx
+++ b/ars-editor/src/features/ui-view/components/UIHierarchy.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useState } from 'react';
+import { useUIViewStore } from '../uiViewStore';
+import { useProjectStore } from '@/stores/projectStore';
+import type { UIElement, UICanvasData, UIElementType } from '../types';
+import { ELEMENT_TYPE_ICONS } from '../types';
+
+// ── Hierarchy node (recursive) ──────────────────────
+
+function HierarchyNode({
+  elementId,
+  canvas,
+  sceneId,
+  depth,
+}: {
+  elementId: string;
+  canvas: UICanvasData;
+  sceneId: string;
+  depth: number;
+}) {
+  const element = canvas.elements[elementId];
+  const selectedId = useUIViewStore((s) => s.selectedElementId);
+  const selectElement = useUIViewStore((s) => s.selectElement);
+  const toggleVisibility = useUIViewStore((s) => s.toggleVisibility);
+  const removeElement = useUIViewStore((s) => s.removeElement);
+
+  const [expanded, setExpanded] = useState(true);
+
+  if (!element) return null;
+
+  const isSelected = selectedId === elementId;
+  const hasChildren = element.childIds.length > 0;
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1 cursor-pointer group"
+        style={{
+          paddingLeft: depth * 16 + 4,
+          paddingRight: 4,
+          paddingTop: 2,
+          paddingBottom: 2,
+          backgroundColor: isSelected ? 'rgba(88, 166, 255, 0.15)' : undefined,
+          borderLeft: isSelected ? '2px solid var(--accent)' : '2px solid transparent',
+        }}
+        onClick={() => selectElement(elementId)}
+        onDoubleClick={() => {
+          // Double click to toggle expand
+          if (hasChildren) setExpanded(!expanded);
+        }}
+      >
+        {/* Expand/collapse toggle */}
+        <button
+          className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-xs"
+          style={{
+            color: 'var(--text-muted)',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            visibility: hasChildren ? 'visible' : 'hidden',
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(!expanded);
+          }}
+        >
+          {expanded ? '\u25BC' : '\u25B6'}
+        </button>
+
+        {/* Type icon */}
+        <span
+          className="flex-shrink-0 w-4 text-center text-xs"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          {ELEMENT_TYPE_ICONS[element.type]}
+        </span>
+
+        {/* Name */}
+        <span
+          className="flex-1 text-xs truncate"
+          style={{
+            color: element.visible ? 'var(--text)' : 'var(--text-muted)',
+            textDecoration: element.visible ? undefined : 'line-through',
+          }}
+        >
+          {element.name}
+        </span>
+
+        {/* Visibility toggle */}
+        <button
+          className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity"
+          style={{
+            color: element.visible ? 'var(--text-muted)' : 'var(--red)',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleVisibility(sceneId, elementId);
+          }}
+          title={element.visible ? 'Hide' : 'Show'}
+        >
+          {element.visible ? '\u25C9' : '\u25CE'}
+        </button>
+
+        {/* Delete */}
+        <button
+          className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-xs opacity-0 group-hover:opacity-100 transition-opacity"
+          style={{
+            color: 'var(--text-muted)',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            removeElement(sceneId, elementId);
+          }}
+          title="Delete"
+        >
+          \u2715
+        </button>
+      </div>
+
+      {/* Children */}
+      {expanded &&
+        element.childIds.map((childId) => (
+          <HierarchyNode
+            key={childId}
+            elementId={childId}
+            canvas={canvas}
+            sceneId={sceneId}
+            depth={depth + 1}
+          />
+        ))}
+    </div>
+  );
+}
+
+// ── Add element menu ────────────────────────────────
+
+function AddElementButton({ sceneId, parentId }: { sceneId: string; parentId: string | null }) {
+  const addElement = useUIViewStore((s) => s.addElement);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const types: UIElementType[] = ['Panel', 'Text', 'Image', 'Button'];
+
+  return (
+    <div className="relative">
+      <button
+        className="w-full text-xs py-1.5 rounded transition-colors"
+        style={{
+          color: 'var(--accent)',
+          background: 'none',
+          border: '1px dashed var(--border)',
+        }}
+        onClick={() => setMenuOpen(!menuOpen)}
+      >
+        + Add Element
+      </button>
+      {menuOpen && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
+          <div
+            className="absolute left-0 right-0 z-50 rounded shadow-lg py-1"
+            style={{
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border)',
+              bottom: '100%',
+              marginBottom: 4,
+            }}
+          >
+            {types.map((type) => (
+              <button
+                key={type}
+                className="w-full text-left text-xs px-3 py-1.5 transition-colors"
+                style={{
+                  color: 'var(--text)',
+                  background: 'transparent',
+                  border: 'none',
+                }}
+                onMouseEnter={(e) => {
+                  (e.target as HTMLElement).style.background = 'var(--bg-surface-2)';
+                }}
+                onMouseLeave={(e) => {
+                  (e.target as HTMLElement).style.background = 'transparent';
+                }}
+                onClick={() => {
+                  addElement(sceneId, type, parentId);
+                  setMenuOpen(false);
+                }}
+              >
+                <span className="mr-2">{ELEMENT_TYPE_ICONS[type]}</span>
+                {type}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Main Hierarchy Panel ────────────────────────────
+
+export function UIHierarchy() {
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const sceneId = activeSceneId ?? '';
+  const canvas = useUIViewStore((s) => s.getCanvas(sceneId));
+  const selectedId = useUIViewStore((s) => s.selectedElementId);
+  const addElement = useUIViewStore((s) => s.addElement);
+
+  const handleAddToSelected = useCallback(
+    (type: UIElementType) => {
+      if (!activeSceneId) return;
+      // Add as child of selected element if it's a container type (Panel)
+      const parentId =
+        selectedId && canvas.elements[selectedId]?.type === 'Panel' ? selectedId : null;
+      addElement(activeSceneId, type, parentId);
+    },
+    [activeSceneId, selectedId, canvas.elements, addElement],
+  );
+
+  if (!activeSceneId) {
+    return (
+      <div
+        className="w-56 min-w-[224px] flex items-center justify-center"
+        style={{
+          background: 'var(--bg-surface)',
+          borderRight: '1px solid var(--border)',
+          color: 'var(--text-muted)',
+          fontSize: 12,
+        }}
+      >
+        No scene
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="w-56 min-w-[224px] flex flex-col"
+      style={{
+        background: 'var(--bg-surface)',
+        borderRight: '1px solid var(--border)',
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-3 py-2 shrink-0"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
+        <span className="text-xs font-semibold" style={{ color: 'var(--text)' }}>
+          Hierarchy
+        </span>
+        <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+          {Object.keys(canvas.elements).length}
+        </span>
+      </div>
+
+      {/* Tree */}
+      <div className="flex-1 overflow-y-auto py-1">
+        {canvas.rootIds.length === 0 && (
+          <div className="px-3 py-4 text-xs text-center" style={{ color: 'var(--text-muted)' }}>
+            No UI elements yet.
+            <br />
+            Add elements to start building your layout.
+          </div>
+        )}
+
+        {canvas.rootIds.map((id) => (
+          <HierarchyNode
+            key={id}
+            elementId={id}
+            canvas={canvas}
+            sceneId={activeSceneId}
+            depth={0}
+          />
+        ))}
+      </div>
+
+      {/* Add element */}
+      <div className="shrink-0 px-2 py-2" style={{ borderTop: '1px solid var(--border)' }}>
+        <AddElementButton sceneId={activeSceneId} parentId={null} />
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/ui-view/components/UIHierarchy.tsx
+++ b/ars-editor/src/features/ui-view/components/UIHierarchy.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { useUIViewStore } from '../uiViewStore';
 import { useProjectStore } from '@/stores/projectStore';
-import type { UIElement, UICanvasData, UIElementType } from '../types';
+import type { UICanvasData, UIElementType } from '../types';
 import { ELEMENT_TYPE_ICONS } from '../types';
 
 // ── Hierarchy node (recursive) ──────────────────────
@@ -207,19 +207,6 @@ export function UIHierarchy() {
   const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
   const sceneId = activeSceneId ?? '';
   const canvas = useUIViewStore((s) => s.getCanvas(sceneId));
-  const selectedId = useUIViewStore((s) => s.selectedElementId);
-  const addElement = useUIViewStore((s) => s.addElement);
-
-  const handleAddToSelected = useCallback(
-    (type: UIElementType) => {
-      if (!activeSceneId) return;
-      // Add as child of selected element if it's a container type (Panel)
-      const parentId =
-        selectedId && (canvas.elements[selectedId]?.type === 'Panel' || canvas.elements[selectedId]?.type === 'Custom') ? selectedId : null;
-      addElement(activeSceneId, type, parentId);
-    },
-    [activeSceneId, selectedId, canvas.elements, addElement],
-  );
 
   if (!activeSceneId) {
     return (

--- a/ars-editor/src/features/ui-view/components/UIHierarchy.tsx
+++ b/ars-editor/src/features/ui-view/components/UIHierarchy.tsx
@@ -143,7 +143,7 @@ function AddElementButton({ sceneId, parentId }: { sceneId: string; parentId: st
   const addElement = useUIViewStore((s) => s.addElement);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const types: UIElementType[] = ['Panel', 'Text', 'Image', 'Button'];
+  const types: UIElementType[] = ['Panel', 'Text', 'Image', 'Button', 'Custom'];
 
   return (
     <div className="relative">
@@ -215,7 +215,7 @@ export function UIHierarchy() {
       if (!activeSceneId) return;
       // Add as child of selected element if it's a container type (Panel)
       const parentId =
-        selectedId && canvas.elements[selectedId]?.type === 'Panel' ? selectedId : null;
+        selectedId && (canvas.elements[selectedId]?.type === 'Panel' || canvas.elements[selectedId]?.type === 'Custom') ? selectedId : null;
       addElement(activeSceneId, type, parentId);
     },
     [activeSceneId, selectedId, canvas.elements, addElement],

--- a/ars-editor/src/features/ui-view/components/UIInspector.tsx
+++ b/ars-editor/src/features/ui-view/components/UIInspector.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useUIViewStore } from '../uiViewStore';
 import { useProjectStore } from '@/stores/projectStore';
-import type { UIElement, UIElementType, UIElementProps, RectTransform, Vec2 } from '../types';
+import type { UIElement, UIElementProps, RectTransform, Vec2 } from '../types';
 import { ELEMENT_TYPE_ICONS } from '../types';
 
 // ── Shared input components ─────────────────────────

--- a/ars-editor/src/features/ui-view/components/UIInspector.tsx
+++ b/ars-editor/src/features/ui-view/components/UIInspector.tsx
@@ -1,0 +1,585 @@
+import { useCallback } from 'react';
+import { useUIViewStore } from '../uiViewStore';
+import { useProjectStore } from '@/stores/projectStore';
+import type { UIElement, UIElementType, UIElementProps, RectTransform, Vec2 } from '../types';
+import { ELEMENT_TYPE_ICONS } from '../types';
+
+// ── Shared input components ─────────────────────────
+
+function NumberInput({
+  label,
+  value,
+  onChange,
+  step = 1,
+  min,
+  max,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  step?: number;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-xs w-6 text-right shrink-0" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <input
+        type="number"
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        className="flex-1 text-xs px-2 py-1 rounded min-w-0"
+        style={{
+          background: 'var(--bg)',
+          border: '1px solid var(--border)',
+          color: 'var(--text)',
+          outline: 'none',
+        }}
+        onFocus={(e) => e.target.select()}
+        onChange={(e) => {
+          const v = parseFloat(e.target.value);
+          if (!isNaN(v)) onChange(v);
+        }}
+      />
+    </div>
+  );
+}
+
+function TextInput({
+  label,
+  value,
+  onChange,
+  multiline,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  multiline?: boolean;
+}) {
+  const Tag = multiline ? 'textarea' : 'input';
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <Tag
+        value={value}
+        className="text-xs px-2 py-1 rounded"
+        style={{
+          background: 'var(--bg)',
+          border: '1px solid var(--border)',
+          color: 'var(--text)',
+          outline: 'none',
+          resize: multiline ? 'vertical' : undefined,
+          minHeight: multiline ? 60 : undefined,
+          fontFamily: 'inherit',
+        }}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function ColorInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-xs flex-1" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <div className="flex items-center gap-1">
+        <input
+          type="color"
+          value={value.startsWith('#') ? value : '#ffffff'}
+          className="w-6 h-6 rounded cursor-pointer"
+          style={{ background: 'none', border: '1px solid var(--border)', padding: 0 }}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <input
+          type="text"
+          value={value}
+          className="text-xs px-1 py-0.5 rounded w-24"
+          style={{
+            background: 'var(--bg)',
+            border: '1px solid var(--border)',
+            color: 'var(--text)',
+            outline: 'none',
+          }}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SelectInput({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-xs flex-1" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </label>
+      <select
+        value={value}
+        className="text-xs px-2 py-1 rounded"
+        style={{
+          background: 'var(--bg)',
+          border: '1px solid var(--border)',
+          color: 'var(--text)',
+          outline: 'none',
+        }}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// ── Section wrapper ─────────────────────────────────
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="px-3 py-2" style={{ borderBottom: '1px solid var(--border)' }}>
+      <h4
+        className="text-xs font-semibold mb-2"
+        style={{ color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}
+      >
+        {title}
+      </h4>
+      <div className="flex flex-col gap-2">{children}</div>
+    </div>
+  );
+}
+
+// ── Anchor presets ──────────────────────────────────
+
+const ANCHOR_PRESETS: {
+  label: string;
+  min: Vec2;
+  max: Vec2;
+}[] = [
+  { label: 'Center', min: { x: 0.5, y: 0.5 }, max: { x: 0.5, y: 0.5 } },
+  { label: 'Top-Left', min: { x: 0, y: 0 }, max: { x: 0, y: 0 } },
+  { label: 'Top', min: { x: 0.5, y: 0 }, max: { x: 0.5, y: 0 } },
+  { label: 'Top-Right', min: { x: 1, y: 0 }, max: { x: 1, y: 0 } },
+  { label: 'Left', min: { x: 0, y: 0.5 }, max: { x: 0, y: 0.5 } },
+  { label: 'Right', min: { x: 1, y: 0.5 }, max: { x: 1, y: 0.5 } },
+  { label: 'Bottom-Left', min: { x: 0, y: 1 }, max: { x: 0, y: 1 } },
+  { label: 'Bottom', min: { x: 0.5, y: 1 }, max: { x: 0.5, y: 1 } },
+  { label: 'Bottom-Right', min: { x: 1, y: 1 }, max: { x: 1, y: 1 } },
+  { label: 'Stretch H', min: { x: 0, y: 0.5 }, max: { x: 1, y: 0.5 } },
+  { label: 'Stretch V', min: { x: 0.5, y: 0 }, max: { x: 0.5, y: 1 } },
+  { label: 'Stretch All', min: { x: 0, y: 0 }, max: { x: 1, y: 1 } },
+];
+
+// ── Type-specific property editors ──────────────────
+
+function PanelProps({
+  element,
+  sceneId,
+}: {
+  element: UIElement;
+  sceneId: string;
+}) {
+  const updateProps = useUIViewStore((s) => s.updateProps);
+  const update = useCallback(
+    (p: Partial<UIElementProps>) => updateProps(sceneId, element.id, p),
+    [sceneId, element.id, updateProps],
+  );
+
+  return (
+    <Section title="Panel">
+      <ColorInput
+        label="Background"
+        value={element.props.backgroundColor ?? 'rgba(30,41,59,0.8)'}
+        onChange={(v) => update({ backgroundColor: v })}
+      />
+      <NumberInput
+        label="R"
+        value={element.props.borderRadius ?? 0}
+        onChange={(v) => update({ borderRadius: v })}
+        min={0}
+      />
+      <ColorInput
+        label="Border"
+        value={element.props.borderColor ?? 'rgba(255,255,255,0.2)'}
+        onChange={(v) => update({ borderColor: v })}
+      />
+      <NumberInput
+        label="BW"
+        value={element.props.borderWidth ?? 0}
+        onChange={(v) => update({ borderWidth: v })}
+        min={0}
+      />
+    </Section>
+  );
+}
+
+function TextProps({
+  element,
+  sceneId,
+}: {
+  element: UIElement;
+  sceneId: string;
+}) {
+  const updateProps = useUIViewStore((s) => s.updateProps);
+  const update = useCallback(
+    (p: Partial<UIElementProps>) => updateProps(sceneId, element.id, p),
+    [sceneId, element.id, updateProps],
+  );
+
+  return (
+    <Section title="Text">
+      <TextInput
+        label="Content"
+        value={element.props.text ?? ''}
+        onChange={(v) => update({ text: v })}
+        multiline
+      />
+      <NumberInput
+        label="Size"
+        value={element.props.fontSize ?? 16}
+        onChange={(v) => update({ fontSize: v })}
+        min={1}
+      />
+      <ColorInput
+        label="Color"
+        value={element.props.fontColor ?? '#e6edf3'}
+        onChange={(v) => update({ fontColor: v })}
+      />
+      <SelectInput
+        label="Align"
+        value={element.props.textAlign ?? 'center'}
+        options={[
+          { value: 'left', label: 'Left' },
+          { value: 'center', label: 'Center' },
+          { value: 'right', label: 'Right' },
+        ]}
+        onChange={(v) => update({ textAlign: v as 'left' | 'center' | 'right' })}
+      />
+      <SelectInput
+        label="Weight"
+        value={element.props.fontWeight ?? 'normal'}
+        options={[
+          { value: 'normal', label: 'Normal' },
+          { value: 'bold', label: 'Bold' },
+        ]}
+        onChange={(v) => update({ fontWeight: v as 'normal' | 'bold' })}
+      />
+    </Section>
+  );
+}
+
+function ImageProps({
+  element,
+  sceneId,
+}: {
+  element: UIElement;
+  sceneId: string;
+}) {
+  const updateProps = useUIViewStore((s) => s.updateProps);
+  const update = useCallback(
+    (p: Partial<UIElementProps>) => updateProps(sceneId, element.id, p),
+    [sceneId, element.id, updateProps],
+  );
+
+  return (
+    <Section title="Image">
+      <TextInput
+        label="URL"
+        value={element.props.imageUrl ?? ''}
+        onChange={(v) => update({ imageUrl: v })}
+      />
+      <ColorInput
+        label="Background"
+        value={element.props.backgroundColor ?? 'rgba(100,116,139,0.3)'}
+        onChange={(v) => update({ backgroundColor: v })}
+      />
+      <SelectInput
+        label="Fit"
+        value={element.props.imageFit ?? 'contain'}
+        options={[
+          { value: 'contain', label: 'Contain' },
+          { value: 'cover', label: 'Cover' },
+          { value: 'fill', label: 'Fill' },
+        ]}
+        onChange={(v) => update({ imageFit: v as 'contain' | 'cover' | 'fill' })}
+      />
+    </Section>
+  );
+}
+
+function ButtonProps({
+  element,
+  sceneId,
+}: {
+  element: UIElement;
+  sceneId: string;
+}) {
+  const updateProps = useUIViewStore((s) => s.updateProps);
+  const update = useCallback(
+    (p: Partial<UIElementProps>) => updateProps(sceneId, element.id, p),
+    [sceneId, element.id, updateProps],
+  );
+
+  return (
+    <Section title="Button">
+      <TextInput
+        label="Label"
+        value={element.props.label ?? 'Button'}
+        onChange={(v) => update({ label: v })}
+      />
+      <ColorInput
+        label="Color"
+        value={element.props.buttonColor ?? '#3b82f6'}
+        onChange={(v) => update({ buttonColor: v })}
+      />
+      <ColorInput
+        label="Text"
+        value={element.props.textColor ?? '#ffffff'}
+        onChange={(v) => update({ textColor: v })}
+      />
+      <NumberInput
+        label="Size"
+        value={element.props.fontSize ?? 14}
+        onChange={(v) => update({ fontSize: v })}
+        min={1}
+      />
+      <NumberInput
+        label="R"
+        value={element.props.borderRadius ?? 6}
+        onChange={(v) => update({ borderRadius: v })}
+        min={0}
+      />
+    </Section>
+  );
+}
+
+// ── Main Inspector Panel ────────────────────────────
+
+export function UIInspector() {
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const sceneId = activeSceneId ?? '';
+  const canvas = useUIViewStore((s) => s.getCanvas(sceneId));
+  const selectedId = useUIViewStore((s) => s.selectedElementId);
+  const updateRect = useUIViewStore((s) => s.updateRect);
+  const renameElement = useUIViewStore((s) => s.renameElement);
+  const removeElement = useUIViewStore((s) => s.removeElement);
+  const addElement = useUIViewStore((s) => s.addElement);
+
+  const element = selectedId ? canvas.elements[selectedId] : null;
+
+  if (!activeSceneId || !element) {
+    return (
+      <div
+        className="w-64 min-w-[256px] flex items-center justify-center"
+        style={{
+          background: 'var(--bg-surface)',
+          borderLeft: '1px solid var(--border)',
+          color: 'var(--text-muted)',
+          fontSize: 12,
+        }}
+      >
+        {activeSceneId ? 'Select an element to inspect' : 'No scene'}
+      </div>
+    );
+  }
+
+  const handleRectChange = (updates: Partial<RectTransform>) => {
+    updateRect(sceneId, element.id, updates);
+  };
+
+  return (
+    <div
+      className="w-64 min-w-[256px] flex flex-col overflow-y-auto"
+      style={{
+        background: 'var(--bg-surface)',
+        borderLeft: '1px solid var(--border)',
+      }}
+    >
+      {/* Header */}
+      <div className="px-3 py-2 shrink-0" style={{ borderBottom: '1px solid var(--border)' }}>
+        <div className="flex items-center gap-2">
+          <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            {ELEMENT_TYPE_ICONS[element.type]}
+          </span>
+          <input
+            type="text"
+            value={element.name}
+            className="flex-1 text-xs font-semibold px-1 py-0.5 rounded min-w-0"
+            style={{
+              background: 'transparent',
+              border: '1px solid transparent',
+              color: 'var(--text)',
+              outline: 'none',
+            }}
+            onFocus={(e) => {
+              (e.target as HTMLInputElement).style.borderColor = 'var(--accent)';
+              (e.target as HTMLInputElement).style.background = 'var(--bg)';
+            }}
+            onBlur={(e) => {
+              (e.target as HTMLInputElement).style.borderColor = 'transparent';
+              (e.target as HTMLInputElement).style.background = 'transparent';
+            }}
+            onChange={(e) => renameElement(sceneId, element.id, e.target.value)}
+          />
+        </div>
+        <div className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>
+          {element.type}
+        </div>
+      </div>
+
+      {/* Transform */}
+      <Section title="Rect Transform">
+        <div className="grid grid-cols-2 gap-2">
+          <NumberInput label="X" value={element.rect.x} onChange={(v) => handleRectChange({ x: v })} />
+          <NumberInput label="Y" value={element.rect.y} onChange={(v) => handleRectChange({ y: v })} />
+          <NumberInput
+            label="W"
+            value={element.rect.width}
+            onChange={(v) => handleRectChange({ width: v })}
+            min={20}
+          />
+          <NumberInput
+            label="H"
+            value={element.rect.height}
+            onChange={(v) => handleRectChange({ height: v })}
+            min={20}
+          />
+        </div>
+        <NumberInput
+          label="Rot"
+          value={element.rect.rotation}
+          onChange={(v) => handleRectChange({ rotation: v })}
+          step={1}
+        />
+      </Section>
+
+      {/* Anchors */}
+      <Section title="Anchors">
+        <div className="flex flex-wrap gap-1">
+          {ANCHOR_PRESETS.map((preset) => {
+            const isActive =
+              element.rect.anchorMin.x === preset.min.x &&
+              element.rect.anchorMin.y === preset.min.y &&
+              element.rect.anchorMax.x === preset.max.x &&
+              element.rect.anchorMax.y === preset.max.y;
+            return (
+              <button
+                key={preset.label}
+                className="text-xs px-1.5 py-0.5 rounded transition-colors"
+                style={{
+                  background: isActive ? 'var(--accent)' : 'var(--bg)',
+                  color: isActive ? '#fff' : 'var(--text-muted)',
+                  border: `1px solid ${isActive ? 'var(--accent)' : 'var(--border)'}`,
+                  fontSize: 10,
+                }}
+                onClick={() =>
+                  handleRectChange({
+                    anchorMin: { ...preset.min },
+                    anchorMax: { ...preset.max },
+                  })
+                }
+                title={preset.label}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 mt-1">
+          <NumberInput
+            label="Px"
+            value={element.rect.pivot.x}
+            onChange={(v) => handleRectChange({ pivot: { ...element.rect.pivot, x: v } })}
+            step={0.1}
+            min={0}
+            max={1}
+          />
+          <NumberInput
+            label="Py"
+            value={element.rect.pivot.y}
+            onChange={(v) => handleRectChange({ pivot: { ...element.rect.pivot, y: v } })}
+            step={0.1}
+            min={0}
+            max={1}
+          />
+        </div>
+      </Section>
+
+      {/* Common appearance */}
+      <Section title="Appearance">
+        <NumberInput
+          label="Op"
+          value={element.props.opacity ?? 1}
+          onChange={(v) =>
+            useUIViewStore.getState().updateProps(sceneId, element.id, { opacity: v })
+          }
+          step={0.1}
+          min={0}
+          max={1}
+        />
+      </Section>
+
+      {/* Type-specific properties */}
+      {element.type === 'Panel' && <PanelProps element={element} sceneId={sceneId} />}
+      {element.type === 'Text' && <TextProps element={element} sceneId={sceneId} />}
+      {element.type === 'Image' && <ImageProps element={element} sceneId={sceneId} />}
+      {element.type === 'Button' && <ButtonProps element={element} sceneId={sceneId} />}
+
+      {/* Actions */}
+      <div className="px-3 py-3 flex flex-col gap-2">
+        {element.type === 'Panel' && (
+          <button
+            className="w-full text-xs py-1.5 rounded transition-colors"
+            style={{
+              color: 'var(--accent)',
+              background: 'none',
+              border: '1px dashed var(--accent)',
+            }}
+            onClick={() => addElement(sceneId, 'Panel', element.id)}
+          >
+            + Add Child
+          </button>
+        )}
+        <button
+          className="w-full text-xs py-1.5 rounded transition-colors"
+          style={{
+            color: 'var(--red)',
+            background: 'none',
+            border: '1px solid var(--red)',
+          }}
+          onClick={() => removeElement(sceneId, element.id)}
+        >
+          Delete Element
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/ui-view/components/UIInspector.tsx
+++ b/ars-editor/src/features/ui-view/components/UIInspector.tsx
@@ -380,6 +380,46 @@ function ButtonProps({
   );
 }
 
+function CustomProps({
+  element,
+  sceneId,
+}: {
+  element: UIElement;
+  sceneId: string;
+}) {
+  const updateProps = useUIViewStore((s) => s.updateProps);
+  const update = useCallback(
+    (p: Partial<UIElementProps>) => updateProps(sceneId, element.id, p),
+    [sceneId, element.id, updateProps],
+  );
+
+  return (
+    <Section title="Custom">
+      <TextInput
+        label="Type Name"
+        value={element.props.typeName ?? ''}
+        onChange={(v) => update({ typeName: v })}
+      />
+      <ColorInput
+        label="Border"
+        value={element.props.borderColor ?? '#bc8cff'}
+        onChange={(v) => update({ borderColor: v })}
+      />
+      <ColorInput
+        label="Background"
+        value={element.props.backgroundColor ?? 'transparent'}
+        onChange={(v) => update({ backgroundColor: v })}
+      />
+      <NumberInput
+        label="R"
+        value={element.props.borderRadius ?? 0}
+        onChange={(v) => update({ borderRadius: v })}
+        min={0}
+      />
+    </Section>
+  );
+}
+
 // ── Main Inspector Panel ────────────────────────────
 
 export function UIInspector() {
@@ -552,10 +592,11 @@ export function UIInspector() {
       {element.type === 'Text' && <TextProps element={element} sceneId={sceneId} />}
       {element.type === 'Image' && <ImageProps element={element} sceneId={sceneId} />}
       {element.type === 'Button' && <ButtonProps element={element} sceneId={sceneId} />}
+      {element.type === 'Custom' && <CustomProps element={element} sceneId={sceneId} />}
 
       {/* Actions */}
       <div className="px-3 py-3 flex flex-col gap-2">
-        {element.type === 'Panel' && (
+        {(element.type === 'Panel' || element.type === 'Custom') && (
           <button
             className="w-full text-xs py-1.5 rounded transition-colors"
             style={{

--- a/ars-editor/src/features/ui-view/components/UIViewLayout.tsx
+++ b/ars-editor/src/features/ui-view/components/UIViewLayout.tsx
@@ -1,0 +1,140 @@
+import { useUIViewStore } from '../uiViewStore';
+import { useProjectStore } from '@/stores/projectStore';
+import { UICanvas } from './UICanvas';
+import { UIHierarchy } from './UIHierarchy';
+import { UIInspector } from './UIInspector';
+import type { UIElementType } from '../types';
+import { ELEMENT_TYPE_ICONS } from '../types';
+
+// ── Element toolbar ─────────────────────────────────
+
+const ELEMENT_TYPES: { type: UIElementType; label: string }[] = [
+  { type: 'Panel', label: 'Panel' },
+  { type: 'Text', label: 'Text' },
+  { type: 'Image', label: 'Image' },
+  { type: 'Button', label: 'Button' },
+];
+
+function UIElementToolbar() {
+  const activeSceneId = useProjectStore((s) => s.project.activeSceneId);
+  const addElement = useUIViewStore((s) => s.addElement);
+  const selectedId = useUIViewStore((s) => s.selectedElementId);
+  const canvas = useUIViewStore((s) => s.getCanvas(activeSceneId ?? ''));
+  const zoom = useUIViewStore((s) => s.zoom);
+  const setZoom = useUIViewStore((s) => s.setZoom);
+  const resetView = useUIViewStore((s) => s.resetView);
+
+  const handleAdd = (type: UIElementType) => {
+    if (!activeSceneId) return;
+    // Add as child of selected Panel, otherwise at root
+    const parentId =
+      selectedId && canvas.elements[selectedId]?.type === 'Panel' ? selectedId : null;
+    addElement(activeSceneId, type, parentId);
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1 px-2 shrink-0"
+      style={{
+        height: 36,
+        background: 'var(--bg-surface)',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      {/* Add element buttons */}
+      {ELEMENT_TYPES.map(({ type, label }) => (
+        <button
+          key={type}
+          className="flex items-center gap-1 text-xs px-2 py-1 rounded transition-colors"
+          style={{
+            color: 'var(--text-muted)',
+            background: 'transparent',
+            border: '1px solid var(--border)',
+          }}
+          onMouseEnter={(e) => {
+            (e.target as HTMLElement).style.color = 'var(--text)';
+            (e.target as HTMLElement).style.borderColor = 'var(--accent)';
+          }}
+          onMouseLeave={(e) => {
+            (e.target as HTMLElement).style.color = 'var(--text-muted)';
+            (e.target as HTMLElement).style.borderColor = 'var(--border)';
+          }}
+          onClick={() => handleAdd(type)}
+          disabled={!activeSceneId}
+          title={`Add ${label}`}
+        >
+          <span>{ELEMENT_TYPE_ICONS[type]}</span>
+          <span>{label}</span>
+        </button>
+      ))}
+
+      <div className="flex-1" />
+
+      {/* Canvas size */}
+      <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        {canvas.width} x {canvas.height}
+      </span>
+
+      <div style={{ width: 1, height: 16, background: 'var(--border)', margin: '0 4px' }} />
+
+      {/* Zoom controls */}
+      <button
+        className="text-xs px-1.5 py-0.5 rounded"
+        style={{
+          color: 'var(--text-muted)',
+          background: 'transparent',
+          border: '1px solid var(--border)',
+        }}
+        onClick={() => setZoom(zoom - 0.1)}
+        title="Zoom out"
+      >
+        -
+      </button>
+      <span
+        className="text-xs w-12 text-center select-none"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        {Math.round(zoom * 100)}%
+      </span>
+      <button
+        className="text-xs px-1.5 py-0.5 rounded"
+        style={{
+          color: 'var(--text-muted)',
+          background: 'transparent',
+          border: '1px solid var(--border)',
+        }}
+        onClick={() => setZoom(zoom + 0.1)}
+        title="Zoom in"
+      >
+        +
+      </button>
+      <button
+        className="text-xs px-2 py-0.5 rounded"
+        style={{
+          color: 'var(--text-muted)',
+          background: 'transparent',
+          border: '1px solid var(--border)',
+        }}
+        onClick={resetView}
+        title="Reset view"
+      >
+        Fit
+      </button>
+    </div>
+  );
+}
+
+// ── Main layout ─────────────────────────────────────
+
+export function UIViewLayout() {
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <UIElementToolbar />
+      <div className="flex flex-1 overflow-hidden">
+        <UIHierarchy />
+        <UICanvas />
+        <UIInspector />
+      </div>
+    </div>
+  );
+}

--- a/ars-editor/src/features/ui-view/components/UIViewLayout.tsx
+++ b/ars-editor/src/features/ui-view/components/UIViewLayout.tsx
@@ -13,6 +13,7 @@ const ELEMENT_TYPES: { type: UIElementType; label: string }[] = [
   { type: 'Text', label: 'Text' },
   { type: 'Image', label: 'Image' },
   { type: 'Button', label: 'Button' },
+  { type: 'Custom', label: 'Custom' },
 ];
 
 function UIElementToolbar() {
@@ -27,8 +28,9 @@ function UIElementToolbar() {
   const handleAdd = (type: UIElementType) => {
     if (!activeSceneId) return;
     // Add as child of selected Panel, otherwise at root
+    const selType = selectedId ? canvas.elements[selectedId]?.type : null;
     const parentId =
-      selectedId && canvas.elements[selectedId]?.type === 'Panel' ? selectedId : null;
+      selectedId && (selType === 'Panel' || selType === 'Custom') ? selectedId : null;
     addElement(activeSceneId, type, parentId);
   };
 

--- a/ars-editor/src/features/ui-view/index.ts
+++ b/ars-editor/src/features/ui-view/index.ts
@@ -1,0 +1,5 @@
+export { UIViewLayout } from './components/UIViewLayout';
+export { UICanvas } from './components/UICanvas';
+export { UIHierarchy } from './components/UIHierarchy';
+export { UIInspector } from './components/UIInspector';
+export { useUIViewStore } from './uiViewStore';

--- a/ars-editor/src/features/ui-view/types.ts
+++ b/ars-editor/src/features/ui-view/types.ts
@@ -1,0 +1,142 @@
+// UI View types — uGUI-inspired layout system for Ars editor
+
+export type UIElementType = 'Panel' | 'Text' | 'Image' | 'Button';
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface RectTransform {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  anchorMin: Vec2;
+  anchorMax: Vec2;
+  pivot: Vec2;
+  rotation: number;
+}
+
+export interface UIElementProps {
+  // Common
+  backgroundColor?: string;
+  opacity?: number;
+  // Panel
+  borderRadius?: number;
+  borderColor?: string;
+  borderWidth?: number;
+  // Text
+  text?: string;
+  fontSize?: number;
+  fontColor?: string;
+  textAlign?: 'left' | 'center' | 'right';
+  fontWeight?: 'normal' | 'bold';
+  // Image
+  imageUrl?: string;
+  imageFit?: 'contain' | 'cover' | 'fill';
+  tintColor?: string;
+  // Button
+  label?: string;
+  buttonColor?: string;
+  hoverColor?: string;
+  textColor?: string;
+}
+
+export interface UIElement {
+  id: string;
+  name: string;
+  type: UIElementType;
+  parentId: string | null;
+  rect: RectTransform;
+  visible: boolean;
+  props: UIElementProps;
+  childIds: string[];
+}
+
+export interface UICanvasData {
+  width: number;
+  height: number;
+  elements: Record<string, UIElement>;
+  rootIds: string[];
+}
+
+export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'nw' | 'ne' | 'sw' | 'se';
+
+// ── Defaults ────────────────────────────────────────
+
+export const DEFAULT_CANVAS_WIDTH = 1920;
+export const DEFAULT_CANVAS_HEIGHT = 1080;
+
+export function createDefaultCanvas(): UICanvasData {
+  return {
+    width: DEFAULT_CANVAS_WIDTH,
+    height: DEFAULT_CANVAS_HEIGHT,
+    elements: {},
+    rootIds: [],
+  };
+}
+
+export function createDefaultRect(overrides?: Partial<RectTransform>): RectTransform {
+  return {
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    anchorMin: { x: 0.5, y: 0.5 },
+    anchorMax: { x: 0.5, y: 0.5 },
+    pivot: { x: 0.5, y: 0.5 },
+    rotation: 0,
+    ...overrides,
+  };
+}
+
+export const ELEMENT_DEFAULTS: Record<UIElementType, { rect: Partial<RectTransform>; props: UIElementProps }> = {
+  Panel: {
+    rect: { width: 300, height: 200 },
+    props: { backgroundColor: 'rgba(30, 41, 59, 0.8)', borderRadius: 8 },
+  },
+  Text: {
+    rect: { width: 200, height: 40 },
+    props: { text: 'New Text', fontSize: 16, fontColor: '#e6edf3', textAlign: 'center' },
+  },
+  Image: {
+    rect: { width: 150, height: 150 },
+    props: { backgroundColor: 'rgba(100, 116, 139, 0.3)', imageFit: 'contain', borderRadius: 4 },
+  },
+  Button: {
+    rect: { width: 160, height: 48 },
+    props: { label: 'Button', buttonColor: '#3b82f6', textColor: '#ffffff', borderRadius: 6, fontSize: 14 },
+  },
+};
+
+export const ELEMENT_TYPE_ICONS: Record<UIElementType, string> = {
+  Panel: '\u25A1',  // □
+  Text: 'T',
+  Image: '\u25A3',  // ▣
+  Button: '\u25A2',  // ▢
+};
+
+// ── Helpers ─────────────────────────────────────────
+
+export function getAbsolutePosition(
+  elementId: string,
+  elements: Record<string, UIElement>,
+): Vec2 {
+  const el = elements[elementId];
+  if (!el) return { x: 0, y: 0 };
+
+  let x = el.rect.x;
+  let y = el.rect.y;
+  let pid = el.parentId;
+
+  while (pid) {
+    const parent = elements[pid];
+    if (!parent) break;
+    x += parent.rect.x;
+    y += parent.rect.y;
+    pid = parent.parentId;
+  }
+
+  return { x, y };
+}

--- a/ars-editor/src/features/ui-view/types.ts
+++ b/ars-editor/src/features/ui-view/types.ts
@@ -1,6 +1,6 @@
 // UI View types — uGUI-inspired layout system for Ars editor
 
-export type UIElementType = 'Panel' | 'Text' | 'Image' | 'Button';
+export type UIElementType = 'Panel' | 'Text' | 'Image' | 'Button' | 'Custom';
 
 export interface Vec2 {
   x: number;
@@ -41,6 +41,8 @@ export interface UIElementProps {
   buttonColor?: string;
   hoverColor?: string;
   textColor?: string;
+  // Custom
+  typeName?: string;
 }
 
 export interface UIElement {
@@ -108,13 +110,18 @@ export const ELEMENT_DEFAULTS: Record<UIElementType, { rect: Partial<RectTransfo
     rect: { width: 160, height: 48 },
     props: { label: 'Button', buttonColor: '#3b82f6', textColor: '#ffffff', borderRadius: 6, fontSize: 14 },
   },
+  Custom: {
+    rect: { width: 240, height: 160 },
+    props: { typeName: 'MyCustomUI', borderColor: 'var(--purple)', backgroundColor: 'transparent' },
+  },
 };
 
 export const ELEMENT_TYPE_ICONS: Record<UIElementType, string> = {
-  Panel: '\u25A1',  // □
+  Panel: '\u25A1',   // □
   Text: 'T',
-  Image: '\u25A3',  // ▣
+  Image: '\u25A3',   // ▣
   Button: '\u25A2',  // ▢
+  Custom: '\u2726',  // ✦
 };
 
 // ── Helpers ─────────────────────────────────────────

--- a/ars-editor/src/features/ui-view/uiViewStore.ts
+++ b/ars-editor/src/features/ui-view/uiViewStore.ts
@@ -1,0 +1,331 @@
+import { create } from 'zustand';
+import { generateId } from '@/lib/utils';
+import type {
+  UICanvasData,
+  UIElement,
+  UIElementType,
+  UIElementProps,
+  RectTransform,
+  Vec2,
+} from './types';
+import { createDefaultCanvas, createDefaultRect, ELEMENT_DEFAULTS } from './types';
+
+interface UIViewState {
+  /** Per-scene canvas data */
+  canvases: Record<string, UICanvasData>;
+  selectedElementId: string | null;
+  hoveredElementId: string | null;
+  zoom: number;
+  panOffset: Vec2;
+
+  // Queries
+  getCanvas: (sceneId: string) => UICanvasData;
+
+  // Canvas actions
+  ensureCanvas: (sceneId: string) => void;
+  setCanvasSize: (sceneId: string, width: number, height: number) => void;
+
+  // Element CRUD
+  addElement: (sceneId: string, type: UIElementType, parentId?: string | null) => string;
+  removeElement: (sceneId: string, elementId: string) => void;
+  renameElement: (sceneId: string, elementId: string, name: string) => void;
+  toggleVisibility: (sceneId: string, elementId: string) => void;
+  updateRect: (sceneId: string, elementId: string, updates: Partial<RectTransform>) => void;
+  updateProps: (sceneId: string, elementId: string, updates: Partial<UIElementProps>) => void;
+  reparentElement: (sceneId: string, elementId: string, newParentId: string | null, index?: number) => void;
+  reorderElement: (sceneId: string, elementId: string, direction: 'up' | 'down') => void;
+
+  // Selection & viewport
+  selectElement: (id: string | null) => void;
+  setHovered: (id: string | null) => void;
+  setZoom: (zoom: number) => void;
+  setPan: (offset: Vec2) => void;
+  resetView: () => void;
+}
+
+function countByType(elements: Record<string, UIElement>, type: UIElementType): number {
+  return Object.values(elements).filter((e) => e.type === type).length;
+}
+
+function updateCanvasInState(
+  state: UIViewState,
+  sceneId: string,
+  updater: (canvas: UICanvasData) => UICanvasData,
+): Partial<UIViewState> {
+  const canvas = state.canvases[sceneId] ?? createDefaultCanvas();
+  return {
+    canvases: {
+      ...state.canvases,
+      [sceneId]: updater(canvas),
+    },
+  };
+}
+
+/** Recursively collect element and all descendant IDs */
+function collectDescendants(elements: Record<string, UIElement>, elementId: string): string[] {
+  const el = elements[elementId];
+  if (!el) return [];
+  const ids = [elementId];
+  for (const childId of el.childIds) {
+    ids.push(...collectDescendants(elements, childId));
+  }
+  return ids;
+}
+
+export const useUIViewStore = create<UIViewState>()((set, get) => ({
+  canvases: {},
+  selectedElementId: null,
+  hoveredElementId: null,
+  zoom: 0.5,
+  panOffset: { x: 0, y: 0 },
+
+  getCanvas: (sceneId) => {
+    return get().canvases[sceneId] ?? createDefaultCanvas();
+  },
+
+  ensureCanvas: (sceneId) =>
+    set((state) => {
+      if (state.canvases[sceneId]) return {};
+      return { canvases: { ...state.canvases, [sceneId]: createDefaultCanvas() } };
+    }),
+
+  setCanvasSize: (sceneId, width, height) =>
+    set((state) =>
+      updateCanvasInState(state, sceneId, (c) => ({ ...c, width, height })),
+    ),
+
+  addElement: (sceneId, type, parentId = null) => {
+    const id = generateId();
+    const state = get();
+    const canvas = state.canvases[sceneId] ?? createDefaultCanvas();
+    const defaults = ELEMENT_DEFAULTS[type];
+    const count = countByType(canvas.elements, type) + 1;
+
+    // Center new elements in parent or canvas
+    const parentRect = parentId
+      ? canvas.elements[parentId]?.rect
+      : null;
+    const containerW = parentRect?.width ?? canvas.width;
+    const containerH = parentRect?.height ?? canvas.height;
+    const elemW = defaults.rect.width ?? 200;
+    const elemH = defaults.rect.height ?? 100;
+
+    const element: UIElement = {
+      id,
+      name: `${type} ${count}`,
+      type,
+      parentId,
+      rect: createDefaultRect({
+        x: (containerW - elemW) / 2,
+        y: (containerH - elemH) / 2,
+        ...defaults.rect,
+      }),
+      visible: true,
+      props: { ...defaults.props },
+      childIds: [],
+    };
+
+    const newElements = { ...canvas.elements, [id]: element };
+
+    let newRootIds = canvas.rootIds;
+    if (parentId && newElements[parentId]) {
+      newElements[parentId] = {
+        ...newElements[parentId],
+        childIds: [...newElements[parentId].childIds, id],
+      };
+    } else {
+      newRootIds = [...canvas.rootIds, id];
+    }
+
+    set({
+      canvases: {
+        ...state.canvases,
+        [sceneId]: { ...canvas, elements: newElements, rootIds: newRootIds },
+      },
+      selectedElementId: id,
+    });
+
+    return id;
+  },
+
+  removeElement: (sceneId, elementId) =>
+    set((state) => {
+      const canvas = state.canvases[sceneId];
+      if (!canvas) return {};
+
+      const el = canvas.elements[elementId];
+      if (!el) return {};
+
+      const idsToRemove = new Set(collectDescendants(canvas.elements, elementId));
+      const newElements = { ...canvas.elements };
+      for (const id of idsToRemove) {
+        delete newElements[id];
+      }
+
+      // Remove from parent's childIds or rootIds
+      let newRootIds = canvas.rootIds;
+      if (el.parentId && newElements[el.parentId]) {
+        newElements[el.parentId] = {
+          ...newElements[el.parentId],
+          childIds: newElements[el.parentId].childIds.filter((c) => c !== elementId),
+        };
+      } else {
+        newRootIds = canvas.rootIds.filter((id) => id !== elementId);
+      }
+
+      return {
+        canvases: {
+          ...state.canvases,
+          [sceneId]: { ...canvas, elements: newElements, rootIds: newRootIds },
+        },
+        selectedElementId:
+          state.selectedElementId && idsToRemove.has(state.selectedElementId)
+            ? null
+            : state.selectedElementId,
+      };
+    }),
+
+  renameElement: (sceneId, elementId, name) =>
+    set((state) =>
+      updateCanvasInState(state, sceneId, (c) => ({
+        ...c,
+        elements: {
+          ...c.elements,
+          [elementId]: c.elements[elementId]
+            ? { ...c.elements[elementId], name }
+            : c.elements[elementId],
+        },
+      })),
+    ),
+
+  toggleVisibility: (sceneId, elementId) =>
+    set((state) =>
+      updateCanvasInState(state, sceneId, (c) => {
+        const el = c.elements[elementId];
+        if (!el) return c;
+        return {
+          ...c,
+          elements: { ...c.elements, [elementId]: { ...el, visible: !el.visible } },
+        };
+      }),
+    ),
+
+  updateRect: (sceneId, elementId, updates) =>
+    set((state) =>
+      updateCanvasInState(state, sceneId, (c) => {
+        const el = c.elements[elementId];
+        if (!el) return c;
+        return {
+          ...c,
+          elements: {
+            ...c.elements,
+            [elementId]: { ...el, rect: { ...el.rect, ...updates } },
+          },
+        };
+      }),
+    ),
+
+  updateProps: (sceneId, elementId, updates) =>
+    set((state) =>
+      updateCanvasInState(state, sceneId, (c) => {
+        const el = c.elements[elementId];
+        if (!el) return c;
+        return {
+          ...c,
+          elements: {
+            ...c.elements,
+            [elementId]: { ...el, props: { ...el.props, ...updates } },
+          },
+        };
+      }),
+    ),
+
+  reparentElement: (sceneId, elementId, newParentId, index) =>
+    set((state) => {
+      const canvas = state.canvases[sceneId];
+      if (!canvas) return {};
+      const el = canvas.elements[elementId];
+      if (!el) return {};
+
+      // Prevent parenting to self or descendant
+      if (newParentId) {
+        const descendants = collectDescendants(canvas.elements, elementId);
+        if (descendants.includes(newParentId)) return {};
+      }
+
+      const newElements = { ...canvas.elements };
+      let newRootIds = [...canvas.rootIds];
+
+      // Remove from old parent
+      if (el.parentId && newElements[el.parentId]) {
+        newElements[el.parentId] = {
+          ...newElements[el.parentId],
+          childIds: newElements[el.parentId].childIds.filter((c) => c !== elementId),
+        };
+      } else {
+        newRootIds = newRootIds.filter((id) => id !== elementId);
+      }
+
+      // Add to new parent
+      if (newParentId && newElements[newParentId]) {
+        const children = [...newElements[newParentId].childIds];
+        const insertAt = index != null ? Math.min(index, children.length) : children.length;
+        children.splice(insertAt, 0, elementId);
+        newElements[newParentId] = { ...newElements[newParentId], childIds: children };
+      } else {
+        const insertAt = index != null ? Math.min(index, newRootIds.length) : newRootIds.length;
+        newRootIds.splice(insertAt, 0, elementId);
+      }
+
+      newElements[elementId] = { ...el, parentId: newParentId };
+
+      return {
+        canvases: {
+          ...state.canvases,
+          [sceneId]: { ...canvas, elements: newElements, rootIds: newRootIds },
+        },
+      };
+    }),
+
+  reorderElement: (sceneId, elementId, direction) =>
+    set((state) => {
+      const canvas = state.canvases[sceneId];
+      if (!canvas) return {};
+      const el = canvas.elements[elementId];
+      if (!el) return {};
+
+      const newElements = { ...canvas.elements };
+      let newRootIds = [...canvas.rootIds];
+
+      const siblings = el.parentId
+        ? [...(newElements[el.parentId]?.childIds ?? [])]
+        : newRootIds;
+
+      const idx = siblings.indexOf(elementId);
+      if (idx === -1) return {};
+
+      const swapIdx = direction === 'up' ? idx - 1 : idx + 1;
+      if (swapIdx < 0 || swapIdx >= siblings.length) return {};
+
+      [siblings[idx], siblings[swapIdx]] = [siblings[swapIdx], siblings[idx]];
+
+      if (el.parentId && newElements[el.parentId]) {
+        newElements[el.parentId] = { ...newElements[el.parentId], childIds: siblings };
+      } else {
+        newRootIds = siblings;
+      }
+
+      return {
+        canvases: {
+          ...state.canvases,
+          [sceneId]: { ...canvas, elements: newElements, rootIds: newRootIds },
+        },
+      };
+    }),
+
+  selectElement: (id) => set({ selectedElementId: id }),
+  setHovered: (id) => set({ hoveredElementId: id }),
+  setZoom: (zoom) => set({ zoom: Math.max(0.1, Math.min(3, zoom)) }),
+  setPan: (offset) => set({ panOffset: offset }),
+  resetView: () => set({ zoom: 0.5, panOffset: { x: 0, y: 0 } }),
+}));


### PR DESCRIPTION
UIタブのプレースホルダーを、フル機能のUIレイアウトエディタに置き換え。
Canvas上にPanel/Text/Image/Buttonを配置し、ドラッグ移動・リサイズ・
ズーム/パン操作が可能なuGUI風のビジュアルレイアウトツールを構築。

主な構成:
- types.ts: UIElement/RectTransform/UICanvasData型定義
- uiViewStore.ts: シーン単位のUI要素CRUD、ビューポート状態管理
- UICanvas: ズーム/パン対応キャンバス、要素の再帰レンダリング、
  ドラッグ移動・8方向リサイズハンドル、グリッド表示
- UIHierarchy: ツリー表示、展開/折畳、表示切替、削除
- UIInspector: RectTransform編集、アンカープリセット、
  型別プロパティ（色・テキスト・フォント等）
- UIViewLayout: ツールバー+3カラムレイアウト統合

https://claude.ai/code/session_012vd7gsDcgSaX6Gjf61P4sk