### PR TITLE
feat(asset-importer): meshopt simplify + proxy.glb writer (#92 P2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,8 +175,10 @@ version = "0.1.0"
 dependencies = [
  "ars-core",
  "blake3",
+ "byteorder",
  "glam",
  "gltf",
+ "meshopt",
  "serde",
  "serde_json",
  "tempfile",
@@ -1391,6 +1393,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2722,6 +2733,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meshopt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01e77ead21976b3a9f01ec1724f766923da74f0726364e2b0f425658935d71a"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "float-cmp",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/ars-asset-importer/Cargo.toml
+++ b/crates/ars-asset-importer/Cargo.toml
@@ -14,6 +14,8 @@ gltf = { version = "1.4", default-features = false, features = ["import", "utils
 glam = { version = "0.29", features = ["serde"] }
 blake3 = "1"
 toml = "0.8"
+meshopt = "0.6"
+byteorder = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ars-asset-importer/src/lib.rs
+++ b/crates/ars-asset-importer/src/lib.rs
@@ -11,20 +11,24 @@
 //!
 //! 本クレートは **Tier 1 の生成**を担当する。描画側の対応は Pictor#37 を参照。
 //!
-//! ## P1 スコープ (本コミット)
+//! ## P1 (`#92` の Phase 1)
 //!
 //! - glTF ローダー
 //! - AABB / OBB 算出
 //! - source hash によるキャッシュ判定
 //! - `data/<id>/` レイアウト書き出し
 //!
-//! P2 以降 (meshopt simplify / 凸包 / サムネ) は stub として存在する。
+//! ## P2 (`#92` の Phase 2)
+//!
+//! - meshopt による mesh simplification
+//! - `proxy.glb` (positions + indices のみの最小 GLB) 書き出し
 
 pub mod error;
 pub mod hull;
 pub mod loaders;
 pub mod obb;
 pub mod pipeline;
+pub mod proxy_writer;
 pub mod schema;
 pub mod simplify;
 pub mod thumbnail;

--- a/crates/ars-asset-importer/src/pipeline.rs
+++ b/crates/ars-asset-importer/src/pipeline.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::loaders::{self, MeshData};
 use crate::schema::{AssetId, AssetMeta, Bounds, CacheLayout};
-use crate::{obb, AssetImporterError, Result};
+use crate::{obb, proxy_writer, simplify, AssetImporterError, Result};
 
 /// `process` の結果。キャッシュヒットかどうかを呼び出し側に伝える。
 #[derive(Debug, Clone)]
@@ -65,6 +65,18 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
     let obb = obb::compute(&mesh.positions).ok_or(AssetImporterError::EmptyGeometry)?;
     let pivot = aabb.center().to_array();
 
+    // 書き出し (アトミックではないがローカル前提)
+    fs::create_dir_all(&dir).map_err(|e| AssetImporterError::io(&dir, e))?;
+
+    // 原アセットをコピー
+    let dst_src = layout.source_path(&source_ext);
+    fs::copy(src, &dst_src).map_err(|e| AssetImporterError::io(&dst_src, e))?;
+
+    // proxy.glb (P2): meshopt で decimate → 最小 GLB を書き出し
+    let proxy_mesh = simplify::simplify(&mesh, simplify::DEFAULT_TARGET_TRIANGLES);
+    proxy_writer::write_glb(&proxy_mesh, &layout.proxy_path())?;
+    let proxy_triangle_count = Some(proxy_mesh.triangle_count());
+
     let meta = AssetMeta {
         version: AssetMeta::CURRENT_VERSION,
         id: id.clone(),
@@ -76,14 +88,8 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
         pivot,
         triangle_count: mesh.triangle_count(),
         vertex_count: mesh.vertex_count(),
+        proxy_triangle_count,
     };
-
-    // 書き出し (アトミックではないがローカル前提)
-    fs::create_dir_all(&dir).map_err(|e| AssetImporterError::io(&dir, e))?;
-
-    // 原アセットをコピー
-    let dst_src = layout.source_path(&source_ext);
-    fs::copy(src, &dst_src).map_err(|e| AssetImporterError::io(&dst_src, e))?;
 
     // meta.toml
     write_meta(&layout.meta_path(), &meta)?;

--- a/crates/ars-asset-importer/src/proxy_writer.rs
+++ b/crates/ars-asset-importer/src/proxy_writer.rs
@@ -1,0 +1,263 @@
+//! 最小 GLB (glTF 2.0 binary) writer (P2)
+//!
+//! プロキシメッシュ (positions + 32-bit indices のみ) を表現する最小限の
+//! GLB ファイルをバイト列で生成する。ノード変換 / マテリアル / 法線 / UV
+//! 等は持たない。
+//!
+//! 決定性: JSON は固定順のキーで手書き、padding 文字も glTF 仕様準拠
+//! (JSON chunk は 0x20、BIN chunk は 0x00) で固定する。同一入力に対し
+//! 常に同一バイト列を返す。
+//!
+//! ## ファイルレイアウト (glTF 2.0 spec)
+//!
+//! ```text
+//! [12B header] [JSON chunk] [BIN chunk]
+//!
+//! header: magic "glTF" (4B) + version=2 (4B) + total length (4B)
+//! chunk:  length (4B) + type (4B "JSON" or "BIN\0") + data + padding to 4B align
+//! ```
+
+use std::io::Write;
+use std::path::Path;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use crate::loaders::MeshData;
+use crate::{AssetImporterError, Result};
+
+const GLB_MAGIC: u32 = 0x4654_6C67; // "glTF"
+const GLB_VERSION: u32 = 2;
+const CHUNK_TYPE_JSON: u32 = 0x4E4F_534A; // "JSON"
+const CHUNK_TYPE_BIN: u32 = 0x004E_4942; // "BIN\0"
+
+const COMPONENT_TYPE_FLOAT: u32 = 5126;
+const COMPONENT_TYPE_UNSIGNED_INT: u32 = 5125;
+const TARGET_ARRAY_BUFFER: u32 = 34962;
+const TARGET_ELEMENT_ARRAY_BUFFER: u32 = 34963;
+const MODE_TRIANGLES: u32 = 4;
+
+/// `mesh` を GLB 形式のバイト列にエンコードする。
+///
+/// `mesh.positions` が空の場合はエラーを返す。`mesh.indices` が空の場合は
+/// non-indexed として連番インデックスを生成する。
+pub fn encode_glb(mesh: &MeshData) -> Result<Vec<u8>> {
+    if mesh.positions.is_empty() {
+        return Err(AssetImporterError::EmptyGeometry);
+    }
+
+    // ---- BIN chunk (positions then indices) を組み立て ----
+    let pos_count = mesh.positions.len();
+    let pos_bytes = pos_count * std::mem::size_of::<[f32; 3]>();
+
+    let indices_owned: Vec<u32>;
+    let indices: &[u32] = if mesh.indices.is_empty() {
+        indices_owned = (0..pos_count as u32).collect();
+        &indices_owned
+    } else {
+        &mesh.indices
+    };
+    let idx_count = indices.len();
+    let idx_bytes = std::mem::size_of_val(indices);
+
+    let mut bin: Vec<u8> = Vec::with_capacity(pos_bytes + idx_bytes);
+    for v in &mesh.positions {
+        bin.write_f32::<LittleEndian>(v.x).unwrap();
+        bin.write_f32::<LittleEndian>(v.y).unwrap();
+        bin.write_f32::<LittleEndian>(v.z).unwrap();
+    }
+    let pos_byte_offset = 0usize;
+    let idx_byte_offset = bin.len();
+    for &i in indices {
+        bin.write_u32::<LittleEndian>(i).unwrap();
+    }
+    pad_to_4(&mut bin, 0x00);
+    let bin_chunk_len = bin.len();
+
+    // ---- AABB (POSITION accessor の min/max) ----
+    let (mn, mx) = aabb_min_max(&mesh.positions);
+
+    // ---- JSON chunk を手書きで決定的に組み立て ----
+    let json = build_json(
+        bin_chunk_len,
+        pos_byte_offset,
+        pos_bytes,
+        idx_byte_offset,
+        idx_bytes,
+        pos_count,
+        idx_count,
+        mn,
+        mx,
+    );
+    let mut json_bytes = json.into_bytes();
+    pad_to_4(&mut json_bytes, 0x20);
+    let json_chunk_len = json_bytes.len();
+
+    // ---- 全体組み立て ----
+    let total_len = 12 + 8 + json_chunk_len + 8 + bin_chunk_len;
+    let mut out = Vec::with_capacity(total_len);
+
+    // header
+    out.write_u32::<LittleEndian>(GLB_MAGIC).unwrap();
+    out.write_u32::<LittleEndian>(GLB_VERSION).unwrap();
+    out.write_u32::<LittleEndian>(total_len as u32).unwrap();
+
+    // JSON chunk
+    out.write_u32::<LittleEndian>(json_chunk_len as u32).unwrap();
+    out.write_u32::<LittleEndian>(CHUNK_TYPE_JSON).unwrap();
+    out.extend_from_slice(&json_bytes);
+
+    // BIN chunk
+    out.write_u32::<LittleEndian>(bin_chunk_len as u32).unwrap();
+    out.write_u32::<LittleEndian>(CHUNK_TYPE_BIN).unwrap();
+    out.extend_from_slice(&bin);
+
+    debug_assert_eq!(out.len(), total_len);
+    Ok(out)
+}
+
+/// `encode_glb` の結果を `path` に書き出す。
+pub fn write_glb(mesh: &MeshData, path: &Path) -> Result<()> {
+    let bytes = encode_glb(mesh)?;
+    let mut f = std::fs::File::create(path).map_err(|e| AssetImporterError::io(path, e))?;
+    f.write_all(&bytes)
+        .map_err(|e| AssetImporterError::io(path, e))?;
+    Ok(())
+}
+
+fn pad_to_4(buf: &mut Vec<u8>, fill: u8) {
+    let rem = buf.len() % 4;
+    if rem != 0 {
+        buf.resize(buf.len() + (4 - rem), fill);
+    }
+}
+
+fn aabb_min_max(positions: &[glam::Vec3]) -> ([f32; 3], [f32; 3]) {
+    let mut mn = positions[0];
+    let mut mx = positions[0];
+    for &p in &positions[1..] {
+        mn = mn.min(p);
+        mx = mx.max(p);
+    }
+    (mn.to_array(), mx.to_array())
+}
+
+/// JSON を決定的な順序で手書き構築する。
+///
+/// `serde_json` を経由しない理由: BTreeMap によるキーソートでは accessors/
+/// bufferViews 内の順序まで完全には制御できないため、バイト一致テストの
+/// 安全性を最大化するために手書きで固定する。
+#[allow(clippy::too_many_arguments)]
+fn build_json(
+    bin_chunk_len: usize,
+    pos_byte_offset: usize,
+    pos_bytes: usize,
+    idx_byte_offset: usize,
+    idx_bytes: usize,
+    pos_count: usize,
+    idx_count: usize,
+    mn: [f32; 3],
+    mx: [f32; 3],
+) -> String {
+    format!(
+        concat!(
+            r#"{{"asset":{{"version":"2.0","generator":"ars-asset-importer"}},"#,
+            r#""buffers":[{{"byteLength":{bin_len}}}],"#,
+            r#""bufferViews":["#,
+            r#"{{"buffer":0,"byteOffset":{pos_off},"byteLength":{pos_len},"target":{pos_target}}},"#,
+            r#"{{"buffer":0,"byteOffset":{idx_off},"byteLength":{idx_len},"target":{idx_target}}}"#,
+            r#"],"#,
+            r#""accessors":["#,
+            r#"{{"bufferView":0,"componentType":{ct_f32},"count":{vc},"type":"VEC3","min":[{mnx},{mny},{mnz}],"max":[{mxx},{mxy},{mxz}]}},"#,
+            r#"{{"bufferView":1,"componentType":{ct_u32},"count":{ic},"type":"SCALAR"}}"#,
+            r#"],"#,
+            r#""meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":{mode}}}]}}],"#,
+            r#""nodes":[{{"mesh":0}}],"#,
+            r#""scenes":[{{"nodes":[0]}}],"#,
+            r#""scene":0}}"#,
+        ),
+        bin_len = bin_chunk_len,
+        pos_off = pos_byte_offset,
+        pos_len = pos_bytes,
+        pos_target = TARGET_ARRAY_BUFFER,
+        idx_off = idx_byte_offset,
+        idx_len = idx_bytes,
+        idx_target = TARGET_ELEMENT_ARRAY_BUFFER,
+        ct_f32 = COMPONENT_TYPE_FLOAT,
+        vc = pos_count,
+        mnx = format_float(mn[0]),
+        mny = format_float(mn[1]),
+        mnz = format_float(mn[2]),
+        mxx = format_float(mx[0]),
+        mxy = format_float(mx[1]),
+        mxz = format_float(mx[2]),
+        ct_u32 = COMPONENT_TYPE_UNSIGNED_INT,
+        ic = idx_count,
+        mode = MODE_TRIANGLES,
+    )
+}
+
+/// 浮動小数点を決定的に整形する。
+///
+/// Rust の `Display for f32` (Grisu/Ryu) は同じ値に対し常に同じ表現を返すので、
+/// プラットフォーム差は出ない。NaN/Inf は仕様外なので 0 として扱う。
+fn format_float(v: f32) -> String {
+    if v.is_finite() {
+        format!("{v}")
+    } else {
+        "0".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    fn triangle_mesh() -> MeshData {
+        MeshData {
+            name: "tri".into(),
+            positions: vec![
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(1.0, 0.0, 0.0),
+                Vec3::new(0.0, 1.0, 0.0),
+            ],
+            indices: vec![0, 1, 2],
+        }
+    }
+
+    #[test]
+    fn header_is_correct() {
+        let bytes = encode_glb(&triangle_mesh()).unwrap();
+        // magic
+        assert_eq!(&bytes[0..4], b"glTF");
+        // version
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 2);
+        // length matches
+        let len = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+        assert_eq!(len, bytes.len());
+    }
+
+    #[test]
+    fn deterministic_byte_for_byte() {
+        let m = triangle_mesh();
+        let a = encode_glb(&m).unwrap();
+        let b = encode_glb(&m).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn round_trip_via_gltf_crate() {
+        // 出力が gltf クレートで再ロード可能であることを確認
+        let bytes = encode_glb(&triangle_mesh()).unwrap();
+        let g = gltf::Gltf::from_slice(&bytes).expect("valid GLB");
+        let mesh = g.document.meshes().next().expect("has mesh");
+        let prim = mesh.primitives().next().expect("has primitive");
+        assert_eq!(prim.mode(), gltf::mesh::Mode::Triangles);
+    }
+
+    #[test]
+    fn empty_mesh_errors() {
+        let m = MeshData::default();
+        assert!(encode_glb(&m).is_err());
+    }
+}

--- a/crates/ars-asset-importer/src/schema.rs
+++ b/crates/ars-asset-importer/src/schema.rs
@@ -112,6 +112,12 @@ pub struct AssetMeta {
     pub triangle_count: u32,
     /// 頂点数 (原メッシュ)
     pub vertex_count: u32,
+    /// `proxy.glb` の三角形数 (P2 以降で書き込まれる)。
+    ///
+    /// P1 で生成された meta は本フィールドを持たないため、`#[serde(default)]`
+    /// で `None` として読み込まれる。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_triangle_count: Option<u32>,
 }
 
 impl AssetMeta {

--- a/crates/ars-asset-importer/src/simplify.rs
+++ b/crates/ars-asset-importer/src/simplify.rs
@@ -1,6 +1,138 @@
-//! メッシュ簡略化 (stub — P2)
+//! メッシュ簡略化 (P2)
 //!
-//! Phase 2 で `meshopt` クレートによる decimate を実装する予定。
-//! 現在は proxy.glb を原メッシュからそのまま生成しない (meta のみ書く) 構成。
+//! `meshopt` (Arseny Kapoulkine) の simplification API で原メッシュを decimate し、
+//! 目標 triangle 数以下のプロキシメッシュを生成する。
+//!
+//! `meshopt::simplify` は擬似乱数を使わない決定的アルゴリズムなので、
+//! 同一入力 + 同一バージョンで常に同一バイト列の結果を返す。
 
-// 実装なし: Phase 2 で meshopt による simplification を導入する。
+use meshopt::{SimplifyOptions, VertexDataAdapter};
+
+use crate::loaders::MeshData;
+
+/// 簡略化の上限 triangle 数 (Tier 1 仕様: < 256 tri を目標)。
+pub const DEFAULT_TARGET_TRIANGLES: u32 = 256;
+
+/// 許容誤差 (絶対値)。`meshopt::simplify` の `target_error`。
+///
+/// 0.05 は「モデル直径の 5%」相当の誤差を許容することを意味する。
+/// プレビュー目的なので過度に小さくしない (収束しないと target に届かない)。
+pub const DEFAULT_TARGET_ERROR: f32 = 0.05;
+
+/// `mesh` を `target_triangles` 以下まで簡略化した新しい [`MeshData`] を返す。
+///
+/// 入力が既に target 以下の場合は (再構築無しで) クローンを返す。
+/// 結果メッシュは indexed (positions の重複を保ったまま indices だけ縮約) になる。
+pub fn simplify(mesh: &MeshData, target_triangles: u32) -> MeshData {
+    if mesh.is_empty() {
+        return mesh.clone();
+    }
+    if mesh.triangle_count() <= target_triangles {
+        return mesh.clone();
+    }
+
+    // meshopt は VertexDataAdapter で位置オフセット付きバイト列を受ける。
+    // [Vec3; N] (= [f32; 3] * N) として直接 byte slice 化する。
+    let position_bytes: &[u8] = bytemuck_cast(&mesh.positions);
+    let adapter = VertexDataAdapter::new(
+        position_bytes,
+        std::mem::size_of::<[f32; 3]>(),
+        0,
+    )
+    .expect("VertexDataAdapter from Vec3 slice");
+
+    let target_index_count = (target_triangles as usize) * 3;
+
+    let new_indices = meshopt::simplify(
+        &mesh.indices,
+        &adapter,
+        target_index_count,
+        DEFAULT_TARGET_ERROR,
+        SimplifyOptions::None,
+        None,
+    );
+
+    MeshData {
+        name: mesh.name.clone(),
+        positions: mesh.positions.clone(),
+        indices: new_indices,
+    }
+}
+
+/// `Vec<glam::Vec3>` → `&[u8]` の安全な再解釈。
+///
+/// `glam::Vec3` は `repr(C)` で `[f32; 3]` 同等のレイアウトなので
+/// `meshopt` (および GPU バッファ) で扱う `[f32; 3]` 列としてそのまま参照できる。
+fn bytemuck_cast(positions: &[glam::Vec3]) -> &[u8] {
+    let len = std::mem::size_of_val(positions);
+    // SAFETY: glam::Vec3 is #[repr(C)] of three f32; reading as bytes is sound.
+    unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, len) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    fn unit_grid_mesh(side: u32) -> MeshData {
+        // side x side の四角形格子を 2 三角形/quad で展開
+        let mut positions = Vec::new();
+        let mut indices = Vec::new();
+        let s = side as f32;
+        for y in 0..=side {
+            for x in 0..=side {
+                positions.push(Vec3::new(x as f32 / s, y as f32 / s, 0.0));
+            }
+        }
+        let row = side + 1;
+        for y in 0..side {
+            for x in 0..side {
+                let i0 = y * row + x;
+                let i1 = i0 + 1;
+                let i2 = i0 + row;
+                let i3 = i2 + 1;
+                indices.extend_from_slice(&[i0, i1, i2, i1, i3, i2]);
+            }
+        }
+        MeshData {
+            name: "grid".into(),
+            positions,
+            indices,
+        }
+    }
+
+    #[test]
+    fn passthrough_when_under_target() {
+        let mesh = unit_grid_mesh(2); // 2*2*2 = 8 tri
+        let out = simplify(&mesh, 256);
+        assert_eq!(out.triangle_count(), mesh.triangle_count());
+    }
+
+    #[test]
+    fn reduces_high_tri_mesh_below_target() {
+        // 32x32 = 2048 tri、target 256
+        let mesh = unit_grid_mesh(32);
+        assert!(mesh.triangle_count() > 256);
+        let out = simplify(&mesh, 256);
+        assert!(
+            out.triangle_count() <= 256,
+            "got {} tri after simplify",
+            out.triangle_count()
+        );
+    }
+
+    #[test]
+    fn deterministic_repeated_calls() {
+        let mesh = unit_grid_mesh(16); // 512 tri
+        let a = simplify(&mesh, 64);
+        let b = simplify(&mesh, 64);
+        assert_eq!(a.indices, b.indices);
+    }
+
+    #[test]
+    fn empty_mesh_passthrough() {
+        let mesh = MeshData::default();
+        let out = simplify(&mesh, 256);
+        assert!(out.is_empty());
+    }
+}

--- a/crates/ars-asset-importer/tests/pipeline_test.rs
+++ b/crates/ars-asset-importer/tests/pipeline_test.rs
@@ -63,6 +63,49 @@ fn reprocessing_same_source_hits_cache() {
 }
 
 #[test]
+fn proxy_glb_is_written_and_recorded_in_meta() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("p2.glb");
+    write_minimal_glb(&src, &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+
+    let out_root = tmp.path().join("data");
+    let id = AssetId::from_string("p2-asset");
+
+    let outcome = process(&src, &out_root, Some(id.clone())).unwrap();
+
+    let proxy_path = outcome.dir.join("proxy.glb");
+    assert!(proxy_path.exists(), "proxy.glb should be written");
+
+    let proxy_bytes = fs::read(&proxy_path).unwrap();
+    assert_eq!(&proxy_bytes[0..4], b"glTF", "proxy.glb must have GLB magic");
+
+    // gltf クレートで再ロードできること
+    let g = gltf::Gltf::from_slice(&proxy_bytes).expect("proxy.glb must be valid GLB");
+    let mesh = g.document.meshes().next().expect("proxy has mesh");
+    let prim = mesh.primitives().next().expect("proxy has primitive");
+    assert_eq!(prim.mode(), gltf::mesh::Mode::Triangles);
+
+    // meta に proxy_triangle_count が記録されている
+    assert_eq!(outcome.meta.proxy_triangle_count, Some(1));
+}
+
+#[test]
+fn proxy_glb_is_deterministic_across_runs() {
+    // 同一 src を別 ID でインポート → proxy.glb がバイト一致 (id は GLB に入らない)
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("det.glb");
+    write_minimal_glb(&src, &[[0.0, 0.0, 0.0], [1.0, 2.0, 3.0], [4.0, 0.0, 0.0]]);
+    let out_root = tmp.path().join("data");
+
+    let a = process(&src, &out_root, Some(AssetId::from_string("a"))).unwrap();
+    let b = process(&src, &out_root, Some(AssetId::from_string("b"))).unwrap();
+
+    let bytes_a = fs::read(a.dir.join("proxy.glb")).unwrap();
+    let bytes_b = fs::read(b.dir.join("proxy.glb")).unwrap();
+    assert_eq!(bytes_a, bytes_b, "proxy.glb must be deterministic");
+}
+
+#[test]
 fn changed_source_invalidates_cache() {
     let tmp = TempDir::new().unwrap();
     let src = tmp.path().join("mutable.glb");


### PR DESCRIPTION
Closes (partially) #92 — P2 フェーズ分。

## Summary
- `simplify.rs`: `meshopt::simplify` で原メッシュを `<= 256 tri` まで decimate (擬似乱数なしで決定的)
- `proxy_writer.rs`: 最小 GLB writer (positions + u32 indices のみ)
  - JSON は固定キー順で手書き、padding は仕様準拠 (JSON=0x20 / BIN=0x00) で **byte-for-byte 決定性** を保証
- `pipeline.rs`: MISS フローで `simplify → write_glb` を実行し `data/<id>/proxy.glb` を出力
- `schema.rs`: `AssetMeta.proxy_triangle_count: Option<u32>` 追加 (P1 meta は `#[serde(default)]` で読める)

## 非スコープ (後続 PR)
- P3 凸包 → `hull.bin`
- P4 サムネ生成 (Pictor#37 P1 完成後)
- P5 Tauri `import_asset` コマンド / asset browser 連携
- P6 Axum ハンドラ + CLI
- P7 決定性 CI

## Test plan
- [x] `cargo build --workspace` 成功
- [x] `cargo test -p ars-asset-importer` **15/15 passed**
  - unit (10): obb 2 + simplify 4 (passthrough / target 達成 / 決定性 / 空入力) + proxy_writer 4 (header / 決定性 / gltf round-trip / 空入力)
  - integration (5): 既存 P1 3 本 + P2 新規 2 本 (proxy.glb 生成 + meta 記録 / 別 ID で再インポートしてバイト一致)
- [x] meshopt は seed-free な決定的アルゴリズムなのでクロスプラットフォーム差なし
- [ ] P3 以降のフェーズで実アセットによる手動 smoke test を追加予定

Refs: #92, LUDIARS/Pictor#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)