### PR TITLE
ars-codegen: コードフィードバック機構の基盤モジュールを追加 (#89 Phase 1)

### DIFF
--- a/ars-editor/package-lock.json
+++ b/ars-editor/package-lock.json
@@ -1135,9 +1135,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1155,9 +1152,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,9 +1169,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,9 +1186,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1215,9 +1203,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1235,9 +1220,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1457,9 +1439,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1477,9 +1456,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1497,9 +1473,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1517,9 +1490,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1707,9 +1677,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1727,9 +1694,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1747,9 +1711,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1767,9 +1728,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1787,9 +1745,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3572,9 +3527,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3596,9 +3548,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3620,9 +3569,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3644,9 +3590,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/ars-editor/src-tauri/src/web_modules/editor.rs
+++ b/ars-editor/src-tauri/src/web_modules/editor.rs
@@ -25,6 +25,7 @@ use ars_codegen::bridge::{
     CodegenBridge, CodegenBridgeConfig, CodegenPreviewResult,
     OutputFormat, TargetPlatform,
 };
+use ars_codegen::feedback::{ApplyResult, FeedbackApplyOptions, FeedbackReport};
 
 const SESSION_COOKIE: &str = "ars_session";
 
@@ -440,6 +441,84 @@ async fn api_codegen_preview(
     Ok(Json(result))
 }
 
+// ========== Code Feedback APIs ==========
+
+/// フィードバック差分検出リクエスト
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodegenFeedbackRequest {
+    /// プロジェクトファイルパス
+    project_path: String,
+    config: CodegenBridgeConfig,
+}
+
+/// フィードバック差分検出
+async fn api_codegen_feedback(
+    Json(req): Json<CodegenFeedbackRequest>,
+) -> Result<Json<FeedbackReport>, (StatusCode, String)> {
+    let project_path = std::path::PathBuf::from(&req.project_path);
+    if !project_path.exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("プロジェクトファイルが見つかりません: {}", req.project_path),
+        ));
+    }
+    let report = CodegenBridge::feedback(&project_path, &req.config)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(report))
+}
+
+/// フィードバック適用リクエスト
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CodegenApplyRequest {
+    /// プロジェクトファイルパス
+    project_path: String,
+    project: Project,
+    config: CodegenBridgeConfig,
+    /// stale マーカーを追記するか（デフォルト true）
+    #[serde(default = "default_true")]
+    mark_code_stale: bool,
+    /// バックアップを作成するか（デフォルト true）
+    #[serde(default = "default_true")]
+    backup_project: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// フィードバック適用レスポンス
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CodegenApplyResponse {
+    result: ApplyResult,
+    /// 反映後の Project（UI のステートを差し替えるため）
+    project: Project,
+}
+
+/// フィードバック差分を適用し、更新後の Project を返す
+async fn api_codegen_apply(
+    Json(req): Json<CodegenApplyRequest>,
+) -> Result<Json<CodegenApplyResponse>, (StatusCode, String)> {
+    let project_path = std::path::PathBuf::from(&req.project_path);
+    if !project_path.exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("プロジェクトファイルが見つかりません: {}", req.project_path),
+        ));
+    }
+    let mut project = req.project;
+    let opts = FeedbackApplyOptions {
+        apply_codedesign_to_project: true,
+        mark_code_stale: req.mark_code_stale,
+        backup_project: req.backup_project,
+    };
+    let result = CodegenBridge::apply(&project_path, &mut project, &req.config, &opts)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(CodegenApplyResponse { result, project }))
+}
+
 /// エディタモジュールのルーターを構築
 pub fn router(state: AppState) -> Router {
     Router::new()
@@ -467,5 +546,8 @@ pub fn router(state: AppState) -> Router {
         // Code generation bridge APIs
         .route("/api/codegen/options", get(api_codegen_options))
         .route("/api/codegen/preview", post(api_codegen_preview))
+        // Code feedback APIs
+        .route("/api/codegen/feedback", post(api_codegen_feedback))
+        .route("/api/codegen/apply", post(api_codegen_apply))
         .with_state(state)
 }

--- a/ars-editor/src/components/Toolbar.tsx
+++ b/ars-editor/src/components/Toolbar.tsx
@@ -12,7 +12,7 @@ import { safeLoadProject } from '@/lib/project-loader';
 import { ProjectManager } from './ProjectManager';
 import { ProjectWizard } from './ProjectWizard';
 import { ArchetypeWizard } from '@/features/archetype-wizard';
-import { CodegenBridgeDialog } from '@/features/codegen-bridge';
+import { CodegenBridgeDialog, CodegenFeedbackDialog } from '@/features/codegen-bridge';
 import { GettingStartedGuide } from './GettingStartedGuide';
 import { ProjectListDialog } from './ProjectListDialog';
 import { LanguageSettings } from './LanguageSettings';
@@ -132,6 +132,7 @@ export function Toolbar() {
   const [showProjectList, setShowProjectList] = useState(false);
   const [showLanguageSettings, setShowLanguageSettings] = useState(false);
   const [showCodegenBridge, setShowCodegenBridge] = useState(false);
+  const [showCodeFeedback, setShowCodeFeedback] = useState(false);
   const [pushing, setPushing] = useState(false);
   const isMobile = useIsMobile();
 
@@ -208,7 +209,8 @@ export function Toolbar() {
     { label: t('toolbar.openProject'), onClick: handleLoad },
     { label: `${t('toolbar.save')}${isDirty ? ' *' : ''}`, onClick: handleSave },
     { label: t('toolbar.archetypeWizard'), onClick: () => setShowArchetypeWizard(true), color: 'var(--accent)' },
-    { label: t('toolbar.codeGeneration'), onClick: () => setShowCodegenBridge(true), color: 'var(--green)', dividerAfter: true },
+    { label: t('toolbar.codeGeneration'), onClick: () => setShowCodegenBridge(true), color: 'var(--green)' },
+    { label: t('toolbar.codeFeedback'), onClick: () => setShowCodeFeedback(true), color: 'var(--orange)', dividerAfter: true },
     { label: t('toolbar.undo'), onClick: () => { if (isGenerating) abortGeneration(); undo(); markDirty(); }, disabled: !canUndo() },
     { label: t('toolbar.redo'), onClick: () => { redo(); markDirty(); }, disabled: !canRedo(), dividerAfter: true },
     ...(activeGitRepo ? [{ label: t('toolbar.pushToGithub'), onClick: handleGitPush, disabled: pushing, color: 'var(--green)', dividerAfter: true as const }] : []),
@@ -252,6 +254,7 @@ export function Toolbar() {
       {showProjectList && <ProjectListDialog onClose={() => setShowProjectList(false)} />}
       {showLanguageSettings && <LanguageSettings onClose={() => setShowLanguageSettings(false)} />}
       {showCodegenBridge && <CodegenBridgeDialog onClose={() => setShowCodegenBridge(false)} />}
+      {showCodeFeedback && <CodegenFeedbackDialog onClose={() => setShowCodeFeedback(false)} />}
     </>
   );
 

--- a/ars-editor/src/features/codegen-bridge/components/CodegenFeedbackDialog.tsx
+++ b/ars-editor/src/features/codegen-bridge/components/CodegenFeedbackDialog.tsx
@@ -1,0 +1,477 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useProjectStore } from '@/stores/projectStore';
+import { useEditorStore } from '@/stores/editorStore';
+import * as backend from '@/lib/backend';
+import type {
+  CodegenBridgeConfig,
+  FeedbackReport,
+  ApplyResult,
+  FileChange,
+} from '@/types/codegen';
+
+// ── Badge helpers ───────────────────────────────────
+
+function changeBadge(change: string) {
+  switch (change) {
+    case 'added':
+      return { label: 'ADD', bg: '#4CAF50', fg: '#fff' };
+    case 'modified':
+      return { label: 'MOD', bg: '#FF9800', fg: '#fff' };
+    case 'removed':
+      return { label: 'DEL', bg: '#f44336', fg: '#fff' };
+    default:
+      return { label: change, bg: '#888', fg: '#fff' };
+  }
+}
+
+function kindBadge(kind: string) {
+  switch (kind) {
+    case 'code':
+      return { label: 'code', color: '#2196F3' };
+    case 'codedesign':
+      return { label: 'design', color: '#9C27B0' };
+    case 'project':
+      return { label: 'project', color: '#FF5722' };
+    default:
+      return { label: kind, color: '#888' };
+  }
+}
+
+// ── Main Component ──────────────────────────────────
+
+type Phase = 'detect' | 'report' | 'applied';
+
+export function CodegenFeedbackDialog({ onClose }: { onClose: () => void }) {
+  const project = useProjectStore((s) => s.project);
+  const loadProject = useProjectStore((s) => s.loadProject);
+  const projectPath = useEditorStore((s) => s.projectPath);
+
+  const [phase, setPhase] = useState<Phase>('detect');
+  const [report, setReport] = useState<FeedbackReport | null>(null);
+  const [applyResult, setApplyResult] = useState<ApplyResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [outputDir, setOutputDir] = useState('./generated');
+  const [markStale, setMarkStale] = useState(true);
+  const [createBackup, setCreateBackup] = useState(true);
+
+  const buildConfig = useCallback((): CodegenBridgeConfig => ({
+    platform: 'ergo',
+    outputFormat: 'source-only',
+    outputDir,
+    sceneIds: [],
+    componentIds: [],
+    dryRun: false,
+    maxConcurrent: 1,
+  }), [outputDir]);
+
+  // Auto-detect on mount
+  useEffect(() => {
+    if (!projectPath) return;
+    handleDetect();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleDetect = useCallback(async () => {
+    if (!projectPath) {
+      setError('Project file path is not set. Save your project first.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await backend.codegenFeedback(projectPath, buildConfig());
+      setReport(result);
+      setPhase('report');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Feedback detection failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectPath, buildConfig]);
+
+  const handleApply = useCallback(async () => {
+    if (!projectPath || !report) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await backend.codegenApply(projectPath, project, buildConfig(), {
+        markCodeStale: markStale,
+        backupProject: createBackup,
+      });
+      setApplyResult(resp.result);
+      // Update UI project state with the mutated Project
+      loadProject(resp.project);
+      setPhase('applied');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Apply failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectPath, project, report, buildConfig, markStale, createBackup, loadProject]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const hasChanges = report && (report.changes.length > 0 || report.projectChanged);
+  const hasCodedesignChanges = report?.changes.some(
+    (c) => c.kind === 'codedesign' && c.change !== 'removed',
+  );
+  const hasCodeChanges = report?.changes.some(
+    (c) => c.kind === 'code' && c.change !== 'removed',
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.6)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="rounded-xl shadow-2xl overflow-hidden flex flex-col"
+        style={{
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--border)',
+          width: '640px',
+          maxHeight: '80vh',
+        }}
+      >
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-5 py-3"
+          style={{ borderBottom: '1px solid var(--border)' }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--text)' }}>
+            Code Feedback
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-sm px-2 py-1 rounded transition-colors"
+            style={{ color: 'var(--text-muted)', background: 'transparent', border: 'none' }}
+          >
+            x
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4" style={{ minHeight: '200px' }}>
+          {error && (
+            <div
+              className="text-xs px-3 py-2 rounded mb-3"
+              style={{ background: '#f443361a', color: '#f44336', border: '1px solid #f4433644' }}
+            >
+              {error}
+            </div>
+          )}
+
+          {/* Detect phase */}
+          {phase === 'detect' && !loading && (
+            <div className="space-y-3">
+              <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                Detect changes in generated code and codedesign since the last sync.
+              </p>
+              <div className="space-y-2">
+                <label className="block text-xs font-medium" style={{ color: 'var(--text)' }}>
+                  Output Directory
+                </label>
+                <input
+                  type="text"
+                  value={outputDir}
+                  onChange={(e) => setOutputDir(e.target.value)}
+                  className="w-full text-xs px-3 py-2 rounded"
+                  style={{
+                    background: 'var(--bg-input)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--text)',
+                  }}
+                />
+              </div>
+              {!projectPath && (
+                <p className="text-xs" style={{ color: '#FF9800' }}>
+                  Save your project to a file before running feedback.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Report phase */}
+          {phase === 'report' && report && (
+            <div className="space-y-3">
+              {report.manifestMissing && (
+                <div
+                  className="text-xs px-3 py-2 rounded"
+                  style={{ background: '#2196F31a', color: '#2196F3', border: '1px solid #2196F344' }}
+                >
+                  No manifest found. Run Code Generation first to establish a baseline.
+                </div>
+              )}
+
+              {!hasChanges && !report.manifestMissing && (
+                <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                  No changes detected.
+                </p>
+              )}
+
+              {hasChanges && (
+                <>
+                  {/* Summary */}
+                  <div className="flex gap-4 text-xs" style={{ color: 'var(--text-muted)' }}>
+                    <span>
+                      Added: <strong style={{ color: '#4CAF50' }}>{report.changes.filter(c => c.change === 'added').length}</strong>
+                    </span>
+                    <span>
+                      Modified: <strong style={{ color: '#FF9800' }}>{report.changes.filter(c => c.change === 'modified').length}</strong>
+                    </span>
+                    <span>
+                      Removed: <strong style={{ color: '#f44336' }}>{report.changes.filter(c => c.change === 'removed').length}</strong>
+                    </span>
+                    {report.projectChanged && (
+                      <span style={{ color: '#FF5722' }}>Project file changed</span>
+                    )}
+                  </div>
+
+                  {/* Change list */}
+                  <div
+                    className="rounded overflow-hidden"
+                    style={{ border: '1px solid var(--border)' }}
+                  >
+                    {report.changes.map((c, i) => (
+                      <ChangeRow key={i} change={c} />
+                    ))}
+                  </div>
+
+                  {/* Apply options */}
+                  <div
+                    className="space-y-2 pt-2"
+                    style={{ borderTop: '1px solid var(--border)' }}
+                  >
+                    <p className="text-xs font-medium" style={{ color: 'var(--text)' }}>
+                      Apply Options
+                    </p>
+                    <label className="flex items-center gap-2 text-xs" style={{ color: 'var(--text)' }}>
+                      <input
+                        type="checkbox"
+                        checked={markStale}
+                        onChange={(e) => setMarkStale(e.target.checked)}
+                      />
+                      Mark stale codedesign when code changes
+                      {hasCodeChanges && (
+                        <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                          ({report.changes.filter(c => c.kind === 'code' && c.change !== 'removed').length} files)
+                        </span>
+                      )}
+                    </label>
+                    <label className="flex items-center gap-2 text-xs" style={{ color: 'var(--text)' }}>
+                      <input
+                        type="checkbox"
+                        checked={createBackup}
+                        onChange={(e) => setCreateBackup(e.target.checked)}
+                      />
+                      Create project backup before apply
+                    </label>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Applied phase */}
+          {phase === 'applied' && applyResult && (
+            <div className="space-y-3">
+              <div
+                className="text-xs px-3 py-2 rounded"
+                style={{ background: '#4CAF501a', color: '#4CAF50', border: '1px solid #4CAF5044' }}
+              >
+                Feedback applied successfully.
+              </div>
+
+              {applyResult.backupPath && (
+                <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                  Backup: <code style={{ color: 'var(--text)' }}>{applyResult.backupPath}</code>
+                </p>
+              )}
+
+              {applyResult.applied.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium mb-1" style={{ color: 'var(--text)' }}>
+                    Applied to Project ({applyResult.applied.length})
+                  </p>
+                  <div
+                    className="rounded text-xs space-y-1 p-2"
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border)' }}
+                  >
+                    {applyResult.applied.map((a, i) => (
+                      <div key={i} style={{ color: 'var(--text)' }}>
+                        <span style={{ color: '#4CAF50' }}>{a.entityName || a.path}</span>
+                        {' — '}
+                        <span style={{ color: 'var(--text-muted)' }}>{a.summary}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {applyResult.staleMarked.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium mb-1" style={{ color: 'var(--text)' }}>
+                    Stale markers added ({applyResult.staleMarked.length})
+                  </p>
+                  <div
+                    className="rounded text-xs space-y-1 p-2"
+                    style={{ background: 'var(--bg-input)', border: '1px solid var(--border)' }}
+                  >
+                    {applyResult.staleMarked.map((s, i) => (
+                      <div key={i} style={{ color: '#FF9800' }}>{s}</div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {applyResult.requiresReview.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium mb-1" style={{ color: '#FF9800' }}>
+                    Requires Review ({applyResult.requiresReview.length})
+                  </p>
+                  <div
+                    className="rounded text-xs space-y-1 p-2"
+                    style={{ background: '#FF98001a', border: '1px solid #FF980044' }}
+                  >
+                    {applyResult.requiresReview.map((r, i) => (
+                      <div key={i} style={{ color: 'var(--text)' }}>
+                        <span>{r.entityName || r.path}</span>
+                        {' — '}
+                        <span style={{ color: 'var(--text-muted)' }}>{r.summary}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Loading spinner */}
+          {loading && (
+            <div className="flex items-center justify-center py-8">
+              <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                {phase === 'detect' ? 'Detecting changes...' : 'Applying changes...'}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex items-center justify-between px-5 py-3"
+          style={{ borderTop: '1px solid var(--border)' }}
+        >
+          <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            {phase === 'report' && hasChanges && (
+              <>
+                {hasCodedesignChanges && 'Codedesign changes will update the Project. '}
+                {hasCodeChanges && 'Code changes will mark codedesign as stale.'}
+              </>
+            )}
+          </div>
+          <div className="flex gap-2">
+            {phase === 'applied' && (
+              <button
+                onClick={onClose}
+                className="text-xs px-4 py-1.5 rounded font-medium"
+                style={{
+                  background: 'var(--green)',
+                  color: '#fff',
+                  border: 'none',
+                }}
+              >
+                Done
+              </button>
+            )}
+            {phase === 'detect' && (
+              <button
+                onClick={handleDetect}
+                disabled={loading || !projectPath}
+                className="text-xs px-4 py-1.5 rounded font-medium"
+                style={{
+                  background: loading || !projectPath ? 'var(--border)' : 'var(--blue)',
+                  color: '#fff',
+                  border: 'none',
+                  opacity: loading || !projectPath ? 0.5 : 1,
+                }}
+              >
+                Detect Changes
+              </button>
+            )}
+            {phase === 'report' && (
+              <>
+                <button
+                  onClick={() => { setPhase('detect'); setReport(null); }}
+                  className="text-xs px-4 py-1.5 rounded"
+                  style={{
+                    background: 'transparent',
+                    color: 'var(--text-muted)',
+                    border: '1px solid var(--border)',
+                  }}
+                >
+                  Back
+                </button>
+                {hasChanges && (
+                  <button
+                    onClick={handleApply}
+                    disabled={loading}
+                    className="text-xs px-4 py-1.5 rounded font-medium"
+                    style={{
+                      background: loading ? 'var(--border)' : '#FF9800',
+                      color: '#fff',
+                      border: 'none',
+                      opacity: loading ? 0.5 : 1,
+                    }}
+                  >
+                    Apply Changes
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────
+
+function ChangeRow({ change }: { change: FileChange }) {
+  const cb = changeBadge(change.change);
+  const kb = kindBadge(change.kind);
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 text-xs"
+      style={{ borderBottom: '1px solid var(--border)' }}
+    >
+      <span
+        className="px-1.5 py-0.5 rounded text-[10px] font-bold"
+        style={{ background: cb.bg, color: cb.fg, minWidth: '32px', textAlign: 'center' }}
+      >
+        {cb.label}
+      </span>
+      <span
+        className="px-1.5 py-0.5 rounded text-[10px]"
+        style={{ color: kb.color, border: `1px solid ${kb.color}44` }}
+      >
+        {kb.label}
+      </span>
+      <span className="flex-1 truncate" style={{ color: 'var(--text)' }}>
+        {change.path}
+      </span>
+      {change.entityName && (
+        <span style={{ color: 'var(--text-muted)' }}>{change.entityName}</span>
+      )}
+    </div>
+  );
+}

--- a/ars-editor/src/features/codegen-bridge/index.tsx
+++ b/ars-editor/src/features/codegen-bridge/index.tsx
@@ -1,1 +1,2 @@
 export { CodegenBridgeDialog } from './components/CodegenBridgeDialog';
+export { CodegenFeedbackDialog } from './components/CodegenFeedbackDialog';

--- a/ars-editor/src/lib/backend.ts
+++ b/ars-editor/src/lib/backend.ts
@@ -3,6 +3,8 @@ import type {
   CodegenOptions,
   CodegenBridgeConfig,
   CodegenPreviewResult,
+  FeedbackReport,
+  CodegenApplyResponse,
 } from '@/types/codegen';
 
 function isTauri(): boolean {
@@ -72,6 +74,36 @@ export async function codegenPreview(
   return webFetch<CodegenPreviewResult>('/codegen/preview', {
     method: 'POST',
     body: JSON.stringify({ project, config }),
+  });
+}
+
+// ── Code Feedback ──────────────────────────────────
+
+export async function codegenFeedback(
+  projectPath: string,
+  config: CodegenBridgeConfig,
+): Promise<FeedbackReport> {
+  return webFetch<FeedbackReport>('/codegen/feedback', {
+    method: 'POST',
+    body: JSON.stringify({ projectPath, config }),
+  });
+}
+
+export async function codegenApply(
+  projectPath: string,
+  project: Project,
+  config: CodegenBridgeConfig,
+  options?: { markCodeStale?: boolean; backupProject?: boolean },
+): Promise<CodegenApplyResponse> {
+  return webFetch<CodegenApplyResponse>('/codegen/apply', {
+    method: 'POST',
+    body: JSON.stringify({
+      projectPath,
+      project,
+      config,
+      markCodeStale: options?.markCodeStale ?? true,
+      backupProject: options?.backupProject ?? true,
+    }),
   });
 }
 

--- a/ars-editor/src/types/codegen.ts
+++ b/ars-editor/src/types/codegen.ts
@@ -37,6 +37,7 @@ export interface CodegenBridgeConfig {
   maxConcurrent: number;
   model?: string;
   permissionMode?: string;
+  codedesignRoot?: string;
 }
 
 /** プレビュータスク */
@@ -57,4 +58,57 @@ export interface CodegenPreviewResult {
   fileExtension: string;
   tasks: CodegenPreviewTask[];
   totalTasks: number;
+}
+
+// ========== Feedback / Apply ==========
+
+/** 変更種別 */
+export type ChangeKind = 'added' | 'modified' | 'removed';
+
+/** ファイル種別 */
+export type FileKind = 'code' | 'codedesign' | 'project';
+
+/** レイアウトカテゴリ */
+export type LayoutCategory = 'scene' | 'actor' | 'module' | 'action' | 'ui' | 'data';
+
+/** 個別ファイルの変更レコード */
+export interface FileChange {
+  change: ChangeKind;
+  kind: FileKind;
+  path: string;
+  category?: LayoutCategory;
+  entityId?: string;
+  entityName?: string;
+  previousCrc32?: string;
+  currentCrc32?: string;
+}
+
+/** フィードバック差分レポート */
+export interface FeedbackReport {
+  projectChanged: boolean;
+  manifestMissing: boolean;
+  changes: FileChange[];
+}
+
+/** 適用済み変更の 1 件 */
+export interface AppliedChange {
+  path: string;
+  kind: FileKind;
+  entityId?: string;
+  entityName?: string;
+  summary: string;
+}
+
+/** apply_feedback の結果 */
+export interface ApplyResult {
+  applied: AppliedChange[];
+  staleMarked: string[];
+  requiresReview: AppliedChange[];
+  backupPath?: string;
+}
+
+/** apply レスポンス (バックエンドから返却) */
+export interface CodegenApplyResponse {
+  result: ApplyResult;
+  project: import('./domain').Project;
 }

--- a/crates/ars-codegen/src/bridge.rs
+++ b/crates/ars-codegen/src/bridge.rs
@@ -4,8 +4,12 @@
 //! 対象環境・出力フォーマットの選択を UI 側で行い、このモジュールの型を通じて
 //! PromptGenerator / SessionRunner に橋渡しする。
 
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
 
+use crate::feedback::{detect_changes, FeedbackInputs, FeedbackReport};
+use crate::manifest::CodegenManifest;
 use crate::prompt_generator::{CodegenTask, PromptGenerator};
 use ars_core::models::Project;
 
@@ -143,6 +147,9 @@ pub struct CodegenBridgeConfig {
     /// パーミッションモード (auto/default/plan)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permission_mode: Option<String>,
+    /// codedesign ルートパス（省略時は `{project_dir}/codedesign`）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codedesign_root: Option<String>,
 }
 
 fn default_output_dir() -> String {
@@ -266,6 +273,33 @@ impl CodegenBridge {
             claude_permission_mode: config.permission_mode.clone(),
         }
     }
+
+    /// プロジェクトディレクトリ + 出力設定から差分を検出する。
+    ///
+    /// 直近 `generate` 実行時に保存された `.ars-cache/codegen-manifest.json` を
+    /// 基準点として、現在のコード／コード詳細設計／プロジェクトファイルとの差分を返す。
+    pub fn feedback(
+        project_file: &Path,
+        config: &CodegenBridgeConfig,
+    ) -> Result<FeedbackReport, String> {
+        let project_dir = project_file
+            .parent()
+            .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+        let output_root = std::path::PathBuf::from(&config.output_dir);
+        let codedesign_root = config
+            .codedesign_root
+            .as_ref()
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| project_dir.join("codedesign"));
+        let manifest_path = CodegenManifest::default_path(project_dir);
+
+        detect_changes(&FeedbackInputs {
+            project_file,
+            output_root: &output_root,
+            codedesign_root: Some(&codedesign_root),
+            manifest_path: &manifest_path,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -332,6 +366,7 @@ mod tests {
             max_concurrent: 1,
             model: None,
             permission_mode: None,
+            codedesign_root: None,
         };
         let result = CodegenBridge::preview(&project, &config);
         assert_eq!(result.total_tasks, 0);

--- a/crates/ars-codegen/src/bridge.rs
+++ b/crates/ars-codegen/src/bridge.rs
@@ -8,9 +8,13 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::feedback::{detect_changes, FeedbackInputs, FeedbackReport};
+use crate::feedback::{
+    apply_feedback, detect_changes, refresh_manifest, ApplyResult, FeedbackApplyOptions,
+    FeedbackInputs, FeedbackReport,
+};
 use crate::manifest::CodegenManifest;
 use crate::prompt_generator::{CodegenTask, PromptGenerator};
+use crate::project_loader::save_project;
 use ars_core::models::Project;
 
 // ── 対象プラットフォーム ────────────────────────────────
@@ -299,6 +303,53 @@ impl CodegenBridge {
             codedesign_root: Some(&codedesign_root),
             manifest_path: &manifest_path,
         })
+    }
+
+    /// `feedback` で得た差分を Project / codedesign に反映し、manifest を更新する。
+    ///
+    /// - codedesign の編集 → Project の対応エンティティ（Actor/Action/Component）に上書き
+    /// - code の変更    → 対応する codedesign MD に stale マーカーを追記
+    /// - 反映後の Project は `project_file` に pretty JSON で書き戻す
+    /// - manifest を最新スナップショットに更新する
+    pub fn apply(
+        project_file: &Path,
+        project: &mut Project,
+        config: &CodegenBridgeConfig,
+        opts: &FeedbackApplyOptions,
+    ) -> Result<ApplyResult, String> {
+        let project_dir = project_file
+            .parent()
+            .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+        let output_root = std::path::PathBuf::from(&config.output_dir);
+        let codedesign_root = config
+            .codedesign_root
+            .as_ref()
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| project_dir.join("codedesign"));
+        let manifest_path = CodegenManifest::default_path(project_dir);
+
+        let inputs = FeedbackInputs {
+            project_file,
+            output_root: &output_root,
+            codedesign_root: Some(&codedesign_root),
+            manifest_path: &manifest_path,
+        };
+
+        let report = detect_changes(&inputs)?;
+        let result = apply_feedback(project, &report, &inputs, opts)?;
+
+        // Project → ファイル書き戻し（変更があった場合のみ）
+        if !result.applied.is_empty() {
+            save_project(project_file, project)?;
+        }
+
+        // manifest を最新化（既存があればそれを基に refresh、無ければスキップ）
+        if let Some(prev) = CodegenManifest::load_from(&manifest_path)? {
+            let next = refresh_manifest(&prev, &inputs)?;
+            next.save_to(&manifest_path)?;
+        }
+
+        Ok(result)
     }
 }
 

--- a/crates/ars-codegen/src/code_layout.rs
+++ b/crates/ars-codegen/src/code_layout.rs
@@ -68,6 +68,7 @@ impl LayoutCategory {
     }
 
     /// 文字列からの復元
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_ascii_lowercase().as_str() {
             "scene" => Some(Self::Scene),

--- a/crates/ars-codegen/src/code_layout.rs
+++ b/crates/ars-codegen/src/code_layout.rs
@@ -1,0 +1,287 @@
+//! コード生成の出力レイアウト
+//!
+//! Ars プロジェクトの構造（Scene / Actor / Module / Action / UI / Data）と
+//! 1:1 で対応するディレクトリ構造とクラス命名規則を提供する。
+//!
+//! - **Scene / Actor / UI / Data** : クラス名にカテゴリ名のサフィックスを付与する。
+//!   - 例: `MainScene`, `PlayerActor`, `HealthBarUI`, `GameStateData`
+//! - **Module / Action** : サフィックスを付与しない（バレな名前を使う）。
+//!   - 例: `Health`, `Attack`
+//!
+//! コード詳細設計（codedesign）と生成コードのパスは本モジュールの関数で
+//! 一貫した形に揃え、フィードバック処理（manifest との突き合わせ）でも同じ
+//! 形を再現する。
+
+use serde::{Deserialize, Serialize};
+
+/// 生成エンティティのカテゴリ
+///
+/// Ars プロジェクトの主要構造に 1:1 で対応する。
+/// `Module` と `Action` のみクラス名にサフィックスを付与しない。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LayoutCategory {
+    Scene,
+    Actor,
+    Module,
+    Action,
+    Ui,
+    Data,
+}
+
+impl LayoutCategory {
+    /// ディレクトリ名（出力ルート直下のフォルダ名）
+    pub fn dir_name(&self) -> &'static str {
+        match self {
+            Self::Scene => "Scene",
+            Self::Actor => "Actor",
+            Self::Module => "Module",
+            Self::Action => "Action",
+            Self::Ui => "UI",
+            Self::Data => "Data",
+        }
+    }
+
+    /// クラス名に付与するサフィックス（ない場合は空文字列）
+    ///
+    /// Module / Action はサフィックスを付けない。
+    pub fn class_suffix(&self) -> &'static str {
+        match self {
+            Self::Scene => "Scene",
+            Self::Actor => "Actor",
+            Self::Ui => "UI",
+            Self::Data => "Data",
+            Self::Module | Self::Action => "",
+        }
+    }
+
+    /// 文字列名称（manifest や CLI で使う）
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Scene => "scene",
+            Self::Actor => "actor",
+            Self::Module => "module",
+            Self::Action => "action",
+            Self::Ui => "ui",
+            Self::Data => "data",
+        }
+    }
+
+    /// 文字列からの復元
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "scene" => Some(Self::Scene),
+            "actor" => Some(Self::Actor),
+            "module" | "component" => Some(Self::Module),
+            "action" => Some(Self::Action),
+            "ui" => Some(Self::Ui),
+            "data" => Some(Self::Data),
+            _ => None,
+        }
+    }
+}
+
+/// コンポーネントカテゴリ ("UI" / "Logic" / ... ) を LayoutCategory に振り分ける。
+///
+/// `category == "UI"` のみ `LayoutCategory::Ui` に分類し、
+/// それ以外は `LayoutCategory::Module` として扱う。
+pub fn classify_component_category(component_category: &str) -> LayoutCategory {
+    if component_category.eq_ignore_ascii_case("UI") {
+        LayoutCategory::Ui
+    } else {
+        LayoutCategory::Module
+    }
+}
+
+/// 任意の入力文字列を PascalCase に変換する。
+///
+/// アルファベットの区切り（空白・ハイフン・アンダースコア・ピリオド）を境界として
+/// 各セグメントを連結し、各セグメントの先頭を大文字化する。日本語などの非ASCII文字は
+/// そのまま保持し、PascalCase 化はASCII英数字部分にのみ作用する。
+pub fn to_pascal_case(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut capitalize_next = true;
+    for ch in input.chars() {
+        if ch.is_ascii_whitespace() || matches!(ch, '-' | '_' | '.' | '/' | '\\') {
+            capitalize_next = true;
+            continue;
+        }
+        if capitalize_next {
+            for upper in ch.to_uppercase() {
+                out.push(upper);
+            }
+            capitalize_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// 任意の入力文字列を kebab-case に変換する。
+///
+/// PascalCase / camelCase の大文字遷移を `-` で区切り、空白・アンダースコアも `-` に
+/// 統一して全体を小文字化する。
+pub fn to_kebab_case(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut prev_lower_or_digit = false;
+    for ch in input.chars() {
+        if ch.is_ascii_whitespace() || matches!(ch, '_' | '.' | '/' | '\\') {
+            if !out.ends_with('-') {
+                out.push('-');
+            }
+            prev_lower_or_digit = false;
+            continue;
+        }
+        if ch == '-' {
+            if !out.ends_with('-') {
+                out.push('-');
+            }
+            prev_lower_or_digit = false;
+            continue;
+        }
+        if ch.is_ascii_uppercase() {
+            if prev_lower_or_digit && !out.ends_with('-') {
+                out.push('-');
+            }
+            for lower in ch.to_lowercase() {
+                out.push(lower);
+            }
+            prev_lower_or_digit = false;
+        } else {
+            out.push(ch);
+            prev_lower_or_digit = ch.is_ascii_alphanumeric();
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    trimmed.to_string()
+}
+
+/// クラス名を組み立てる
+///
+/// 入力名を PascalCase 化し、`LayoutCategory::class_suffix()` を末尾に付与する。
+pub fn class_name_for(category: LayoutCategory, raw_name: &str) -> String {
+    let base = to_pascal_case(raw_name);
+    let suffix = category.class_suffix();
+    if suffix.is_empty() || base.ends_with(suffix) {
+        base
+    } else {
+        format!("{}{}", base, suffix)
+    }
+}
+
+/// 出力ファイル名（拡張子付き）
+pub fn file_name_for(category: LayoutCategory, raw_name: &str, ext: &str) -> String {
+    format!("{}{}", class_name_for(category, raw_name), ext)
+}
+
+/// エンティティ単位の出力ディレクトリパスを生成する。
+///
+/// パスは出力ルート直下の `{Category}/{ClassName}/` で構成される。Module / Action は
+/// クラス名にサフィックスが付かないため `{Category}/{Name}/` となる。
+pub fn entity_dir(output_root: &str, category: LayoutCategory, raw_name: &str) -> String {
+    format!(
+        "{}/{}/{}",
+        trim_trailing_sep(output_root),
+        category.dir_name(),
+        class_name_for(category, raw_name)
+    )
+}
+
+/// 単一ファイル配置のエンティティ用ファイルパスを返す（サブディレクトリを作らない）。
+pub fn flat_entity_path(
+    output_root: &str,
+    category: LayoutCategory,
+    raw_name: &str,
+    ext: &str,
+) -> String {
+    format!(
+        "{}/{}/{}",
+        trim_trailing_sep(output_root),
+        category.dir_name(),
+        file_name_for(category, raw_name, ext)
+    )
+}
+
+fn trim_trailing_sep(s: &str) -> &str {
+    s.trim_end_matches('/').trim_end_matches('\\')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pascal_case_basic() {
+        assert_eq!(to_pascal_case("player character"), "PlayerCharacter");
+        assert_eq!(to_pascal_case("player-character"), "PlayerCharacter");
+        assert_eq!(to_pascal_case("playerCharacter"), "PlayerCharacter");
+        assert_eq!(to_pascal_case("PLAYER_character"), "PLAYERCharacter");
+    }
+
+    #[test]
+    fn kebab_case_basic() {
+        assert_eq!(to_kebab_case("PlayerCharacter"), "player-character");
+        assert_eq!(to_kebab_case("player_character"), "player-character");
+        assert_eq!(to_kebab_case("Player Character"), "player-character");
+    }
+
+    #[test]
+    fn class_name_with_suffix() {
+        assert_eq!(class_name_for(LayoutCategory::Scene, "Main"), "MainScene");
+        assert_eq!(
+            class_name_for(LayoutCategory::Actor, "player-character"),
+            "PlayerCharacterActor"
+        );
+        assert_eq!(class_name_for(LayoutCategory::Ui, "HealthBar"), "HealthBarUI");
+        assert_eq!(class_name_for(LayoutCategory::Data, "GameState"), "GameStateData");
+    }
+
+    #[test]
+    fn class_name_without_suffix_for_module_and_action() {
+        assert_eq!(class_name_for(LayoutCategory::Module, "Health"), "Health");
+        assert_eq!(class_name_for(LayoutCategory::Action, "Attack"), "Attack");
+    }
+
+    #[test]
+    fn duplicate_suffix_is_not_appended() {
+        // 既にサフィックスが付いている名前に二重付与しない
+        assert_eq!(class_name_for(LayoutCategory::Scene, "MainScene"), "MainScene");
+        assert_eq!(class_name_for(LayoutCategory::Actor, "PlayerActor"), "PlayerActor");
+    }
+
+    #[test]
+    fn entity_dir_layout() {
+        assert_eq!(
+            entity_dir("./out", LayoutCategory::Scene, "Main"),
+            "./out/Scene/MainScene"
+        );
+        assert_eq!(
+            entity_dir("./out/", LayoutCategory::Module, "Health"),
+            "./out/Module/Health"
+        );
+    }
+
+    #[test]
+    fn classify_component_category_works() {
+        assert_eq!(classify_component_category("UI"), LayoutCategory::Ui);
+        assert_eq!(classify_component_category("ui"), LayoutCategory::Ui);
+        assert_eq!(classify_component_category("Logic"), LayoutCategory::Module);
+        assert_eq!(classify_component_category("System"), LayoutCategory::Module);
+        assert_eq!(classify_component_category("GameObject"), LayoutCategory::Module);
+    }
+
+    #[test]
+    fn category_str_roundtrip() {
+        for cat in [
+            LayoutCategory::Scene,
+            LayoutCategory::Actor,
+            LayoutCategory::Module,
+            LayoutCategory::Action,
+            LayoutCategory::Ui,
+            LayoutCategory::Data,
+        ] {
+            assert_eq!(LayoutCategory::from_str(cat.as_str()), Some(cat));
+        }
+    }
+}

--- a/crates/ars-codegen/src/codedesign_parser.rs
+++ b/crates/ars-codegen/src/codedesign_parser.rs
@@ -137,8 +137,7 @@ fn split_meta_line(s: &str) -> Option<(String, String)> {
 /// 飾り付けを除去する用途。
 fn strip_inline_marks(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(ch) = chars.next() {
+    for ch in s.chars() {
         match ch {
             '*' => {
                 // **bold** / *italic* どちらも単純に外す

--- a/crates/ars-codegen/src/codedesign_parser.rs
+++ b/crates/ars-codegen/src/codedesign_parser.rs
@@ -1,0 +1,259 @@
+//! codedesign Markdown パーサ
+//!
+//! `codedesign-generation-rules.md` のテンプレートに準拠する MD ファイルから、
+//! Ars プロジェクトに反映する候補となる軽量フィールドを抽出する。
+//!
+//! 抽出対象（フェーズ2 適用範囲）:
+//!
+//! - `# {見出し}` から `entity_name`
+//! - `## メタ情報` セクションの `- **ID**: {id}` から `entity_id`
+//! - `## 概要 / 達成目標 / 役割 / 挙動` セクションの箇条書き
+//! - `## アクション定義` テーブル / `## 振る舞い` セクションのアクション情報
+//!
+//! 厳格な Markdown パーサではなく、生成テンプレートが固定的であることを前提とした
+//! 行ベースの軽量抽出器。テンプレートから外れた手書き MD では空に近い結果を返す。
+
+use std::collections::BTreeMap;
+
+/// 1 ファイル分の抽出結果
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ParsedCodedesign {
+    /// `# {見出し}` から取得したエンティティ表示名
+    pub title: Option<String>,
+    /// `## メタ情報` の `- **ID**: ...` から取得した ID
+    pub entity_id: Option<String>,
+    /// `## メタ情報` の `- **タイプ**: ...`
+    pub actor_type: Option<String>,
+    /// `## メタ情報` の `- **ドメインロール**: ...`
+    pub role: Option<String>,
+    /// 見出し → 箇条書き行のマップ
+    /// キーは見出しテキスト（`概要` / `達成目標` / `役割` / `挙動` / `振る舞い` 等）
+    pub bullet_sections: BTreeMap<String, Vec<String>>,
+}
+
+impl ParsedCodedesign {
+    pub fn overview(&self) -> Option<&[String]> {
+        self.bullet_sections.get("概要").map(|v| v.as_slice())
+    }
+    pub fn goals(&self) -> Option<&[String]> {
+        self.bullet_sections.get("達成目標").map(|v| v.as_slice())
+    }
+    pub fn role_items(&self) -> Option<&[String]> {
+        self.bullet_sections.get("役割").map(|v| v.as_slice())
+    }
+    pub fn behavior(&self) -> Option<&[String]> {
+        self.bullet_sections.get("挙動").map(|v| v.as_slice())
+    }
+    pub fn behaviors(&self) -> Option<&[String]> {
+        // アクションファイル用: `## 振る舞い`
+        self.bullet_sections.get("振る舞い").map(|v| v.as_slice())
+    }
+}
+
+/// MD テキストを解析する。
+pub fn parse(text: &str) -> ParsedCodedesign {
+    let mut out = ParsedCodedesign::default();
+    let mut current_h2: Option<String> = None;
+    let mut in_meta = false;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+
+        // タイトル (# heading)
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            if out.title.is_none() {
+                out.title = Some(strip_inline_marks(rest.trim()));
+            }
+            continue;
+        }
+
+        // セクション境界
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            let heading = strip_inline_marks(rest.trim());
+            in_meta = heading == "メタ情報";
+            current_h2 = Some(heading.clone());
+            // 既知見出しならば空 Vec を用意（重複登場時にもマージ可能）
+            if matches!(
+                heading.as_str(),
+                "概要" | "達成目標" | "役割" | "挙動" | "振る舞い"
+            ) {
+                out.bullet_sections.entry(heading).or_default();
+            }
+            continue;
+        }
+
+        // メタ情報セクション内: `- **ID**: ...` 形式
+        if in_meta {
+            if let Some(rest) = trimmed.strip_prefix("- ") {
+                if let Some((label, value)) = split_meta_line(rest) {
+                    match label.as_str() {
+                        "ID" => out.entity_id = Some(value),
+                        "タイプ" => out.actor_type = Some(value),
+                        "ドメインロール" => out.role = Some(value),
+                        _ => {}
+                    }
+                }
+                continue;
+            }
+        }
+
+        // 既知の箇条書きセクション内
+        if let Some(h) = &current_h2 {
+            if !matches!(
+                h.as_str(),
+                "概要" | "達成目標" | "役割" | "挙動" | "振る舞い"
+            ) {
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("- ") {
+                let item = strip_inline_marks(rest.trim()).trim().to_string();
+                if !item.is_empty() {
+                    out.bullet_sections
+                        .entry(h.clone())
+                        .or_default()
+                        .push(item);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// `**ID**: value` のような行を `(label, value)` に分割する
+fn split_meta_line(s: &str) -> Option<(String, String)> {
+    // `**LABEL**: value` を想定
+    let stripped = s.strip_prefix("**")?;
+    let close = stripped.find("**")?;
+    let label = stripped[..close].trim().to_string();
+    let after = stripped[close + 2..].trim_start();
+    let after = after.strip_prefix(':').unwrap_or(after).trim();
+    Some((label, after.to_string()))
+}
+
+/// `**bold**` / `` `code` `` といった軽量装飾を削除して中身だけを残す。
+///
+/// 完全な Markdown 解析ではなく、抽出した値を Project へ書き戻す前に
+/// 飾り付けを除去する用途。
+fn strip_inline_marks(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '*' => {
+                // **bold** / *italic* どちらも単純に外す
+                continue;
+            }
+            '`' => {
+                continue;
+            }
+            _ => out.push(ch),
+        }
+    }
+    out.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_ACTOR: &str = r#"# Player
+
+## メタ情報
+- **ID**: actor-player
+- **タイプ**: state
+- **ドメインロール**: protagonist
+- **対象プラットフォーム**: ars-native
+
+## 概要
+- プレイヤーキャラクター
+- ユーザーの主操作を受け取る
+
+## 達成目標
+- 入力に基づくキャラクター制御
+
+## 役割
+- 主人公
+
+## 挙動
+- 移動・攻撃・防御
+"#;
+
+    #[test]
+    fn parses_actor_template() {
+        let p = parse(SAMPLE_ACTOR);
+        assert_eq!(p.title.as_deref(), Some("Player"));
+        assert_eq!(p.entity_id.as_deref(), Some("actor-player"));
+        assert_eq!(p.actor_type.as_deref(), Some("state"));
+        assert_eq!(p.role.as_deref(), Some("protagonist"));
+        assert_eq!(
+            p.overview(),
+            Some(["プレイヤーキャラクター", "ユーザーの主操作を受け取る"]
+                .map(String::from)
+                .as_slice())
+        );
+        assert_eq!(
+            p.goals(),
+            Some([String::from("入力に基づくキャラクター制御")].as_slice())
+        );
+        assert_eq!(p.role_items(), Some([String::from("主人公")].as_slice()));
+        assert_eq!(
+            p.behavior(),
+            Some([String::from("移動・攻撃・防御")].as_slice())
+        );
+    }
+
+    #[test]
+    fn empty_sections_are_handled() {
+        let md = "# Empty\n\n## メタ情報\n- **ID**: x\n\n## 概要\n";
+        let p = parse(md);
+        assert_eq!(p.entity_id.as_deref(), Some("x"));
+        // 概要セクションは登場しているが空
+        assert_eq!(p.overview(), Some(&[][..]));
+    }
+
+    #[test]
+    fn ignores_unknown_sections() {
+        let md = "# X\n\n## ランダム\n- foo\n- bar\n";
+        let p = parse(md);
+        assert_eq!(p.title.as_deref(), Some("X"));
+        assert!(p.bullet_sections.is_empty() || !p.bullet_sections.contains_key("ランダム"));
+    }
+
+    #[test]
+    fn parses_action_behaviors() {
+        let md = r#"# Attack
+
+## メタ情報
+- **ID**: action-attack
+
+## 振る舞い
+- ダメージを計算する
+- 命中判定を行う
+"#;
+        let p = parse(md);
+        assert_eq!(p.entity_id.as_deref(), Some("action-attack"));
+        assert_eq!(
+            p.behaviors(),
+            Some([
+                String::from("ダメージを計算する"),
+                String::from("命中判定を行う"),
+            ]
+            .as_slice())
+        );
+    }
+
+    #[test]
+    fn strip_inline_marks_works() {
+        assert_eq!(strip_inline_marks("**Bold**"), "Bold");
+        assert_eq!(strip_inline_marks("`code` value"), "code value");
+        assert_eq!(strip_inline_marks("plain"), "plain");
+    }
+
+    #[test]
+    fn split_meta_line_works() {
+        let (label, value) = split_meta_line("**ID**: x-1").unwrap();
+        assert_eq!(label, "ID");
+        assert_eq!(value, "x-1");
+    }
+}

--- a/crates/ars-codegen/src/crc32.rs
+++ b/crates/ars-codegen/src/crc32.rs
@@ -1,0 +1,53 @@
+//! CRC32 (IEEE 802.3) 計算
+//!
+//! 生成済みコード／コード詳細設計ファイルの差分検出に使う軽量チェックサム。
+//! 暗号学的強度は不要のため、外部依存を増やさず最小実装で提供する。
+
+const POLY: u32 = 0xEDB8_8320;
+
+/// CRC32 IEEE 802.3 — テーブル無しの逐次計算
+pub fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (POLY & mask);
+        }
+    }
+    !crc
+}
+
+/// 16進文字列で返す（manifest 永続化用）
+pub fn crc32_hex(data: &[u8]) -> String {
+    format!("{:08x}", crc32(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input() {
+        // CRC32 of empty buffer is 0
+        assert_eq!(crc32(b""), 0);
+    }
+
+    #[test]
+    fn known_value() {
+        // CRC32("123456789") = 0xCBF43926 (ITU-T standard test vector for IEEE 802.3)
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+    }
+
+    #[test]
+    fn hex_format() {
+        assert_eq!(crc32_hex(b"123456789"), "cbf43926");
+    }
+
+    #[test]
+    fn changes_on_modification() {
+        let a = crc32(b"hello world");
+        let b = crc32(b"hello worle");
+        assert_ne!(a, b);
+    }
+}

--- a/crates/ars-codegen/src/feedback.rs
+++ b/crates/ars-codegen/src/feedback.rs
@@ -730,9 +730,7 @@ fn backup_project_file(project_file: &Path, project_dir: &Path) -> Result<Option
         .map_err(|e| format!("バックアップディレクトリ作成失敗: {e}"))?;
     // 安全なファイル名にタイムスタンプを埋め込む（":" を含めない）
     let stamp = crate::manifest::now_rfc3339()
-        .replace(':', "")
-        .replace('-', "")
-        .replace('Z', "");
+        .replace([':', '-', 'Z'], "");
     let backup_path = cache_dir.join(format!("feedback-backup-{stamp}.json"));
     std::fs::write(&backup_path, bytes)
         .map_err(|e| format!("バックアップ書き込み失敗: {e}"))?;

--- a/crates/ars-codegen/src/feedback.rs
+++ b/crates/ars-codegen/src/feedback.rs
@@ -1,0 +1,640 @@
+//! コード生成フィードバック
+//!
+//! `.ars-cache/codegen-manifest.json` (前回同期時のスナップショット) と
+//! 現在のファイルシステム状態を突き合わせ、差分を検出する。
+//!
+//! 検出対象は以下 3 種別:
+//!
+//! - **project**    : `*.ars.json` 自体（コード「設計」）
+//! - **codedesign** : `codedesign/**/*.md`（コード詳細設計）
+//! - **code**       : `{output-root}/{Category}/{Entity}/**`（生成ソース）
+//!
+//! 差分は `FeedbackReport` に集約され、ドライランでの確認や、
+//! 後段の "適用" 処理（codedesign → Project 反映、stale マーカー付与など）に渡される。
+//!
+//! 本モジュールは差分**検出**までを責務とし、適用ロジックは別エントリポイント
+//! (`apply_codedesign_feedback` 等) から段階的に拡張する設計。
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use crate::code_layout::LayoutCategory;
+use crate::crc32::crc32_hex;
+use crate::manifest::{
+    relative_path, system_time_to_rfc3339, CodegenManifest, FileKind, FileRecord, ManifestEntry,
+};
+
+/// 1 ファイルに発生した変更の種別
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChangeKind {
+    /// manifest になく、新規に出現したファイル
+    Added,
+    /// manifest にあり、CRC32 が変化したファイル
+    Modified,
+    /// manifest にあるが、ファイルシステムから消えたファイル
+    Removed,
+}
+
+/// 個別ファイルの変更レコード
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChange {
+    pub change: ChangeKind,
+    pub kind: FileKind,
+    pub path: String,
+    /// 紐づくレイアウトカテゴリ（manifest にエントリがある場合）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<LayoutCategory>,
+    /// 紐づくエンティティ ID（manifest にエントリがある場合）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<String>,
+    /// 紐づくエンティティ名
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_name: Option<String>,
+    /// 前回 CRC32（Added の場合 None）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_crc32: Option<String>,
+    /// 現在 CRC32（Removed の場合 None）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_crc32: Option<String>,
+}
+
+/// プロジェクト全体に対する差分レポート
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FeedbackReport {
+    /// プロジェクトファイル本体の CRC32 が manifest と異なるか
+    pub project_changed: bool,
+    /// manifest が存在しなかった（初回 feedback）
+    pub manifest_missing: bool,
+    /// 全変更（Added / Modified / Removed をまとめて時系列順に並べる）
+    pub changes: Vec<FileChange>,
+}
+
+impl FeedbackReport {
+    pub fn is_empty(&self) -> bool {
+        !self.project_changed && self.changes.is_empty()
+    }
+
+    pub fn count(&self, change: ChangeKind) -> usize {
+        self.changes.iter().filter(|c| c.change == change).count()
+    }
+
+    pub fn count_kind(&self, kind: FileKind) -> usize {
+        self.changes.iter().filter(|c| c.kind == kind).count()
+    }
+}
+
+/// `detect_changes` への入力
+pub struct FeedbackInputs<'a> {
+    /// プロジェクトファイル絶対パス（`*.ars.json`）
+    pub project_file: &'a Path,
+    /// 出力ルート（生成コード配置先）絶対パス
+    pub output_root: &'a Path,
+    /// codedesign ルート絶対パス。なければ走査をスキップ
+    pub codedesign_root: Option<&'a Path>,
+    /// manifest 絶対パス（通常 `{project_dir}/.ars-cache/codegen-manifest.json`）
+    pub manifest_path: &'a Path,
+}
+
+/// 差分検出
+///
+/// manifest が存在しない場合は `manifest_missing = true` を返し、
+/// すべての既存ファイルを `Added` 扱いで列挙する。
+pub fn detect_changes(inputs: &FeedbackInputs<'_>) -> Result<FeedbackReport, String> {
+    let project_dir = inputs
+        .project_file
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+
+    let manifest = CodegenManifest::load_from(inputs.manifest_path)?;
+    let manifest_missing = manifest.is_none();
+    let manifest = manifest.unwrap_or_else(|| CodegenManifest::new("(unknown)", "(unknown)"));
+
+    let mut report = FeedbackReport {
+        project_changed: false,
+        manifest_missing,
+        changes: Vec::new(),
+    };
+
+    // ── 1. プロジェクトファイル本体 ──
+    if let Ok(bytes) = std::fs::read(inputs.project_file) {
+        let current = crc32_hex(&bytes);
+        if !manifest.project_crc32.is_empty() && manifest.project_crc32 != current {
+            report.project_changed = true;
+            report.changes.push(FileChange {
+                change: ChangeKind::Modified,
+                kind: FileKind::Project,
+                path: relative_path(inputs.project_file, &project_dir),
+                category: None,
+                entity_id: None,
+                entity_name: None,
+                previous_crc32: Some(manifest.project_crc32.clone()),
+                current_crc32: Some(current),
+            });
+        }
+    }
+
+    // ── 2. manifest に登録されたファイルを突き合わせ ──
+    let mut visited: BTreeSet<PathBuf> = BTreeSet::new();
+    for entry in &manifest.entries {
+        for file in &entry.files {
+            // project レコードは上で処理済みなのでスキップ
+            if file.kind == FileKind::Project {
+                continue;
+            }
+            let abs = project_dir.join(&file.path);
+            visited.insert(abs.clone());
+
+            match std::fs::read(&abs) {
+                Ok(bytes) => {
+                    let current = crc32_hex(&bytes);
+                    if current != file.crc32 {
+                        report.changes.push(FileChange {
+                            change: ChangeKind::Modified,
+                            kind: file.kind,
+                            path: file.path.clone(),
+                            category: Some(entry.category),
+                            entity_id: Some(entry.entity_id.clone()),
+                            entity_name: Some(entry.entity_name.clone()),
+                            previous_crc32: Some(file.crc32.clone()),
+                            current_crc32: Some(current),
+                        });
+                    }
+                }
+                Err(_) => {
+                    // ファイル消失 → Removed
+                    report.changes.push(FileChange {
+                        change: ChangeKind::Removed,
+                        kind: file.kind,
+                        path: file.path.clone(),
+                        category: Some(entry.category),
+                        entity_id: Some(entry.entity_id.clone()),
+                        entity_name: Some(entry.entity_name.clone()),
+                        previous_crc32: Some(file.crc32.clone()),
+                        current_crc32: None,
+                    });
+                }
+            }
+        }
+    }
+
+    // ── 3. 出力ルートを走査して新規ファイルを検出 ──
+    if inputs.output_root.exists() {
+        scan_added(inputs.output_root, &project_dir, &visited, FileKind::Code, &mut report);
+    }
+    if let Some(cd) = inputs.codedesign_root {
+        if cd.exists() {
+            scan_added(cd, &project_dir, &visited, FileKind::CodeDesign, &mut report);
+        }
+    }
+
+    Ok(report)
+}
+
+/// 出力ディレクトリを再帰走査し、manifest に未登録のファイルを Added で記録する
+fn scan_added(
+    root: &Path,
+    project_dir: &Path,
+    visited: &BTreeSet<PathBuf>,
+    kind: FileKind,
+    report: &mut FeedbackReport,
+) {
+    visit_files(root, &mut |abs_path| {
+        // 内部生成物はフィードバック対象外
+        let name = abs_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if name.starts_with(".codegen-")
+            || name == "codegen-manifest.json"
+            || abs_path
+                .components()
+                .any(|c| c.as_os_str() == ".ars-cache")
+        {
+            return;
+        }
+        if visited.contains(abs_path) {
+            return;
+        }
+        if let Ok(bytes) = std::fs::read(abs_path) {
+            let current = crc32_hex(&bytes);
+            report.changes.push(FileChange {
+                change: ChangeKind::Added,
+                kind,
+                path: relative_path(abs_path, project_dir),
+                category: None,
+                entity_id: None,
+                entity_name: None,
+                previous_crc32: None,
+                current_crc32: Some(current),
+            });
+        }
+    });
+}
+
+fn visit_files<F: FnMut(&Path)>(dir: &Path, visitor: &mut F) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            visit_files(&path, visitor);
+        } else {
+            visitor(&path);
+        }
+    }
+}
+
+// ── Manifest 更新ヘルパ ────────────────────────────────────────
+
+/// `feedback --apply` 後に呼ばれ、現状ファイルから新しい manifest を構築する。
+///
+/// 既存 manifest の `entries` 構造（カテゴリ/エンティティ対応）を流用し、
+/// 各ファイルの CRC32 / size / mtime を最新値で上書きする。Added だった
+/// ファイルは未分類のまま `_unassigned` エントリにまとめる。
+pub fn refresh_manifest(
+    previous: &CodegenManifest,
+    inputs: &FeedbackInputs<'_>,
+) -> Result<CodegenManifest, String> {
+    let project_dir = inputs
+        .project_file
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+
+    let mut next = previous.clone();
+
+    // プロジェクトファイル CRC32 更新
+    if let Ok(bytes) = std::fs::read(inputs.project_file) {
+        next.project_crc32 = crc32_hex(&bytes);
+        next.project_file = relative_path(inputs.project_file, &project_dir);
+    }
+
+    // 既存エントリの各ファイルを refresh
+    let mut visited: BTreeSet<PathBuf> = BTreeSet::new();
+    for entry in &mut next.entries {
+        let mut updated_files = Vec::with_capacity(entry.files.len());
+        for file in &entry.files {
+            if file.kind == FileKind::Project {
+                continue;
+            }
+            let abs = project_dir.join(&file.path);
+            visited.insert(abs.clone());
+            if let Ok(bytes) = std::fs::read(&abs) {
+                let metadata = std::fs::metadata(&abs).ok();
+                updated_files.push(FileRecord {
+                    path: file.path.clone(),
+                    crc32: crc32_hex(&bytes),
+                    size: metadata.as_ref().map(|m| m.len()).unwrap_or(0),
+                    modified_at: metadata
+                        .and_then(|m| m.modified().ok())
+                        .map(system_time_to_rfc3339)
+                        .unwrap_or_default(),
+                    kind: file.kind,
+                });
+            }
+            // ファイル消失したものは entry から落とす
+        }
+        entry.files = updated_files;
+    }
+
+    // Added のファイルを `_unassigned` エントリにまとめる
+    let mut added: Vec<FileRecord> = Vec::new();
+    let walk_targets: Vec<(PathBuf, FileKind)> = std::iter::once((
+        inputs.output_root.to_path_buf(),
+        FileKind::Code,
+    ))
+    .chain(inputs.codedesign_root.map(|p| (p.to_path_buf(), FileKind::CodeDesign)))
+    .collect();
+
+    for (root, kind) in walk_targets {
+        if !root.exists() {
+            continue;
+        }
+        visit_files(&root, &mut |abs| {
+            let name = abs
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+            if name.starts_with(".codegen-")
+                || name == "codegen-manifest.json"
+                || abs
+                    .components()
+                    .any(|c| c.as_os_str() == ".ars-cache")
+            {
+                return;
+            }
+            if visited.contains(abs) {
+                return;
+            }
+            if let Ok(bytes) = std::fs::read(abs) {
+                let metadata = std::fs::metadata(abs).ok();
+                added.push(FileRecord {
+                    path: relative_path(abs, &project_dir),
+                    crc32: crc32_hex(&bytes),
+                    size: metadata.as_ref().map(|m| m.len()).unwrap_or(0),
+                    modified_at: metadata
+                        .and_then(|m| m.modified().ok())
+                        .map(system_time_to_rfc3339)
+                        .unwrap_or_default(),
+                    kind,
+                });
+            }
+        });
+    }
+
+    if !added.is_empty() {
+        let mut grouped: BTreeMap<&'static str, Vec<FileRecord>> = BTreeMap::new();
+        for rec in added {
+            grouped.entry("_unassigned").or_default().push(rec);
+        }
+        for (_, files) in grouped {
+            next.entries.push(ManifestEntry {
+                category: LayoutCategory::Module,
+                entity_id: "_unassigned".into(),
+                entity_name: "_unassigned".into(),
+                class_name: "_unassigned".into(),
+                parent_id: None,
+                files,
+            });
+        }
+    }
+
+    next.last_synced_at = crate::manifest::now_rfc3339();
+    Ok(next)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{CodegenManifest, FileKind, FileRecord, ManifestEntry, MANIFEST_FILE, CACHE_DIR};
+    use std::fs;
+    use std::io::Write;
+
+    /// 一時ディレクトリ＋プロジェクトファイル＋manifest を組み立てるテストハーネス
+    struct Harness {
+        dir: PathBuf,
+    }
+
+    impl Harness {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "ars-codegen-feedback-{}-{}",
+                name,
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+            ));
+            let _ = fs::remove_dir_all(&dir);
+            fs::create_dir_all(&dir).unwrap();
+            Self { dir }
+        }
+
+        fn write(&self, rel: &str, content: &[u8]) -> PathBuf {
+            let p = self.dir.join(rel);
+            if let Some(parent) = p.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            let mut f = fs::File::create(&p).unwrap();
+            f.write_all(content).unwrap();
+            p
+        }
+
+        fn project_file(&self) -> PathBuf {
+            self.dir.join("demo.ars.json")
+        }
+
+        fn manifest_path(&self) -> PathBuf {
+            self.dir.join(CACHE_DIR).join(MANIFEST_FILE)
+        }
+
+        fn output_root(&self) -> PathBuf {
+            self.dir.join("generated")
+        }
+
+        fn codedesign_root(&self) -> PathBuf {
+            self.dir.join("codedesign")
+        }
+    }
+
+    impl Drop for Harness {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn fake_manifest(harness: &Harness) -> CodegenManifest {
+        let mut m = CodegenManifest::new("Demo", "ars-native");
+        m.project_file = "demo.ars.json".into();
+        m.output_root = "generated".into();
+        m.codedesign_root = Some("codedesign".into());
+        // プロジェクトファイル CRC を後から記録
+        let bytes = std::fs::read(harness.project_file()).unwrap();
+        m.project_crc32 = crc32_hex(&bytes);
+        m
+    }
+
+    #[test]
+    fn manifest_missing_returns_flag() {
+        let h = Harness::new("missing");
+        h.write("demo.ars.json", b"{}");
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        assert!(report.manifest_missing);
+        assert!(!report.project_changed);
+    }
+
+    #[test]
+    fn project_change_detected() {
+        let h = Harness::new("project");
+        h.write("demo.ars.json", b"{\"name\":\"Demo\"}");
+        let m = fake_manifest(&h);
+        // manifest 保存後にプロジェクトを書き換える
+        m.save_to(&h.manifest_path()).unwrap();
+        h.write("demo.ars.json", b"{\"name\":\"Demo!\"}");
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        assert!(report.project_changed);
+        assert_eq!(report.count(ChangeKind::Modified), 1);
+        assert_eq!(report.count_kind(FileKind::Project), 1);
+    }
+
+    #[test]
+    fn modified_and_removed_and_added_are_detected() {
+        let h = Harness::new("modified");
+        h.write("demo.ars.json", b"{}");
+        // manifest に登録される 2 ファイルを用意
+        let modif = h.write(
+            "generated/Scene/MainScene/MainScene.ts",
+            b"class MainScene {}",
+        );
+        let removed_path = h.write("generated/Module/Health/Health.ts", b"class Health {}");
+
+        let mut m = fake_manifest(&h);
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Scene,
+            entity_id: "scene-1".into(),
+            entity_name: "Main".into(),
+            class_name: "MainScene".into(),
+            parent_id: None,
+            files: vec![FileRecord {
+                path: "generated/Scene/MainScene/MainScene.ts".into(),
+                crc32: crc32_hex(&fs::read(&modif).unwrap()),
+                size: 0,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::Code,
+            }],
+        });
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Module,
+            entity_id: "comp-1".into(),
+            entity_name: "Health".into(),
+            class_name: "Health".into(),
+            parent_id: None,
+            files: vec![FileRecord {
+                path: "generated/Module/Health/Health.ts".into(),
+                crc32: crc32_hex(&fs::read(&removed_path).unwrap()),
+                size: 0,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::Code,
+            }],
+        });
+        m.save_to(&h.manifest_path()).unwrap();
+
+        // 1) Modify
+        h.write(
+            "generated/Scene/MainScene/MainScene.ts",
+            b"class MainScene { update() {} }",
+        );
+        // 2) Remove
+        fs::remove_file(&removed_path).unwrap();
+        // 3) Add (manifest 未登録)
+        h.write(
+            "generated/Action/Attack/Attack.ts",
+            b"class Attack {}",
+        );
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        assert!(!report.project_changed);
+        assert_eq!(report.count(ChangeKind::Modified), 1);
+        assert_eq!(report.count(ChangeKind::Removed), 1);
+        assert_eq!(report.count(ChangeKind::Added), 1);
+
+        let added = report
+            .changes
+            .iter()
+            .find(|c| c.change == ChangeKind::Added)
+            .unwrap();
+        assert!(added.path.contains("Attack"));
+        assert_eq!(added.kind, FileKind::Code);
+
+        let removed = report
+            .changes
+            .iter()
+            .find(|c| c.change == ChangeKind::Removed)
+            .unwrap();
+        assert_eq!(removed.entity_name.as_deref(), Some("Health"));
+    }
+
+    #[test]
+    fn cache_dir_files_are_ignored_in_added_scan() {
+        let h = Harness::new("ignore-cache");
+        h.write("demo.ars.json", b"{}");
+        let m = fake_manifest(&h);
+        m.save_to(&h.manifest_path()).unwrap();
+        // .ars-cache 配下や .codegen-* マーカー類は走査対象外
+        h.write(".ars-cache/extra.json", b"{}");
+        h.write("generated/Scene/MainScene/.codegen-prompt.md", b"prompt");
+        h.write("generated/Scene/MainScene/MainScene.ts", b"class MainScene {}");
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        // MainScene.ts のみ Added で検出される
+        let added: Vec<_> = report
+            .changes
+            .iter()
+            .filter(|c| c.change == ChangeKind::Added)
+            .collect();
+        assert_eq!(added.len(), 1);
+        assert!(added[0].path.ends_with("MainScene.ts"));
+    }
+
+    #[test]
+    fn refresh_manifest_updates_crc_and_drops_removed() {
+        let h = Harness::new("refresh");
+        h.write("demo.ars.json", b"{}");
+        let modif = h.write("generated/Module/Health/Health.ts", b"v1");
+
+        let mut m = fake_manifest(&h);
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Module,
+            entity_id: "comp-1".into(),
+            entity_name: "Health".into(),
+            class_name: "Health".into(),
+            parent_id: None,
+            files: vec![FileRecord {
+                path: "generated/Module/Health/Health.ts".into(),
+                crc32: crc32_hex(&fs::read(&modif).unwrap()),
+                size: 2,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::Code,
+            }],
+        });
+        m.save_to(&h.manifest_path()).unwrap();
+
+        // 修正 + 新規追加
+        h.write("generated/Module/Health/Health.ts", b"v2-updated");
+        h.write("generated/Action/Attack/Attack.ts", b"class Attack {}");
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let next = refresh_manifest(&m, &inputs).unwrap();
+
+        // Health のCRCが新しくなっている
+        let health_entry = next
+            .entries
+            .iter()
+            .find(|e| e.entity_name == "Health")
+            .unwrap();
+        assert_eq!(health_entry.files[0].crc32, crc32_hex(b"v2-updated"));
+
+        // _unassigned に Attack が追加されている
+        let unassigned = next
+            .entries
+            .iter()
+            .find(|e| e.entity_id == "_unassigned")
+            .expect("Added ファイルが _unassigned に集約される");
+        assert!(unassigned.files.iter().any(|f| f.path.ends_with("Attack.ts")));
+    }
+}

--- a/crates/ars-codegen/src/feedback.rs
+++ b/crates/ars-codegen/src/feedback.rs
@@ -20,10 +20,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use crate::code_layout::LayoutCategory;
+use crate::codedesign_parser::{parse as parse_codedesign, ParsedCodedesign};
 use crate::crc32::crc32_hex;
 use crate::manifest::{
     relative_path, system_time_to_rfc3339, CodegenManifest, FileKind, FileRecord, ManifestEntry,
 };
+use ars_core::models::Project;
 
 /// 1 ファイルに発生した変更の種別
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -368,6 +370,375 @@ pub fn refresh_manifest(
     Ok(next)
 }
 
+// ── 適用 (Apply) ────────────────────────────────────────────────
+//
+// `detect_changes` で得た差分を **書き込み側** へ反映するエントリポイント。
+// 適用内容は次の 2 種類:
+//
+// 1. codedesign → Project (`*.ars.json`)
+//    - 編集された MD ファイルを `codedesign_parser` でパースし、
+//      対応する Actor/Action/Component に「概要 / 達成目標 / 役割 / 挙動」等を上書きする。
+// 2. code → codedesign (stale マーカー)
+//    - 生成後にコードが書き換わったエンティティの MD 末尾に
+//      `<!-- code-feedback: stale ... -->` を追記し、設計が遅れていることを通知する。
+//
+// 適用は **冪等** を志向する: 同一差分を二度適用しても結果が変わらないようにする。
+// プロジェクトファイルの上書きはしないため、呼び出し側で `Project::save` を行う。
+
+/// `apply_feedback` の挙動オプション
+#[derive(Debug, Clone)]
+pub struct FeedbackApplyOptions {
+    /// codedesign の編集を Project に反映する
+    pub apply_codedesign_to_project: bool,
+    /// code 変更時に対応する codedesign に stale マーカーを追記する
+    pub mark_code_stale: bool,
+    /// バックアップを作成する（`.ars-cache/feedback-backup-*.json`）
+    pub backup_project: bool,
+}
+
+impl Default for FeedbackApplyOptions {
+    fn default() -> Self {
+        Self {
+            apply_codedesign_to_project: true,
+            mark_code_stale: true,
+            backup_project: true,
+        }
+    }
+}
+
+/// 1 件の適用結果
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppliedChange {
+    pub path: String,
+    pub kind: FileKind,
+    pub entity_id: Option<String>,
+    pub entity_name: Option<String>,
+    /// 適用内容のサマリ（"requirements.overview を 3 件更新" 等）
+    pub summary: String,
+}
+
+/// `apply_feedback` の戻り値
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ApplyResult {
+    /// codedesign → Project に反映された変更
+    pub applied: Vec<AppliedChange>,
+    /// stale マーカーを追記した codedesign ファイル
+    pub stale_marked: Vec<String>,
+    /// 対応エンティティ不明等で人手レビューが必要な変更
+    pub requires_review: Vec<AppliedChange>,
+    /// バックアップ先パス（作成した場合）
+    pub backup_path: Option<String>,
+}
+
+/// stale マーカー本文。複数回適用しても重複追記しないように検出キーに使う。
+const STALE_MARKER_PREFIX: &str = "<!-- code-feedback: stale";
+
+/// `detect_changes` の結果と現状ファイルから、Project と codedesign に変更を適用する。
+///
+/// 戻り値の `Project` は変異後のもの（呼び出し側で save する想定）。
+///
+/// `mark_code_stale = true` のときは、変更された code エントリに対応する
+/// codedesign MD の末尾に stale コメントを追記する（既に同等のマーカーがあれば追記しない）。
+pub fn apply_feedback(
+    project: &mut Project,
+    report: &FeedbackReport,
+    inputs: &FeedbackInputs<'_>,
+    opts: &FeedbackApplyOptions,
+) -> Result<ApplyResult, String> {
+    let project_dir = inputs
+        .project_file
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+
+    let mut result = ApplyResult::default();
+
+    // ── 0. プロジェクトファイルのバックアップ ────
+    if opts.backup_project && inputs.project_file.exists() {
+        if let Some(backup) = backup_project_file(inputs.project_file, &project_dir)? {
+            result.backup_path = Some(relative_path(&backup, &project_dir));
+        }
+    }
+
+    // ── 1. codedesign → Project ────
+    if opts.apply_codedesign_to_project {
+        for change in &report.changes {
+            if change.kind != FileKind::CodeDesign {
+                continue;
+            }
+            if matches!(change.change, ChangeKind::Removed) {
+                // 削除に対しては自動反映しない（Project の意図的な変更可能性）
+                result.requires_review.push(AppliedChange {
+                    path: change.path.clone(),
+                    kind: change.kind,
+                    entity_id: change.entity_id.clone(),
+                    entity_name: change.entity_name.clone(),
+                    summary: "codedesign 削除（手動レビュー要）".into(),
+                });
+                continue;
+            }
+            let abs = project_dir.join(&change.path);
+            let text = match std::fs::read_to_string(&abs) {
+                Ok(t) => t,
+                Err(e) => {
+                    result.requires_review.push(AppliedChange {
+                        path: change.path.clone(),
+                        kind: change.kind,
+                        entity_id: change.entity_id.clone(),
+                        entity_name: change.entity_name.clone(),
+                        summary: format!("読み込み失敗: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let parsed = parse_codedesign(&text);
+            match apply_parsed_codedesign(project, &parsed, change.entity_id.as_deref()) {
+                Ok(summary) => result.applied.push(AppliedChange {
+                    path: change.path.clone(),
+                    kind: change.kind,
+                    entity_id: change.entity_id.clone().or_else(|| parsed.entity_id.clone()),
+                    entity_name: change
+                        .entity_name
+                        .clone()
+                        .or_else(|| parsed.title.clone()),
+                    summary,
+                }),
+                Err(reason) => result.requires_review.push(AppliedChange {
+                    path: change.path.clone(),
+                    kind: change.kind,
+                    entity_id: change.entity_id.clone().or_else(|| parsed.entity_id.clone()),
+                    entity_name: change
+                        .entity_name
+                        .clone()
+                        .or_else(|| parsed.title.clone()),
+                    summary: reason,
+                }),
+            }
+        }
+    }
+
+    // ── 2. code → codedesign (stale マーカー) ────
+    if opts.mark_code_stale {
+        if let Some(cd_root) = inputs.codedesign_root {
+            // entity_id → codedesign パス候補のマップ
+            let cd_index = build_codedesign_index(cd_root);
+            for change in &report.changes {
+                if change.kind != FileKind::Code {
+                    continue;
+                }
+                if !matches!(change.change, ChangeKind::Modified | ChangeKind::Added) {
+                    continue;
+                }
+                let Some(entity_id) = change.entity_id.as_deref() else {
+                    // entity_id 不明（_unassigned 等）のものはスキップ
+                    continue;
+                };
+                let Some(cd_paths) = cd_index.get(entity_id) else {
+                    continue;
+                };
+                for path in cd_paths {
+                    if append_stale_marker(path, &change.path)? {
+                        result
+                            .stale_marked
+                            .push(relative_path(path, &project_dir));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// パース済み codedesign を Project 内の対応エンティティへ適用する
+///
+/// `hint_entity_id` は manifest 由来のヒント（あればそちらを優先）
+fn apply_parsed_codedesign(
+    project: &mut Project,
+    parsed: &ParsedCodedesign,
+    hint_entity_id: Option<&str>,
+) -> Result<String, String> {
+    let entity_id = hint_entity_id
+        .map(|s| s.to_string())
+        .or_else(|| parsed.entity_id.clone())
+        .ok_or_else(|| "対応する entity_id が特定できません".to_string())?;
+
+    // Actor 探索
+    for scene in project.scenes.values_mut() {
+        if let Some(actor) = scene.actors.get_mut(&entity_id) {
+            return Ok(apply_to_actor(actor, parsed));
+        }
+        // Action 探索
+        if let Some(action) = scene.actions.get_mut(&entity_id) {
+            return Ok(apply_to_action(action, parsed));
+        }
+    }
+    // Component 探索
+    if let Some(comp) = project.components.get_mut(&entity_id) {
+        return Ok(apply_to_component(comp, parsed));
+    }
+
+    Err(format!("entity_id={entity_id} に対応するエンティティが見つかりません"))
+}
+
+fn apply_to_actor(actor: &mut ars_core::models::Actor, parsed: &ParsedCodedesign) -> String {
+    let mut updates: Vec<String> = Vec::new();
+
+    if let Some(role) = parsed.role.as_deref() {
+        if !role.is_empty() && actor.role != role {
+            actor.role = role.to_string();
+            updates.push("role".into());
+        }
+    }
+    if let Some(t) = parsed.actor_type.as_deref() {
+        if !t.is_empty() && actor.actor_type != t {
+            actor.actor_type = t.to_string();
+            updates.push("actor_type".into());
+        }
+    }
+
+    if let Some(items) = parsed.overview() {
+        if !items.is_empty() && actor.requirements.overview != items {
+            actor.requirements.overview = items.to_vec();
+            updates.push(format!("requirements.overview ({}件)", items.len()));
+        }
+    }
+    if let Some(items) = parsed.goals() {
+        if !items.is_empty() && actor.requirements.goals != items {
+            actor.requirements.goals = items.to_vec();
+            updates.push(format!("requirements.goals ({}件)", items.len()));
+        }
+    }
+    if let Some(items) = parsed.role_items() {
+        if !items.is_empty() && actor.requirements.role != items {
+            actor.requirements.role = items.to_vec();
+            updates.push(format!("requirements.role ({}件)", items.len()));
+        }
+    }
+    if let Some(items) = parsed.behavior() {
+        if !items.is_empty() && actor.requirements.behavior != items {
+            actor.requirements.behavior = items.to_vec();
+            updates.push(format!("requirements.behavior ({}件)", items.len()));
+        }
+    }
+
+    if updates.is_empty() {
+        "actor: 変更なし".into()
+    } else {
+        format!("actor[{}]: {}", actor.id, updates.join(", "))
+    }
+}
+
+fn apply_to_action(action: &mut ars_core::models::Action, parsed: &ParsedCodedesign) -> String {
+    let mut updates: Vec<String> = Vec::new();
+    if let Some(items) = parsed.behaviors() {
+        if !items.is_empty() && action.behaviors != items {
+            action.behaviors = items.to_vec();
+            updates.push(format!("behaviors ({}件)", items.len()));
+        }
+    }
+    // 概要があれば description に転写（複数行は改行で結合）
+    if let Some(items) = parsed.overview() {
+        if !items.is_empty() {
+            let joined = items.join("\n");
+            if action.description != joined {
+                action.description = joined;
+                updates.push("description".into());
+            }
+        }
+    }
+    if updates.is_empty() {
+        "action: 変更なし".into()
+    } else {
+        format!("action[{}]: {}", action.id, updates.join(", "))
+    }
+}
+
+fn apply_to_component(
+    component: &mut ars_core::models::Component,
+    parsed: &ParsedCodedesign,
+) -> String {
+    // Component には自由テキスト系フィールドが少ないため、現状は domain/role 相当の
+    // ドメインロール指定だけを反映する。タスク本体の編集はしない。
+    let mut updates: Vec<String> = Vec::new();
+    if let Some(role) = parsed.role.as_deref() {
+        if !role.is_empty() && component.domain != role {
+            component.domain = role.to_string();
+            updates.push("domain".into());
+        }
+    }
+    if updates.is_empty() {
+        "component: 変更なし".into()
+    } else {
+        format!("component[{}]: {}", component.id, updates.join(", "))
+    }
+}
+
+/// codedesign ルート配下を走査し、`entity_id` → 該当 MD パスのマップを構築する。
+///
+/// MD の `## メタ情報` セクションから `- **ID**: ...` 行を読み取って index 化する。
+fn build_codedesign_index(root: &Path) -> BTreeMap<String, Vec<PathBuf>> {
+    let mut index: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+    visit_files(root, &mut |path| {
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            return;
+        }
+        let Ok(text) = std::fs::read_to_string(path) else {
+            return;
+        };
+        let parsed = parse_codedesign(&text);
+        if let Some(eid) = parsed.entity_id {
+            index.entry(eid).or_default().push(path.to_path_buf());
+        }
+    });
+    index
+}
+
+/// stale マーカーをファイル末尾に追記する。既に同 file_path に対する
+/// マーカーが存在する場合は何もしない。
+///
+/// 追記した場合は `Ok(true)`、既存のためスキップした場合は `Ok(false)`。
+fn append_stale_marker(path: &Path, code_path: &str) -> Result<bool, String> {
+    let mut text = std::fs::read_to_string(path)
+        .map_err(|e| format!("codedesign 読み込み失敗: {}: {e}", path.display()))?;
+
+    // 既に同 code_path に対するマーカーが立っているならスキップ
+    let needle = format!("file=\"{}\"", code_path);
+    if text.contains(STALE_MARKER_PREFIX) && text.contains(&needle) {
+        return Ok(false);
+    }
+
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    let stamp = crate::manifest::now_rfc3339();
+    text.push_str(&format!(
+        "\n{} at=\"{stamp}\" file=\"{code_path}\" -->\n",
+        STALE_MARKER_PREFIX
+    ));
+    std::fs::write(path, text)
+        .map_err(|e| format!("codedesign 書き込み失敗: {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+/// プロジェクトファイルを `.ars-cache/feedback-backup-{ts}.json` にコピー
+fn backup_project_file(project_file: &Path, project_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let bytes = std::fs::read(project_file)
+        .map_err(|e| format!("プロジェクトファイル読み込み失敗: {e}"))?;
+    let cache_dir = project_dir.join(crate::manifest::CACHE_DIR);
+    std::fs::create_dir_all(&cache_dir)
+        .map_err(|e| format!("バックアップディレクトリ作成失敗: {e}"))?;
+    // 安全なファイル名にタイムスタンプを埋め込む（":" を含めない）
+    let stamp = crate::manifest::now_rfc3339()
+        .replace(':', "")
+        .replace('-', "")
+        .replace('Z', "");
+    let backup_path = cache_dir.join(format!("feedback-backup-{stamp}.json"));
+    std::fs::write(&backup_path, bytes)
+        .map_err(|e| format!("バックアップ書き込み失敗: {e}"))?;
+    Ok(Some(backup_path))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -636,5 +1007,375 @@ mod tests {
             .find(|e| e.entity_id == "_unassigned")
             .expect("Added ファイルが _unassigned に集約される");
         assert!(unassigned.files.iter().any(|f| f.path.ends_with("Attack.ts")));
+    }
+
+    // ── Apply 系テスト ────────────────────────────────────────
+
+    use ars_core::models::{
+        Action, ActionType, Actor, Component, Position, Project as ArsProject, Requirements, Scene,
+    };
+    use std::collections::HashMap;
+
+    fn empty_project() -> ArsProject {
+        ArsProject {
+            name: "Demo".into(),
+            scenes: HashMap::new(),
+            components: HashMap::new(),
+            prefabs: HashMap::new(),
+            active_scene_id: None,
+        }
+    }
+
+    fn actor(id: &str, name: &str) -> Actor {
+        Actor {
+            id: id.into(),
+            name: name.into(),
+            role: "actor".into(),
+            actor_type: "simple".into(),
+            requirements: Requirements::default(),
+            actor_states: vec![],
+            flexible_content: String::new(),
+            displays: vec![],
+            position: Position { x: 0.0, y: 0.0 },
+            sub_scene_id: None,
+        }
+    }
+
+    fn action(id: &str, name: &str) -> Action {
+        Action {
+            id: id.into(),
+            name: name.into(),
+            action_type: ActionType::default(),
+            description: String::new(),
+            behaviors: vec![],
+            concretes: vec![],
+        }
+    }
+
+    fn component(id: &str, name: &str) -> Component {
+        Component {
+            id: id.into(),
+            name: name.into(),
+            category: "Logic".into(),
+            domain: "core".into(),
+            variables: vec![],
+            tasks: vec![],
+            dependencies: vec![],
+            source_module_id: None,
+        }
+    }
+
+    #[test]
+    fn apply_codedesign_updates_actor_requirements() {
+        let h = Harness::new("apply-actor");
+        h.write("demo.ars.json", b"{}");
+        let md_path = h.write(
+            "codedesign/actors/player.md",
+            r#"# Player
+
+## メタ情報
+- **ID**: actor-player
+- **タイプ**: state
+- **ドメインロール**: protagonist
+
+## 概要
+- プレイヤーキャラクター
+- 主操作の対象
+
+## 達成目標
+- 入力に従う
+
+## 役割
+- 主人公
+
+## 挙動
+- 移動する
+"#
+            .as_bytes(),
+        );
+
+        // 初期 Project: Actor "actor-player" を内包する Scene を作成
+        let mut project = empty_project();
+        let mut scene = Scene {
+            id: "scene-1".into(),
+            name: "Main".into(),
+            root_actor_id: "actor-player".into(),
+            actors: HashMap::new(),
+            messages: vec![],
+            actions: HashMap::new(),
+        };
+        scene
+            .actors
+            .insert("actor-player".into(), actor("actor-player", "Player"));
+        project.scenes.insert(scene.id.clone(), scene);
+
+        // manifest を作って codedesign を Modified 扱いに見せかける
+        let mut m = fake_manifest(&h);
+        let cd_rel = relative_path(&md_path, &h.dir);
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Actor,
+            entity_id: "actor-player".into(),
+            entity_name: "Player".into(),
+            class_name: "PlayerActor".into(),
+            parent_id: Some("scene-1".into()),
+            files: vec![FileRecord {
+                path: cd_rel,
+                // 元 CRC をわざと別物にして Modified 検出させる
+                crc32: "00000000".into(),
+                size: 0,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::CodeDesign,
+            }],
+        });
+        m.save_to(&h.manifest_path()).unwrap();
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        assert!(report.changes.iter().any(|c| c.kind == FileKind::CodeDesign));
+
+        let opts = FeedbackApplyOptions {
+            apply_codedesign_to_project: true,
+            mark_code_stale: false,
+            backup_project: false,
+        };
+        let result = apply_feedback(&mut project, &report, &inputs, &opts).unwrap();
+
+        assert_eq!(result.applied.len(), 1, "1 件適用される");
+        let updated_actor = project
+            .scenes
+            .get("scene-1")
+            .and_then(|s| s.actors.get("actor-player"))
+            .unwrap();
+        assert_eq!(updated_actor.actor_type, "state");
+        assert_eq!(updated_actor.role, "protagonist");
+        assert_eq!(
+            updated_actor.requirements.overview,
+            vec!["プレイヤーキャラクター", "主操作の対象"]
+        );
+        assert_eq!(updated_actor.requirements.goals, vec!["入力に従う"]);
+        assert_eq!(updated_actor.requirements.role, vec!["主人公"]);
+        assert_eq!(updated_actor.requirements.behavior, vec!["移動する"]);
+    }
+
+    #[test]
+    fn apply_codedesign_updates_action_behaviors() {
+        let h = Harness::new("apply-action");
+        h.write("demo.ars.json", b"{}");
+        let md_path = h.write(
+            "codedesign/actions/attack.md",
+            r#"# Attack
+
+## メタ情報
+- **ID**: action-attack
+
+## 概要
+- 攻撃アクション
+
+## 振る舞い
+- ダメージを計算する
+- 命中判定を行う
+"#
+            .as_bytes(),
+        );
+
+        let mut project = empty_project();
+        let mut scene = Scene {
+            id: "scene-1".into(),
+            name: "Main".into(),
+            root_actor_id: "x".into(),
+            actors: HashMap::new(),
+            messages: vec![],
+            actions: HashMap::new(),
+        };
+        scene
+            .actions
+            .insert("action-attack".into(), action("action-attack", "Attack"));
+        project.scenes.insert(scene.id.clone(), scene);
+
+        let mut m = fake_manifest(&h);
+        let cd_rel = relative_path(&md_path, &h.dir);
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Action,
+            entity_id: "action-attack".into(),
+            entity_name: "Attack".into(),
+            class_name: "Attack".into(),
+            parent_id: Some("scene-1".into()),
+            files: vec![FileRecord {
+                path: cd_rel,
+                crc32: "00000000".into(),
+                size: 0,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::CodeDesign,
+            }],
+        });
+        m.save_to(&h.manifest_path()).unwrap();
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        let opts = FeedbackApplyOptions {
+            apply_codedesign_to_project: true,
+            mark_code_stale: false,
+            backup_project: false,
+        };
+        let _ = apply_feedback(&mut project, &report, &inputs, &opts).unwrap();
+
+        let upd = project
+            .scenes
+            .get("scene-1")
+            .and_then(|s| s.actions.get("action-attack"))
+            .unwrap();
+        assert_eq!(upd.behaviors, vec!["ダメージを計算する", "命中判定を行う"]);
+        assert_eq!(upd.description, "攻撃アクション");
+    }
+
+    #[test]
+    fn stale_marker_is_appended_idempotently() {
+        let h = Harness::new("stale");
+        h.write("demo.ars.json", b"{}");
+
+        // entity_id を持つ codedesign を用意
+        let cd_path = h.write(
+            "codedesign/components/health.md",
+            b"# Health\n\n## \xe3\x83\xa1\xe3\x82\xbf\xe6\x83\x85\xe5\xa0\xb1\n- **ID**: comp-health\n",
+        );
+        let code_rel = "generated/Module/Health/Health.ts";
+        let code_abs = h.write(code_rel, b"class Health {}");
+
+        let mut project = empty_project();
+        project
+            .components
+            .insert("comp-health".into(), component("comp-health", "Health"));
+
+        let mut m = fake_manifest(&h);
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Module,
+            entity_id: "comp-health".into(),
+            entity_name: "Health".into(),
+            class_name: "Health".into(),
+            parent_id: None,
+            files: vec![FileRecord {
+                path: code_rel.into(),
+                crc32: crc32_hex(&fs::read(&code_abs).unwrap()),
+                size: 0,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::Code,
+            }],
+        });
+        m.save_to(&h.manifest_path()).unwrap();
+
+        // コードを書き換え
+        h.write(code_rel, b"class Health { hp = 100; }");
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        assert_eq!(report.count(ChangeKind::Modified), 1);
+
+        let opts = FeedbackApplyOptions {
+            apply_codedesign_to_project: false,
+            mark_code_stale: true,
+            backup_project: false,
+        };
+
+        // 1 回目: マーカーが追記される
+        let result = apply_feedback(&mut project, &report, &inputs, &opts).unwrap();
+        assert_eq!(result.stale_marked.len(), 1);
+        let after = std::fs::read_to_string(&cd_path).unwrap();
+        assert!(after.contains(STALE_MARKER_PREFIX));
+        assert!(after.contains(code_rel));
+
+        // 2 回目: 既存マーカー検出でスキップされる
+        let result2 = apply_feedback(&mut project, &report, &inputs, &opts).unwrap();
+        assert_eq!(result2.stale_marked.len(), 0);
+        let after2 = std::fs::read_to_string(&cd_path).unwrap();
+        let count = after2.matches(STALE_MARKER_PREFIX).count();
+        assert_eq!(count, 1, "stale マーカーは 1 つだけ");
+    }
+
+    #[test]
+    fn apply_creates_backup() {
+        let h = Harness::new("backup");
+        h.write("demo.ars.json", b"{\"name\":\"Demo\"}");
+        let m = fake_manifest(&h);
+        m.save_to(&h.manifest_path()).unwrap();
+
+        let mut project = empty_project();
+        let report = FeedbackReport::default();
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let opts = FeedbackApplyOptions {
+            apply_codedesign_to_project: false,
+            mark_code_stale: false,
+            backup_project: true,
+        };
+        let result = apply_feedback(&mut project, &report, &inputs, &opts).unwrap();
+        let backup = result.backup_path.expect("バックアップが作成される");
+        assert!(backup.starts_with(".ars-cache/feedback-backup-"));
+        let abs = h.dir.join(&backup);
+        assert!(abs.exists());
+    }
+
+    #[test]
+    fn unknown_entity_id_goes_to_requires_review() {
+        let h = Harness::new("unknown-entity");
+        h.write("demo.ars.json", b"{}");
+        let md_path = h.write(
+            "codedesign/actors/ghost.md",
+            b"# Ghost\n\n## \xe3\x83\xa1\xe3\x82\xbf\xe6\x83\x85\xe5\xa0\xb1\n- **ID**: actor-ghost\n\n## \xe6\xa6\x82\xe8\xa6\x81\n- foo\n",
+        );
+
+        let mut project = empty_project();
+        let mut m = fake_manifest(&h);
+        let cd_rel = relative_path(&md_path, &h.dir);
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Actor,
+            entity_id: "actor-ghost".into(),
+            entity_name: "Ghost".into(),
+            class_name: "GhostActor".into(),
+            parent_id: None,
+            files: vec![FileRecord {
+                path: cd_rel,
+                crc32: "00000000".into(),
+                size: 0,
+                modified_at: "2026-01-01T00:00:00Z".into(),
+                kind: FileKind::CodeDesign,
+            }],
+        });
+        m.save_to(&h.manifest_path()).unwrap();
+
+        let inputs = FeedbackInputs {
+            project_file: &h.project_file(),
+            output_root: &h.output_root(),
+            codedesign_root: Some(&h.codedesign_root()),
+            manifest_path: &h.manifest_path(),
+        };
+        let report = detect_changes(&inputs).unwrap();
+        let opts = FeedbackApplyOptions {
+            apply_codedesign_to_project: true,
+            mark_code_stale: false,
+            backup_project: false,
+        };
+        let result = apply_feedback(&mut project, &report, &inputs, &opts).unwrap();
+        assert!(result.applied.is_empty());
+        assert_eq!(result.requires_review.len(), 1);
+        assert!(result.requires_review[0].summary.contains("見つかりません"));
     }
 }

--- a/crates/ars-codegen/src/lib.rs
+++ b/crates/ars-codegen/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bridge;
 pub mod code_layout;
 pub mod crc32;
+pub mod feedback;
 pub mod manifest;
 pub mod project_loader;
 pub mod prompt_generator;

--- a/crates/ars-codegen/src/lib.rs
+++ b/crates/ars-codegen/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod bridge;
+pub mod code_layout;
+pub mod crc32;
+pub mod manifest;
 pub mod project_loader;
 pub mod prompt_generator;
 pub mod session_runner;

--- a/crates/ars-codegen/src/lib.rs
+++ b/crates/ars-codegen/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bridge;
 pub mod code_layout;
+pub mod codedesign_parser;
 pub mod crc32;
 pub mod feedback;
 pub mod manifest;

--- a/crates/ars-codegen/src/main.rs
+++ b/crates/ars-codegen/src/main.rs
@@ -1,9 +1,13 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+use ars_codegen::feedback::{detect_changes, ChangeKind, FeedbackInputs};
+use ars_codegen::manifest::{CodegenManifest, FileKind};
 use ars_codegen::project_loader::{find_project_files, load_project};
 use ars_codegen::prompt_generator::PromptGenerator;
-use ars_codegen::session_runner::{CodegenConfig, SessionRunner};
+use ars_codegen::session_runner::{
+    build_manifest, CodegenConfig, SessionRunner,
+};
 use ars_core::models::Project;
 
 #[derive(Parser)]
@@ -62,6 +66,27 @@ enum Commands {
         /// 対象コンポーネントID
         #[arg(short, long)]
         component: Vec<String>,
+    },
+    /// 生成済みコード/コード詳細設計の差分を Ars 側へフィードバック
+    ///
+    /// `.ars-cache/codegen-manifest.json` を基準点として、最後の同期以降に
+    /// 編集されたファイル (Added / Modified / Removed) を一覧表示する。
+    Feedback {
+        /// .ars.json プロジェクトファイル
+        #[arg(short, long)]
+        project: Option<String>,
+        /// 出力ディレクトリ (デフォルト: ./generated)
+        #[arg(short, long, default_value = "./generated")]
+        output: String,
+        /// codedesign ディレクトリ (デフォルト: {project_dir}/codedesign)
+        #[arg(long)]
+        codedesign: Option<String>,
+    },
+    /// 現在の codegen-manifest.json を表示
+    Manifest {
+        /// .ars.json プロジェクトファイル
+        #[arg(short, long)]
+        project: Option<String>,
     },
 }
 
@@ -166,6 +191,11 @@ async fn run(cli: Cli) -> Result<(), String> {
             }
 
             let runner = SessionRunner::new(config);
+            // tasks を消費する前にメタ情報をキャプチャしておく（manifest 構築用）
+            let task_meta: Vec<_> = tasks
+                .iter()
+                .map(|t| (t.id.clone(), t.layout_category, t.entity_id.clone(), t.name.clone(), t.class_name.clone()))
+                .collect();
             let results = runner.run_tasks(tasks).await;
 
             let succeeded = results.iter().filter(|r| r.success).count();
@@ -181,7 +211,129 @@ async fn run(cli: Cli) -> Result<(), String> {
                 }
             }
             println!("合計時間: {:.1}s", total_duration as f64 / 1000.0);
+
+            // Manifest 更新（成功タスクのみ集計）
+            let project_dir = pf.parent().map(PathBuf::from).unwrap_or_else(|| PathBuf::from("."));
+            let codedesign_root = project_dir.join("codedesign");
+            let cd = if codedesign_root.exists() { Some(codedesign_root.as_path()) } else { None };
+
+            // task メタを CodegenTask っぽい雛形に詰め直して build_manifest に渡す
+            let synthetic_tasks: Vec<ars_codegen::prompt_generator::CodegenTask> = task_meta
+                .into_iter()
+                .map(|(id, cat, eid, name, class_name)| ars_codegen::prompt_generator::CodegenTask {
+                    id,
+                    task_type: cat.as_str().to_string(),
+                    name,
+                    prompt: String::new(),
+                    dependencies: vec![],
+                    output_dir: String::new(),
+                    layout_category: cat,
+                    entity_id: eid,
+                    class_name,
+                })
+                .collect();
+
+            let manifest = build_manifest(
+                &synthetic_tasks,
+                &results,
+                &pf,
+                &output,
+                cd,
+                &proj.name,
+                "ars-native",
+            );
+            let manifest_path = CodegenManifest::default_path(&project_dir);
+            if let Err(e) = manifest.save_to(&manifest_path) {
+                eprintln!("manifest 保存に失敗: {e}");
+            } else {
+                println!("\nmanifest を保存しました: {}", manifest_path.display());
+            }
             Ok(())
+        }
+        Commands::Feedback { project, output, codedesign } => {
+            let pf = resolve_project_file(project.as_deref())?;
+            let project_dir = pf
+                .parent()
+                .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+            let output_root = std::path::Path::new(&output)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(&output));
+            let cd_path = codedesign
+                .map(PathBuf::from)
+                .unwrap_or_else(|| project_dir.join("codedesign"));
+            let manifest_path = CodegenManifest::default_path(project_dir);
+
+            let report = detect_changes(&FeedbackInputs {
+                project_file: &pf,
+                output_root: &output_root,
+                codedesign_root: Some(&cd_path),
+                manifest_path: &manifest_path,
+            })?;
+
+            println!("\n=== Codegen Feedback ===");
+            println!("プロジェクト: {}", pf.display());
+            println!("出力ルート: {}", output_root.display());
+            println!("codedesign: {}", cd_path.display());
+            println!("manifest: {}", manifest_path.display());
+
+            if report.manifest_missing {
+                println!("\n[INFO] manifest が存在しません。`generate` を一度実行すると基準点が記録されます。");
+            }
+
+            if report.is_empty() && !report.manifest_missing {
+                println!("\n変更はありません。");
+                return Ok(());
+            }
+
+            let added = report.count(ChangeKind::Added);
+            let modified = report.count(ChangeKind::Modified);
+            let removed = report.count(ChangeKind::Removed);
+            let project_n = report.count_kind(FileKind::Project);
+            let cd_n = report.count_kind(FileKind::CodeDesign);
+            let code_n = report.count_kind(FileKind::Code);
+
+            println!("\n--- サマリー ---");
+            println!("プロジェクト変更: {}", if report.project_changed { "あり" } else { "なし" });
+            println!("変更数: Added={} / Modified={} / Removed={}", added, modified, removed);
+            println!("種別:   project={} / codedesign={} / code={}", project_n, cd_n, code_n);
+
+            println!("\n--- 詳細 ---");
+            for c in &report.changes {
+                let entity = c
+                    .entity_name
+                    .as_deref()
+                    .map(|n| format!(" [{}]", n))
+                    .unwrap_or_default();
+                let kind = match c.kind {
+                    FileKind::Project => "project",
+                    FileKind::CodeDesign => "codedesign",
+                    FileKind::Code => "code",
+                };
+                let change = match c.change {
+                    ChangeKind::Added => "ADD",
+                    ChangeKind::Modified => "MOD",
+                    ChangeKind::Removed => "DEL",
+                };
+                println!("  {} [{}] {}{}", change, kind, c.path, entity);
+            }
+            Ok(())
+        }
+        Commands::Manifest { project } => {
+            let pf = resolve_project_file(project.as_deref())?;
+            let project_dir = pf
+                .parent()
+                .ok_or_else(|| "project_file の親ディレクトリが取得できません".to_string())?;
+            let manifest_path = CodegenManifest::default_path(project_dir);
+            match CodegenManifest::load_from(&manifest_path)? {
+                Some(m) => {
+                    println!("{}", serde_json::to_string_pretty(&m).map_err(|e| format!("シリアライズ失敗: {e}"))?);
+                    Ok(())
+                }
+                None => {
+                    println!("manifest が存在しません: {}", manifest_path.display());
+                    Ok(())
+                }
+            }
         }
     }
 }

--- a/crates/ars-codegen/src/main.rs
+++ b/crates/ars-codegen/src/main.rs
@@ -1,9 +1,12 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-use ars_codegen::feedback::{detect_changes, ChangeKind, FeedbackInputs};
+use ars_codegen::feedback::{
+    apply_feedback, detect_changes, refresh_manifest, ChangeKind, FeedbackApplyOptions,
+    FeedbackInputs,
+};
 use ars_codegen::manifest::{CodegenManifest, FileKind};
-use ars_codegen::project_loader::{find_project_files, load_project};
+use ars_codegen::project_loader::{find_project_files, load_project, save_project};
 use ars_codegen::prompt_generator::PromptGenerator;
 use ars_codegen::session_runner::{
     build_manifest, CodegenConfig, SessionRunner,
@@ -71,6 +74,7 @@ enum Commands {
     ///
     /// `.ars-cache/codegen-manifest.json` を基準点として、最後の同期以降に
     /// 編集されたファイル (Added / Modified / Removed) を一覧表示する。
+    /// `--apply` 指定時は差分を Project / codedesign に書き戻す。
     Feedback {
         /// .ars.json プロジェクトファイル
         #[arg(short, long)]
@@ -81,6 +85,15 @@ enum Commands {
         /// codedesign ディレクトリ (デフォルト: {project_dir}/codedesign)
         #[arg(long)]
         codedesign: Option<String>,
+        /// 差分を実際に Project / codedesign に書き戻す
+        #[arg(long)]
+        apply: bool,
+        /// stale マーカーの追記を抑止する (apply 時)
+        #[arg(long)]
+        no_stale_marker: bool,
+        /// バックアップ作成を抑止する (apply 時)
+        #[arg(long)]
+        no_backup: bool,
     },
     /// 現在の codegen-manifest.json を表示
     Manifest {
@@ -250,7 +263,7 @@ async fn run(cli: Cli) -> Result<(), String> {
             }
             Ok(())
         }
-        Commands::Feedback { project, output, codedesign } => {
+        Commands::Feedback { project, output, codedesign, apply, no_stale_marker, no_backup } => {
             let pf = resolve_project_file(project.as_deref())?;
             let project_dir = pf
                 .parent()
@@ -263,12 +276,13 @@ async fn run(cli: Cli) -> Result<(), String> {
                 .unwrap_or_else(|| project_dir.join("codedesign"));
             let manifest_path = CodegenManifest::default_path(project_dir);
 
-            let report = detect_changes(&FeedbackInputs {
+            let inputs = FeedbackInputs {
                 project_file: &pf,
                 output_root: &output_root,
                 codedesign_root: Some(&cd_path),
                 manifest_path: &manifest_path,
-            })?;
+            };
+            let report = detect_changes(&inputs)?;
 
             println!("\n=== Codegen Feedback ===");
             println!("プロジェクト: {}", pf.display());
@@ -316,6 +330,63 @@ async fn run(cli: Cli) -> Result<(), String> {
                 };
                 println!("  {} [{}] {}{}", change, kind, c.path, entity);
             }
+
+            if !apply {
+                println!("\n（dry-run: 反映するには --apply を指定してください）");
+                return Ok(());
+            }
+
+            // ── --apply 指定時: codedesign → Project, code → stale マーカー ──
+            let mut proj = load_project(&pf)?;
+            let opts = FeedbackApplyOptions {
+                apply_codedesign_to_project: true,
+                mark_code_stale: !no_stale_marker,
+                backup_project: !no_backup,
+            };
+            let result = apply_feedback(&mut proj, &report, &inputs, &opts)?;
+
+            println!("\n=== Apply 結果 ===");
+            if let Some(backup) = &result.backup_path {
+                println!("バックアップ: {}", backup);
+            }
+            println!("Project 反映: {} 件", result.applied.len());
+            for a in &result.applied {
+                let entity = a
+                    .entity_name
+                    .as_deref()
+                    .map(|n| format!(" [{}]", n))
+                    .unwrap_or_default();
+                println!("  - {}{}: {}", a.path, entity, a.summary);
+            }
+            println!("stale マーカー追記: {} 件", result.stale_marked.len());
+            for s in &result.stale_marked {
+                println!("  - {}", s);
+            }
+            if !result.requires_review.is_empty() {
+                println!("要レビュー: {} 件", result.requires_review.len());
+                for r in &result.requires_review {
+                    let entity = r
+                        .entity_name
+                        .as_deref()
+                        .map(|n| format!(" [{}]", n))
+                        .unwrap_or_default();
+                    println!("  - {}{}: {}", r.path, entity, r.summary);
+                }
+            }
+
+            // Project を保存
+            if !result.applied.is_empty() {
+                save_project(&pf, &proj)?;
+                println!("\nプロジェクトを更新しました: {}", pf.display());
+            }
+
+            // manifest を最新化
+            if let Some(prev) = CodegenManifest::load_from(&manifest_path)? {
+                let next = refresh_manifest(&prev, &inputs)?;
+                next.save_to(&manifest_path)?;
+                println!("manifest を更新しました: {}", manifest_path.display());
+            }
+
             Ok(())
         }
         Commands::Manifest { project } => {

--- a/crates/ars-codegen/src/manifest.rs
+++ b/crates/ars-codegen/src/manifest.rs
@@ -1,0 +1,284 @@
+//! コード生成 Manifest
+//!
+//! `.ars-cache/codegen-manifest.json` に永続化される、生成済みファイルの追跡情報。
+//!
+//! - **目的**: 直近の生成時点における CRC32 とタイムスタンプを記録し、
+//!   後段の `feedback` 処理で差分検出（追加 / 変更 / 削除）の基準とする。
+//! - **追跡対象**:
+//!   - 生成されたソースコード（`Scene/...`, `Actor/...`, ...）
+//!   - 生成されたコード詳細設計（`codedesign/...`）
+//!   - プロジェクトファイル自体（`*.ars.json`）
+//!
+//! Manifest は「直前同期の状態」を表すスナップショットであり、
+//! コード／設計を編集した後に `feedback` を実行するとここからの差分が検出される。
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::code_layout::LayoutCategory;
+use crate::crc32::crc32_hex;
+
+/// Manifest 形式のバージョン番号。フォーマット変更時にインクリメントする。
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// `.ars-cache` ディレクトリ名（プロジェクトファイル直下に作成）
+pub const CACHE_DIR: &str = ".ars-cache";
+
+/// Manifest ファイル名
+pub const MANIFEST_FILE: &str = "codegen-manifest.json";
+
+/// 追跡対象ファイルの種別
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileKind {
+    /// 生成されたソースコード
+    Code,
+    /// コード詳細設計（codedesign の MD ファイル）
+    CodeDesign,
+    /// プロジェクトファイル本体（コード「設計」）
+    Project,
+}
+
+/// Manifest に記録される 1 ファイル分のエントリ
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileRecord {
+    /// プロジェクトルート（manifest が置かれているディレクトリの親）からの相対パス
+    pub path: String,
+    /// CRC32 (16進) — 生成時点でのファイル内容
+    pub crc32: String,
+    /// バイトサイズ
+    pub size: u64,
+    /// 最終更新時刻 (RFC3339)。OS の mtime を採用。
+    pub modified_at: String,
+    /// ファイル種別
+    pub kind: FileKind,
+}
+
+/// エンティティ単位の追跡記録
+///
+/// 1 つのエンティティ（シーン / アクター / モジュール / アクション / UI / データ）に
+/// 紐づく生成ファイル群を 1 エントリとしてまとめる。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    /// レイアウトカテゴリ
+    pub category: LayoutCategory,
+    /// 元エンティティの ID（プロジェクト内で一意）
+    pub entity_id: String,
+    /// 元エンティティの名前（生成時のクラス名導出に使用）
+    pub entity_name: String,
+    /// 生成時の出力クラス名（サフィックス付与済み）
+    pub class_name: String,
+    /// 親エンティティのID（Actor は所属シーン、Action は所属シーンなど）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    /// 紐づくファイル群（コード・コード詳細設計・プロジェクトファイル）
+    pub files: Vec<FileRecord>,
+}
+
+/// Manifest 全体
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodegenManifest {
+    pub version: u32,
+    /// プロジェクト名（生成時点）
+    pub project_name: String,
+    /// プロジェクトファイル相対パス（manifest ディレクトリ起点）
+    pub project_file: String,
+    /// 出力ルート（manifest ディレクトリ起点の相対パスに正規化）
+    pub output_root: String,
+    /// codedesign ルート（あれば。manifest ディレクトリ起点の相対パス）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codedesign_root: Option<String>,
+    /// 対象プラットフォーム文字列
+    pub platform: String,
+    /// 生成または同期時刻 (RFC3339)
+    pub last_synced_at: String,
+    /// プロジェクトファイル全体の CRC32（差分検出のショートカット用）
+    pub project_crc32: String,
+    /// エンティティ別の追跡記録
+    pub entries: Vec<ManifestEntry>,
+}
+
+impl CodegenManifest {
+    /// 空 manifest を新規作成する
+    pub fn new(project_name: impl Into<String>, platform: impl Into<String>) -> Self {
+        Self {
+            version: MANIFEST_VERSION,
+            project_name: project_name.into(),
+            project_file: String::new(),
+            output_root: String::new(),
+            codedesign_root: None,
+            platform: platform.into(),
+            last_synced_at: now_rfc3339(),
+            project_crc32: String::new(),
+            entries: Vec::new(),
+        }
+    }
+
+    /// プロジェクトディレクトリ直下の `.ars-cache/codegen-manifest.json` パスを返す
+    pub fn default_path(project_dir: &Path) -> PathBuf {
+        project_dir.join(CACHE_DIR).join(MANIFEST_FILE)
+    }
+
+    /// JSON ファイルから読み込む。ファイルが存在しなければ `Ok(None)`。
+    pub fn load_from(path: &Path) -> Result<Option<Self>, String> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("manifestの読み込みに失敗: {}: {e}", path.display()))?;
+        let manifest: Self = serde_json::from_str(&text)
+            .map_err(|e| format!("manifestのパースに失敗: {}: {e}", path.display()))?;
+        Ok(Some(manifest))
+    }
+
+    /// JSON ファイルに保存する（親ディレクトリを必要なら作成する）
+    pub fn save_to(&self, path: &Path) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("manifestディレクトリ作成に失敗: {}: {e}", parent.display()))?;
+        }
+        let text = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("manifestのシリアライズに失敗: {e}"))?;
+        std::fs::write(path, text)
+            .map_err(|e| format!("manifestの書き込みに失敗: {}: {e}", path.display()))?;
+        Ok(())
+    }
+
+    /// エンティティID → エントリ参照のマップを返す（差分計算用）
+    pub fn entries_by_id(&self) -> BTreeMap<String, &ManifestEntry> {
+        self.entries
+            .iter()
+            .map(|e| (e.entity_id.clone(), e))
+            .collect()
+    }
+}
+
+/// パスからファイルレコードを構築する。ファイルが存在しなければ `None`。
+///
+/// `base_dir` は manifest が記録するパスの基準（通常はプロジェクトディレクトリ）。
+/// `abs_path` は実ファイルへの絶対パス。
+pub fn record_for(abs_path: &Path, base_dir: &Path, kind: FileKind) -> Option<FileRecord> {
+    let bytes = std::fs::read(abs_path).ok()?;
+    let metadata = std::fs::metadata(abs_path).ok()?;
+    let size = metadata.len();
+    let modified_at = system_time_to_rfc3339(metadata.modified().ok()?);
+    let rel = relative_path(abs_path, base_dir);
+    Some(FileRecord {
+        path: rel,
+        crc32: crc32_hex(&bytes),
+        size,
+        modified_at,
+        kind,
+    })
+}
+
+/// 絶対パスを `base_dir` 起点の相対パス文字列に正規化する（前方スラッシュ統一）
+pub fn relative_path(abs: &Path, base: &Path) -> String {
+    let stripped = abs
+        .strip_prefix(base)
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| abs.to_path_buf());
+    stripped
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// 現在時刻を RFC3339 (UTC) で返す
+///
+/// `chrono` を依存に追加せず、`std::time::SystemTime` から手書きで RFC3339 を組み立てる。
+pub fn now_rfc3339() -> String {
+    system_time_to_rfc3339(std::time::SystemTime::now())
+}
+
+/// `SystemTime` を RFC3339 (UTC) に変換する
+pub fn system_time_to_rfc3339(t: std::time::SystemTime) -> String {
+    let secs = t
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    format_unix_secs_rfc3339(secs)
+}
+
+/// UNIX 秒を RFC3339 (UTC, "Z" 表記) に整形する
+fn format_unix_secs_rfc3339(unix_secs: i64) -> String {
+    // UNIX エポックからの日数と時分秒を計算
+    let days = unix_secs.div_euclid(86_400);
+    let secs_of_day = unix_secs.rem_euclid(86_400);
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let (year, month, day) = days_from_epoch_to_ymd(days);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, minute, second
+    )
+}
+
+/// UNIX エポック (1970-01-01) からの日数を (年, 月, 日) に変換する。
+///
+/// グレゴリオ暦の閏年規則に則った変換。タイムゾーンは UTC 固定。
+fn days_from_epoch_to_ymd(days_since_epoch: i64) -> (i32, u32, u32) {
+    // Ref: Howard Hinnant のアルゴリズム http://howardhinnant.github.io/date_algorithms.html
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_format_known_epoch() {
+        assert_eq!(format_unix_secs_rfc3339(0), "1970-01-01T00:00:00Z");
+        assert_eq!(format_unix_secs_rfc3339(1_700_000_000), "2023-11-14T22:13:20Z");
+    }
+
+    #[test]
+    fn rfc3339_handles_leap_year() {
+        // 2024-02-29 is a leap day
+        let secs = 1_709_164_800; // 2024-02-29T00:00:00Z
+        assert_eq!(format_unix_secs_rfc3339(secs), "2024-02-29T00:00:00Z");
+    }
+
+    #[test]
+    fn manifest_roundtrip() {
+        let mut m = CodegenManifest::new("Demo", "ars-native");
+        m.entries.push(ManifestEntry {
+            category: LayoutCategory::Scene,
+            entity_id: "scene-1".into(),
+            entity_name: "Main".into(),
+            class_name: "MainScene".into(),
+            parent_id: None,
+            files: vec![FileRecord {
+                path: "Scene/MainScene/MainScene.ts".into(),
+                crc32: "deadbeef".into(),
+                size: 42,
+                modified_at: now_rfc3339(),
+                kind: FileKind::Code,
+            }],
+        });
+        let json = serde_json::to_string(&m).unwrap();
+        let loaded: CodegenManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].class_name, "MainScene");
+        assert_eq!(loaded.entries[0].files[0].crc32, "deadbeef");
+    }
+
+    #[test]
+    fn relative_path_normalizes_slashes() {
+        let base = Path::new("/proj");
+        let abs = Path::new("/proj/sub/file.txt");
+        assert_eq!(relative_path(abs, base), "sub/file.txt");
+    }
+}

--- a/crates/ars-codegen/src/project_loader.rs
+++ b/crates/ars-codegen/src/project_loader.rs
@@ -8,6 +8,14 @@ pub fn load_project(path: &Path) -> Result<Project, String> {
         .map_err(|e| format!("プロジェクトファイルのパースに失敗: {}", e))
 }
 
+/// Project を pretty JSON でファイルに保存する。
+pub fn save_project(path: &Path, project: &Project) -> Result<(), String> {
+    let text = serde_json::to_string_pretty(project)
+        .map_err(|e| format!("プロジェクトのシリアライズに失敗: {e}"))?;
+    std::fs::write(path, text)
+        .map_err(|e| format!("プロジェクトファイル書き込みに失敗: {}: {e}", path.display()))
+}
+
 pub fn find_project_files(dir: &Path, max_depth: usize) -> Vec<PathBuf> {
     let mut files = Vec::new();
     scan_dir(dir, &mut files, max_depth);

--- a/crates/ars-codegen/src/prompt_generator.rs
+++ b/crates/ars-codegen/src/prompt_generator.rs
@@ -1,5 +1,9 @@
 use ars_core::models::{Component, Project, Scene};
 
+use crate::code_layout::{
+    class_name_for, classify_component_category, entity_dir, LayoutCategory,
+};
+
 /// コード生成タスク
 pub struct CodegenTask {
     pub id: String,
@@ -8,6 +12,12 @@ pub struct CodegenTask {
     pub prompt: String,
     pub dependencies: Vec<String>,
     pub output_dir: String,
+    /// レイアウトカテゴリ (Scene/Actor/Module/Action/UI/Data)
+    pub layout_category: LayoutCategory,
+    /// 元エンティティ ID（manifest 紐付け用）
+    pub entity_id: String,
+    /// 生成されるクラス名（サフィックス付与済み）
+    pub class_name: String,
 }
 
 /// カテゴリの日本語マッピング
@@ -28,17 +38,6 @@ fn is_pictor_domain(domain: &str) -> bool {
     keywords.iter().any(|k| lower.contains(k))
 }
 
-fn to_kebab_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() && i > 0 {
-            result.push('-');
-        }
-        result.push(c.to_ascii_lowercase());
-    }
-    result.replace(' ', "-")
-}
-
 pub struct PromptGenerator<'a> {
     project: &'a Project,
     platform: &'a str,
@@ -57,30 +56,85 @@ impl<'a> PromptGenerator<'a> {
     ) -> Vec<CodegenTask> {
         let mut tasks = Vec::new();
 
-        // 1. コンポーネント単位
+        // 1. コンポーネント単位 (UI / Module の振り分けは category で決定)
         let components = self.get_target_components(component_ids);
         for comp in &components {
+            let category = classify_component_category(&comp.category);
+            let class_name = class_name_for(category, &comp.name);
             tasks.push(CodegenTask {
                 id: format!("comp-{}", comp.id),
-                task_type: "component".into(),
+                task_type: category.as_str().to_string(),
                 name: comp.name.clone(),
                 prompt: self.build_component_prompt(comp),
                 dependencies: self.resolve_component_deps(comp, &components),
-                output_dir: format!("{}/components/{}/{}", output_dir, to_kebab_case(&comp.domain), to_kebab_case(&comp.name)),
+                output_dir: entity_dir(output_dir, category, &comp.name),
+                layout_category: category,
+                entity_id: comp.id.clone(),
+                class_name,
             });
         }
 
-        // 2. シーン単位
+        // 2. アクション単位 (Scene 横断で集約)
         let scenes = self.get_target_scenes(scene_ids);
         for scene in &scenes {
+            for action in scene.actions.values() {
+                let category = LayoutCategory::Action;
+                let class_name = class_name_for(category, &action.name);
+                tasks.push(CodegenTask {
+                    id: format!("action-{}", action.id),
+                    task_type: category.as_str().to_string(),
+                    name: action.name.clone(),
+                    prompt: self.build_action_prompt(scene, action),
+                    dependencies: vec![],
+                    output_dir: entity_dir(output_dir, category, &action.name),
+                    layout_category: category,
+                    entity_id: action.id.clone(),
+                    class_name,
+                });
+            }
+        }
+
+        // 3. アクター単位 (各シーン配下のアクターを Actor カテゴリで個別生成)
+        for scene in &scenes {
+            for actor in scene.actors.values() {
+                let category = LayoutCategory::Actor;
+                let class_name = class_name_for(category, &actor.name);
+                tasks.push(CodegenTask {
+                    id: format!("actor-{}", actor.id),
+                    task_type: category.as_str().to_string(),
+                    name: actor.name.clone(),
+                    prompt: self.build_actor_prompt(scene, actor),
+                    dependencies: vec![],
+                    output_dir: entity_dir(output_dir, category, &actor.name),
+                    layout_category: category,
+                    entity_id: actor.id.clone(),
+                    class_name,
+                });
+            }
+        }
+
+        // 4. シーン単位
+        for scene in &scenes {
             let comp_deps = self.get_scene_component_deps(scene, &components);
+            let category = LayoutCategory::Scene;
+            let class_name = class_name_for(category, &scene.name);
+            let mut deps: Vec<String> = comp_deps.iter().map(|c| format!("comp-{}", c.id)).collect();
+            for actor in scene.actors.values() {
+                deps.push(format!("actor-{}", actor.id));
+            }
+            for action in scene.actions.values() {
+                deps.push(format!("action-{}", action.id));
+            }
             tasks.push(CodegenTask {
                 id: format!("scene-{}", scene.id),
-                task_type: "scene".into(),
+                task_type: category.as_str().to_string(),
                 name: scene.name.clone(),
                 prompt: self.build_scene_prompt(scene),
-                dependencies: comp_deps.iter().map(|c| format!("comp-{}", c.id)).collect(),
-                output_dir: format!("{}/scenes/{}", output_dir, to_kebab_case(&scene.name)),
+                dependencies: deps,
+                output_dir: entity_dir(output_dir, category, &scene.name),
+                layout_category: category,
+                entity_id: scene.id.clone(),
+                class_name,
             });
         }
 
@@ -118,12 +172,20 @@ impl<'a> PromptGenerator<'a> {
     fn build_component_prompt(&self, component: &Component) -> String {
         let needs_pictor = is_pictor_domain(&component.domain);
         let (lang, ext, module_pattern) = self.platform_info();
+        let category = classify_component_category(&component.category);
+        let class_name = class_name_for(category, &component.name);
 
         let mut lines = vec![
-            format!("# コード生成指示: {} コンポーネント", component.name),
+            format!(
+                "# コード生成指示: {} ({})",
+                component.name,
+                category.dir_name()
+            ),
             String::new(),
             format!("## ターゲットプラットフォーム: {}", self.platform),
             format!("## 実装言語: {}", lang),
+            format!("## 出力カテゴリ: {}", category.dir_name()),
+            format!("## クラス名: `{}`", class_name),
             String::new(),
             format!("以下のErgoモジュール定義に基づいて、{}として実装コードを生成してください。", module_pattern),
             String::new(),
@@ -143,20 +205,142 @@ impl<'a> PromptGenerator<'a> {
         lines.push("---".into());
         lines.push(String::new());
         lines.push("## 生成要件".into());
-        lines.push(format!("1. メインモジュールファイル: `{}{}`", to_kebab_case(&component.name), ext));
-        lines.push("2. 各タスクの実装".into());
-        lines.push("3. エラーハンドリング".into());
+        lines.push(format!(
+            "1. メインモジュールファイル: `{}{}` (クラス名 `{}`)",
+            class_name, ext, class_name
+        ));
+        lines.push(format!(
+            "2. このファイルは出力ルート配下の `{}/{}/` に配置すること",
+            category.dir_name(),
+            class_name
+        ));
+        lines.push("3. 各タスクの実装".into());
+        lines.push("4. エラーハンドリング".into());
 
         lines.join("\n")
     }
 
+    fn build_actor_prompt(&self, scene: &Scene, actor: &ars_core::models::Actor) -> String {
+        let (lang, ext, _pattern) = self.platform_info();
+        let category = LayoutCategory::Actor;
+        let class_name = class_name_for(category, &actor.name);
+
+        let mut lines = vec![
+            format!("# コード生成指示: {} (Actor)", actor.name),
+            String::new(),
+            format!("## ターゲットプラットフォーム: {}", self.platform),
+            format!("## 実装言語: {}", lang),
+            format!("## 所属シーン: {}", scene.name),
+            format!("## ドメインロール: {}", actor.role),
+            format!("## アクタータイプ: {}", actor.actor_type),
+            format!("## クラス名: `{}`", class_name),
+            String::new(),
+        ];
+
+        if !actor.requirements.overview.is_empty() {
+            lines.push("## 概要".into());
+            for item in &actor.requirements.overview {
+                lines.push(format!("- {}", item));
+            }
+            lines.push(String::new());
+        }
+        if !actor.requirements.goals.is_empty() {
+            lines.push("## 達成目標".into());
+            for item in &actor.requirements.goals {
+                lines.push(format!("- {}", item));
+            }
+            lines.push(String::new());
+        }
+        if !actor.requirements.role.is_empty() {
+            lines.push("## 役割".into());
+            for item in &actor.requirements.role {
+                lines.push(format!("- {}", item));
+            }
+            lines.push(String::new());
+        }
+        if !actor.requirements.behavior.is_empty() {
+            lines.push("## 挙動".into());
+            for item in &actor.requirements.behavior {
+                lines.push(format!("- {}", item));
+            }
+            lines.push(String::new());
+        }
+
+        lines.push("## 生成要件".into());
+        lines.push(format!(
+            "1. アクタークラス: `{}{}` (クラス名 `{}`、Actor サフィックス必須)",
+            class_name, ext, class_name
+        ));
+        lines.push(format!(
+            "2. 出力配置: `Actor/{}/`",
+            class_name
+        ));
+        lines.push("3. ドメインロール / 要件定義をクラスのヘッダコメントに反映".into());
+        lines.join("\n")
+    }
+
+    fn build_action_prompt(&self, scene: &Scene, action: &ars_core::models::Action) -> String {
+        let (lang, ext, _pattern) = self.platform_info();
+        // Action はサフィックスを付与しない
+        let class_name = class_name_for(LayoutCategory::Action, &action.name);
+
+        let mut lines = vec![
+            format!("# コード生成指示: {} (Action)", action.name),
+            String::new(),
+            format!("## ターゲットプラットフォーム: {}", self.platform),
+            format!("## 実装言語: {}", lang),
+            format!("## 所属シーン: {}", scene.name),
+            format!(
+                "## アクション種別: {}",
+                serde_json::to_string(&action.action_type).unwrap_or("\"interface\"".into())
+            ),
+            format!("## クラス名: `{}` (サフィックス無し)", class_name),
+            String::new(),
+        ];
+
+        if !action.description.is_empty() {
+            lines.push("## 説明".into());
+            lines.push(action.description.clone());
+            lines.push(String::new());
+        }
+        if !action.behaviors.is_empty() {
+            lines.push("## 振る舞い".into());
+            for b in &action.behaviors {
+                lines.push(format!("- {}", b));
+            }
+            lines.push(String::new());
+        }
+        if !action.concretes.is_empty() {
+            lines.push("## 具体実装".into());
+            for c in &action.concretes {
+                lines.push(format!("- {}: {}", c.name, c.description));
+            }
+            lines.push(String::new());
+        }
+
+        lines.push("## 生成要件".into());
+        lines.push(format!(
+            "1. アクション本体: `{}{}` (クラス名 `{}` — サフィックスを付与しない)",
+            class_name, ext, class_name
+        ));
+        lines.push(format!("2. 出力配置: `Action/{}/`", class_name));
+        lines.join("\n")
+    }
+
     fn build_scene_prompt(&self, scene: &Scene) -> String {
-        let (lang, _ext, _pattern) = self.platform_info();
+        let (lang, ext, _pattern) = self.platform_info();
+        let category = LayoutCategory::Scene;
+        let class_name = class_name_for(category, &scene.name);
         let mut lines = vec![
             format!("# コード生成指示: {} シーン", scene.name),
             String::new(),
             format!("## ターゲットプラットフォーム: {}", self.platform),
             format!("## 実装言語: {}", lang),
+            format!("## クラス名: `{}` (Scene サフィックス必須)", class_name),
+            format!(
+                "## 出力配置: `Scene/{}/{}{}`",
+                class_name, class_name, ext
+            ),
             String::new(),
             "以下のシーン構造に基づいて、アクター生成・接続配線のコードを生成してください。".into(),
             String::new(),

--- a/crates/ars-codegen/src/session_runner.rs
+++ b/crates/ars-codegen/src/session_runner.rs
@@ -1,6 +1,10 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
+use crate::crc32::crc32_hex;
+use crate::manifest::{
+    record_for, system_time_to_rfc3339, CodegenManifest, FileKind, ManifestEntry,
+};
 use crate::prompt_generator::CodegenTask;
 
 pub struct CodegenConfig {
@@ -236,6 +240,118 @@ fn scan_files(dir: &Path, results: &mut Vec<String>) {
             scan_files(&path, results);
         } else {
             results.push(path.to_string_lossy().to_string());
+        }
+    }
+}
+
+// ── Manifest 構築 ─────────────────────────────────────────
+
+/// `run_tasks` の結果から Manifest を構築する。
+///
+/// - `tasks`              : 実行したタスク一覧（`layout_category` / `entity_id` / `class_name` を保持）
+/// - `results`            : `run_tasks` の戻り値（成功・出力ファイル一覧）
+/// - `project_file`       : プロジェクトファイル絶対パス
+/// - `output_root`        : 生成出力ルート絶対パス
+/// - `codedesign_root`    : codedesign ルート絶対パス（任意）
+/// - `project_name`       : プロジェクト名
+/// - `platform`           : 対象プラットフォーム文字列
+///
+/// 成功した各タスクの出力ファイルを `code` 種別として記録し、
+/// codedesign ルート配下に同じ class_name を持つ MD があれば `codedesign` 種別で
+/// 同エントリにまとめる。
+pub fn build_manifest(
+    tasks: &[CodegenTask],
+    results: &[CodegenResult],
+    project_file: &Path,
+    output_root: &Path,
+    codedesign_root: Option<&Path>,
+    project_name: &str,
+    platform: &str,
+) -> CodegenManifest {
+    let project_dir: PathBuf = project_file
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let mut manifest = CodegenManifest::new(project_name, platform);
+    manifest.project_file = crate::manifest::relative_path(project_file, &project_dir);
+    manifest.output_root = crate::manifest::relative_path(output_root, &project_dir);
+    manifest.codedesign_root = codedesign_root
+        .map(|p| crate::manifest::relative_path(p, &project_dir));
+    if let Ok(bytes) = std::fs::read(project_file) {
+        manifest.project_crc32 = crc32_hex(&bytes);
+    }
+
+    for task in tasks {
+        let result = results.iter().find(|r| r.task_id == task.id);
+        let success = result.map(|r| r.success).unwrap_or(false);
+        if !success {
+            continue;
+        }
+        let mut files = Vec::new();
+        if let Some(r) = result {
+            for file_path in &r.output_files {
+                let abs = Path::new(file_path);
+                if let Some(rec) = record_for(abs, &project_dir, FileKind::Code) {
+                    files.push(rec);
+                }
+            }
+        }
+        // codedesign 側に対応する MD があればまとめる
+        if let Some(cd) = codedesign_root {
+            for cd_path in find_codedesign_for(cd, task) {
+                if let Some(rec) = record_for(&cd_path, &project_dir, FileKind::CodeDesign) {
+                    files.push(rec);
+                }
+            }
+        }
+        manifest.entries.push(ManifestEntry {
+            category: task.layout_category,
+            entity_id: task.entity_id.clone(),
+            entity_name: task.name.clone(),
+            class_name: task.class_name.clone(),
+            parent_id: None,
+            files,
+        });
+    }
+    manifest.last_synced_at = system_time_to_rfc3339(std::time::SystemTime::now());
+    manifest
+}
+
+/// codedesign ルート配下から、タスクと一致する MD ファイルを探す。
+///
+/// 命名は `codedesign-generation-rules.md` に従い kebab-case を採用しているため、
+/// `class_name` および raw `name` の両方で検索する。
+fn find_codedesign_for(codedesign_root: &Path, task: &CodegenTask) -> Vec<PathBuf> {
+    use crate::code_layout::to_kebab_case;
+    let candidates = [
+        to_kebab_case(&task.class_name),
+        to_kebab_case(&task.name),
+    ];
+    let mut hits = Vec::new();
+    visit_md_files(codedesign_root, &mut |path| {
+        let stem = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_lowercase())
+            .unwrap_or_default();
+        if candidates.iter().any(|c| c == &stem) {
+            hits.push(path.to_path_buf());
+        }
+    });
+    hits
+}
+
+fn visit_md_files<F: FnMut(&Path)>(dir: &Path, visitor: &mut F) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            visit_md_files(&path, visitor);
+        } else if path.extension().map(|e| e == "md").unwrap_or(false) {
+            visitor(&path);
         }
     }
 }


### PR DESCRIPTION
- code_layout: Scene/Actor/Module/Action/UI/Data の 6 カテゴリを定義し、
  Module/Action 以外はクラス名にカテゴリ名のサフィックスを付与する命名規則
  (PascalCase 化と二重サフィックス防止を含む) を実装。
- crc32: 外部依存を増やさず IEEE 802.3 CRC32 を逐次計算する軽量実装。
  生成済みファイルの差分検出に使用する。
- manifest: .ars-cache/codegen-manifest.json として永続化される
  CodegenManifest / ManifestEntry / FileRecord を定義。RFC3339 整形も
  std::time から自前で実装し、依存追加なしで完結。

実装設計は #89 を参照。本コミットは Phase 1 (出力レイアウト + Manifest 記録 +
差分検出基盤) のための前提モジュール。後続コミットで feedback.rs および
PromptGenerator/CLI/Bridge の更新を行う。

https://claude.ai/code/session_01Fd57tbqx5iJVgdJ7CGmSAy