### PR TITLE
feat(asset-importer): chull 3D convex hull + hull.bin writer (#92 P3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "ars-core",
  "blake3",
  "byteorder",
+ "chull",
  "glam",
  "gltf",
  "meshopt",
@@ -756,6 +757,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chull"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977db54e5eec96279bea3032dcf41d3844e90d62e5cfeded48f8d53b1a755d7a"
+dependencies = [
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -2892,10 +2903,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"

--- a/crates/ars-asset-importer/Cargo.toml
+++ b/crates/ars-asset-importer/Cargo.toml
@@ -16,6 +16,7 @@ blake3 = "1"
 toml = "0.8"
 meshopt = "0.6"
 byteorder = "1"
+chull = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ars-asset-importer/src/hull.rs
+++ b/crates/ars-asset-importer/src/hull.rs
@@ -1,6 +1,145 @@
-//! 凸包生成 (stub — P3)
+//! 凸包生成 (P3)
 //!
-//! 本モジュールは Phase 3 で `chull` / `qhull-rs` による実装に差し替える予定。
-//! 現在はビルドを通すためのプレースホルダのみ提供する。
+//! `chull` クレート (pure Rust QuickHull 系) で原メッシュ頂点群の凸包を求め、
+//! 三角形化されたメッシュとして返す。Tier 1 のコリジョン/配置プレビュー目的。
+//!
+//! 退化入力 (頂点数 < 4 / 共面 / 共線 / 重複頂点) の場合は `None` を返す。
 
-// 実装なし: Phase 3 で chull / qhull-rs を導入する。
+use glam::Vec3;
+
+/// 凸包の三角形メッシュ表現。indices は三角形ごとに 3 要素ずつ。
+#[derive(Debug, Clone, PartialEq)]
+pub struct HullMesh {
+    pub vertices: Vec<Vec3>,
+    pub indices: Vec<u32>,
+}
+
+impl HullMesh {
+    pub fn triangle_count(&self) -> u32 {
+        (self.indices.len() / 3) as u32
+    }
+
+    pub fn vertex_count(&self) -> u32 {
+        self.vertices.len() as u32
+    }
+}
+
+/// `points` の 3D 凸包を計算する。
+///
+/// 退化入力 (頂点数不足 / 共面) の場合は `None`。
+pub fn compute(points: &[Vec3]) -> Option<HullMesh> {
+    if points.len() < 4 {
+        return None;
+    }
+
+    let raw: Vec<Vec<f64>> = points
+        .iter()
+        .map(|p| vec![p.x as f64, p.y as f64, p.z as f64])
+        .collect();
+
+    // chull::ConvexHullWrapper::try_new(points, max_iter)
+    let hull = chull::ConvexHullWrapper::try_new(&raw, None).ok()?;
+    let (verts_f64, faces) = hull.vertices_indices();
+
+    if verts_f64.is_empty() || faces.is_empty() {
+        return None;
+    }
+
+    let vertices: Vec<Vec3> = verts_f64
+        .iter()
+        .map(|v| Vec3::new(v[0] as f32, v[1] as f32, v[2] as f32))
+        .collect();
+
+    let indices: Vec<u32> = faces.iter().map(|&i| i as u32).collect();
+
+    // chull の内部反復順は非決定的 (HashMap 由来) なため三角形配列を
+    // カノニカル化する: 各三角形を「最小 index が先頭」へ回転 (winding 保持)
+    // → 三角形配列を辞書順ソート。
+    let indices = canonicalize_triangles(&indices);
+
+    Some(HullMesh { vertices, indices })
+}
+
+fn canonicalize_triangles(indices: &[u32]) -> Vec<u32> {
+    let mut tris: Vec<[u32; 3]> = indices
+        .chunks_exact(3)
+        .map(|c| rotate_min_first([c[0], c[1], c[2]]))
+        .collect();
+    tris.sort_unstable();
+    tris.into_iter().flat_map(|t| t.into_iter()).collect()
+}
+
+/// `[a, b, c]` を最小要素が先頭になるよう回転する。winding は保持。
+fn rotate_min_first(t: [u32; 3]) -> [u32; 3] {
+    let m = t.iter().enumerate().min_by_key(|(_, v)| **v).unwrap().0;
+    match m {
+        0 => t,
+        1 => [t[1], t[2], t[0]],
+        _ => [t[2], t[0], t[1]],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cube_corners() -> Vec<Vec3> {
+        vec![
+            Vec3::new(-1.0, -1.0, -1.0),
+            Vec3::new(1.0, -1.0, -1.0),
+            Vec3::new(-1.0, 1.0, -1.0),
+            Vec3::new(1.0, 1.0, -1.0),
+            Vec3::new(-1.0, -1.0, 1.0),
+            Vec3::new(1.0, -1.0, 1.0),
+            Vec3::new(-1.0, 1.0, 1.0),
+            Vec3::new(1.0, 1.0, 1.0),
+        ]
+    }
+
+    #[test]
+    fn cube_hull_has_8_vertices_and_12_triangles() {
+        let hull = compute(&cube_corners()).expect("cube has hull");
+        assert_eq!(hull.vertex_count(), 8);
+        // 立方体の凸包は 6 面 = 12 三角形 (各面 2 三角形)
+        assert_eq!(hull.triangle_count(), 12);
+    }
+
+    #[test]
+    fn interior_points_are_culled() {
+        // 立方体 + 中心の点 → 凸包の頂点数は 8 のまま
+        let mut pts = cube_corners();
+        pts.push(Vec3::ZERO);
+        let hull = compute(&pts).expect("cube hull");
+        assert_eq!(hull.vertex_count(), 8);
+    }
+
+    #[test]
+    fn too_few_points_returns_none() {
+        let pts = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+        ];
+        assert!(compute(&pts).is_none());
+    }
+
+    #[test]
+    fn coplanar_points_returns_none() {
+        // すべて z=0 平面上 → 退化、None を期待
+        let pts = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(1.0, 1.0, 0.0),
+        ];
+        assert!(compute(&pts).is_none());
+    }
+
+    #[test]
+    fn deterministic() {
+        let a = compute(&cube_corners()).unwrap();
+        let b = compute(&cube_corners()).unwrap();
+        assert_eq!(a.vertices, b.vertices);
+        assert_eq!(a.indices, b.indices);
+    }
+}

--- a/crates/ars-asset-importer/src/hull_writer.rs
+++ b/crates/ars-asset-importer/src/hull_writer.rs
@@ -1,0 +1,103 @@
+//! `hull.bin` バイナリフォーマットの writer/reader (P3)
+//!
+//! Tier 1 凸包を最小限のバイナリで永続化する。glTF より軽量で
+//! ランタイム (Pictor) は mmap して頂点/インデックスを直接読める。
+//!
+//! ## レイアウト (little-endian, 4-byte alignment)
+//!
+//! ```text
+//! offset  size    field
+//! 0       4       magic "HULL"
+//! 4       4       u32  version (= 1)
+//! 8       4       u32  vertex_count
+//! 12      4       u32  triangle_count
+//! 16      12*V    [f32; 3] * V    vertices
+//! 16+12V  12*T    [u32; 3] * T    triangles
+//! ```
+//!
+//! 全フィールド固定幅 + 12 バイト要素なので 4-byte aligned で padding 不要。
+
+use std::io::Write;
+use std::path::Path;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use crate::hull::HullMesh;
+use crate::{AssetImporterError, Result};
+
+const HULL_MAGIC: u32 = 0x4C4C_5548; // "HULL" (little-endian: 0x48 0x55 0x4C 0x4C)
+const HULL_VERSION: u32 = 1;
+
+pub fn encode(hull: &HullMesh) -> Vec<u8> {
+    let v_count = hull.vertices.len();
+    let t_count = (hull.indices.len() / 3) as u32;
+    let total = 16 + 12 * v_count + 4 * hull.indices.len();
+    let mut out = Vec::with_capacity(total);
+
+    out.write_u32::<LittleEndian>(HULL_MAGIC).unwrap();
+    out.write_u32::<LittleEndian>(HULL_VERSION).unwrap();
+    out.write_u32::<LittleEndian>(v_count as u32).unwrap();
+    out.write_u32::<LittleEndian>(t_count).unwrap();
+
+    for v in &hull.vertices {
+        out.write_f32::<LittleEndian>(v.x).unwrap();
+        out.write_f32::<LittleEndian>(v.y).unwrap();
+        out.write_f32::<LittleEndian>(v.z).unwrap();
+    }
+    for &i in &hull.indices {
+        out.write_u32::<LittleEndian>(i).unwrap();
+    }
+
+    debug_assert_eq!(out.len(), total);
+    out
+}
+
+pub fn write(hull: &HullMesh, path: &Path) -> Result<()> {
+    let bytes = encode(hull);
+    let mut f = std::fs::File::create(path).map_err(|e| AssetImporterError::io(path, e))?;
+    f.write_all(&bytes)
+        .map_err(|e| AssetImporterError::io(path, e))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hull;
+    use glam::Vec3;
+
+    fn cube_hull() -> HullMesh {
+        let corners = vec![
+            Vec3::new(-1.0, -1.0, -1.0),
+            Vec3::new(1.0, -1.0, -1.0),
+            Vec3::new(-1.0, 1.0, -1.0),
+            Vec3::new(1.0, 1.0, -1.0),
+            Vec3::new(-1.0, -1.0, 1.0),
+            Vec3::new(1.0, -1.0, 1.0),
+            Vec3::new(-1.0, 1.0, 1.0),
+            Vec3::new(1.0, 1.0, 1.0),
+        ];
+        hull::compute(&corners).unwrap()
+    }
+
+    #[test]
+    fn header_layout_is_correct() {
+        let bytes = encode(&cube_hull());
+        // magic
+        assert_eq!(&bytes[0..4], b"HULL");
+        // version
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 1);
+        // vertex_count = 8
+        assert_eq!(u32::from_le_bytes(bytes[8..12].try_into().unwrap()), 8);
+        // triangle_count = 12
+        assert_eq!(u32::from_le_bytes(bytes[12..16].try_into().unwrap()), 12);
+        // total length: 16 + 12*8 + 4*36 = 16 + 96 + 144 = 256
+        assert_eq!(bytes.len(), 256);
+    }
+
+    #[test]
+    fn deterministic_byte_for_byte() {
+        let h = cube_hull();
+        assert_eq!(encode(&h), encode(&h));
+    }
+}

--- a/crates/ars-asset-importer/src/lib.rs
+++ b/crates/ars-asset-importer/src/lib.rs
@@ -22,9 +22,15 @@
 //!
 //! - meshopt による mesh simplification
 //! - `proxy.glb` (positions + indices のみの最小 GLB) 書き出し
+//!
+//! ## P3 (`#92` の Phase 3)
+//!
+//! - chull (pure Rust QuickHull 系) で 3D 凸包を生成
+//! - 独自バイナリ `hull.bin` (HULL magic + 頂点 + 三角形) で書き出し
 
 pub mod error;
 pub mod hull;
+pub mod hull_writer;
 pub mod loaders;
 pub mod obb;
 pub mod pipeline;

--- a/crates/ars-asset-importer/src/pipeline.rs
+++ b/crates/ars-asset-importer/src/pipeline.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::loaders::{self, MeshData};
 use crate::schema::{AssetId, AssetMeta, Bounds, CacheLayout};
-use crate::{obb, proxy_writer, simplify, AssetImporterError, Result};
+use crate::{hull, hull_writer, obb, proxy_writer, simplify, AssetImporterError, Result};
 
 /// `process` の結果。キャッシュヒットかどうかを呼び出し側に伝える。
 #[derive(Debug, Clone)]
@@ -77,6 +77,16 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
     proxy_writer::write_glb(&proxy_mesh, &layout.proxy_path())?;
     let proxy_triangle_count = Some(proxy_mesh.triangle_count());
 
+    // hull.bin (P3): 3D 凸包を独自バイナリで書き出し
+    // 共面/退化メッシュは凸包不可なので Option として扱う
+    let (hull_vertex_count, hull_triangle_count) = match hull::compute(&mesh.positions) {
+        Some(h) => {
+            hull_writer::write(&h, &layout.hull_path())?;
+            (Some(h.vertex_count()), Some(h.triangle_count()))
+        }
+        None => (None, None),
+    };
+
     let meta = AssetMeta {
         version: AssetMeta::CURRENT_VERSION,
         id: id.clone(),
@@ -89,6 +99,8 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
         triangle_count: mesh.triangle_count(),
         vertex_count: mesh.vertex_count(),
         proxy_triangle_count,
+        hull_vertex_count,
+        hull_triangle_count,
     };
 
     // meta.toml

--- a/crates/ars-asset-importer/src/schema.rs
+++ b/crates/ars-asset-importer/src/schema.rs
@@ -118,6 +118,14 @@ pub struct AssetMeta {
     /// で `None` として読み込まれる。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_triangle_count: Option<u32>,
+    /// `hull.bin` の頂点数 (P3 以降で書き込まれる)。
+    ///
+    /// 共面/退化メッシュ等で凸包生成に失敗した場合は `None`。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hull_vertex_count: Option<u32>,
+    /// `hull.bin` の三角形数 (P3 以降で書き込まれる)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hull_triangle_count: Option<u32>,
 }
 
 impl AssetMeta {

--- a/crates/ars-asset-importer/tests/pipeline_test.rs
+++ b/crates/ars-asset-importer/tests/pipeline_test.rs
@@ -106,6 +106,56 @@ fn proxy_glb_is_deterministic_across_runs() {
 }
 
 #[test]
+fn tetrahedron_hull_is_written_and_recorded() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("tet.glb");
+    write_tetra_glb(&src);
+    let out_root = tmp.path().join("data");
+
+    let outcome = process(&src, &out_root, Some(AssetId::from_string("tet"))).unwrap();
+
+    let hull_path = outcome.dir.join("hull.bin");
+    assert!(hull_path.exists(), "hull.bin should be written");
+
+    let bytes = fs::read(&hull_path).unwrap();
+    assert_eq!(&bytes[0..4], b"HULL", "hull.bin must have HULL magic");
+
+    // 四面体の凸包: 4 頂点 / 4 三角形
+    assert_eq!(outcome.meta.hull_vertex_count, Some(4));
+    assert_eq!(outcome.meta.hull_triangle_count, Some(4));
+}
+
+#[test]
+fn hull_bin_is_deterministic_across_runs() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("det_tet.glb");
+    write_tetra_glb(&src);
+    let out_root = tmp.path().join("data");
+
+    let a = process(&src, &out_root, Some(AssetId::from_string("a"))).unwrap();
+    let b = process(&src, &out_root, Some(AssetId::from_string("b"))).unwrap();
+
+    let bytes_a = fs::read(a.dir.join("hull.bin")).unwrap();
+    let bytes_b = fs::read(b.dir.join("hull.bin")).unwrap();
+    assert_eq!(bytes_a, bytes_b, "hull.bin must be byte-deterministic");
+}
+
+#[test]
+fn flat_triangle_has_no_hull() {
+    // 3 頂点の単一三角形 → hull は退化、None。エラーにはならない
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("flat.glb");
+    write_minimal_glb(&src, &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+    let out_root = tmp.path().join("data");
+
+    let outcome = process(&src, &out_root, Some(AssetId::from_string("flat"))).unwrap();
+
+    assert!(outcome.meta.hull_vertex_count.is_none());
+    assert!(outcome.meta.hull_triangle_count.is_none());
+    assert!(!outcome.dir.join("hull.bin").exists());
+}
+
+#[test]
 fn changed_source_invalidates_cache() {
     let tmp = TempDir::new().unwrap();
     let src = tmp.path().join("mutable.glb");
@@ -124,6 +174,79 @@ fn changed_source_invalidates_cache() {
     assert!(!second.cache_hit, "mutated source must invalidate cache");
     assert_ne!(second.meta.source_hash, first.meta.source_hash);
     assert!((second.meta.aabb.max[0] - 5.0).abs() < 1e-5);
+}
+
+/// 四面体 (4 頂点 / 4 三角形) の最小 GLB を書き出す。hull テスト用。
+fn write_tetra_glb(path: &Path) {
+    let verts: [[f32; 3]; 4] = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ];
+    let tris: [u16; 12] = [0, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3];
+    write_glb_arbitrary(path, &verts, &tris);
+}
+
+fn write_glb_arbitrary(path: &Path, verts: &[[f32; 3]], tris: &[u16]) {
+    let pos_bytes_len = verts.len() * 12;
+    let idx_bytes_len = tris.len() * 2;
+
+    let mut bin = Vec::with_capacity(pos_bytes_len + idx_bytes_len + 4);
+    for v in verts {
+        for &c in v {
+            bin.extend_from_slice(&c.to_le_bytes());
+        }
+    }
+    let idx_offset = bin.len();
+    for &i in tris {
+        bin.extend_from_slice(&i.to_le_bytes());
+    }
+    while bin.len() % 4 != 0 {
+        bin.push(0);
+    }
+
+    let (mut min, mut max) = ([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]);
+    for v in verts {
+        for i in 0..3 {
+            if v[i] < min[i] {
+                min[i] = v[i];
+            }
+            if v[i] > max[i] {
+                max[i] = v[i];
+            }
+        }
+    }
+
+    let json = format!(
+        r#"{{"asset":{{"version":"2.0"}},"buffers":[{{"byteLength":{bin_len}}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":{pl},"target":34962}},{{"buffer":0,"byteOffset":{io},"byteLength":{il},"target":34963}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":{vc},"type":"VEC3","min":[{n0},{n1},{n2}],"max":[{x0},{x1},{x2}]}},{{"bufferView":1,"componentType":5123,"count":{ic},"type":"SCALAR"}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":4}}]}}],"nodes":[{{"mesh":0}}],"scenes":[{{"nodes":[0]}}],"scene":0}}"#,
+        bin_len = bin.len(),
+        pl = pos_bytes_len,
+        io = idx_offset,
+        il = idx_bytes_len,
+        vc = verts.len(),
+        ic = tris.len(),
+        n0 = min[0], n1 = min[1], n2 = min[2],
+        x0 = max[0], x1 = max[1], x2 = max[2],
+    );
+    let mut json_bytes = json.into_bytes();
+    while json_bytes.len() % 4 != 0 {
+        json_bytes.push(0x20);
+    }
+
+    let total_len = 12 + 8 + json_bytes.len() + 8 + bin.len();
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(&0x46546C67u32.to_le_bytes());
+    out.extend_from_slice(&2u32.to_le_bytes());
+    out.extend_from_slice(&(total_len as u32).to_le_bytes());
+    out.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0x4E4F534Au32.to_le_bytes());
+    out.extend_from_slice(&json_bytes);
+    out.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0x004E4942u32.to_le_bytes());
+    out.extend_from_slice(&bin);
+
+    fs::write(path, out).unwrap();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes (partially) #92 — P3 フェーズ分。

**Stacked on top of #94 (P2)**. P2 マージ後、自動的に main へ向かう。

## Summary
- `hull.rs`: `chull` (pure Rust QuickHull 系) で 3D 凸包生成。退化入力 (頂点 < 4 / 共面) は `None` を返す
  - `chull` 内部の HashMap 反復順は非決定的 → 出力三角形を **「最小 index 先頭回転 → 辞書順ソート」** でカノニカル化 (winding 保持)
- `hull_writer.rs`: 独自バイナリ `hull.bin`
  - レイアウト: `[4B "HULL"][4B version=1][4B vertex_count][4B triangle_count][12B*V positions][12B*T indices]`
  - 全要素 4-byte aligned、padding 不要
- `pipeline.rs`: MISS フローで hull 生成 → `hull.bin` 書き出し。退化入力時はファイル無し + meta None
- `schema.rs`: `hull_vertex_count` / `hull_triangle_count` を `Option<u32>` で追加 (P2 meta との後方互換)

## 非スコープ (後続 PR)
- P4 サムネ生成 (Pictor#37 P1 完成後)
- P5 Tauri `import_asset` コマンド / asset browser 連携
- P6 Axum ハンドラ + CLI
- P7 決定性 CI

## Test plan
- [x] `cargo build --workspace` 成功
- [x] `cargo test -p ars-asset-importer` **25/25 passed**
  - unit (17): 既存 10 + hull 5 (cube 8v 12t / 内部点 cull / 頂点不足 None / 共面 None / 決定性) + hull_writer 2 (header layout / 決定性)
  - integration (8): 既存 5 + 新規 3 (四面体 4v 4t 検証 / 別 ID で hull.bin バイト一致 / 共面入力 None)
- [x] chull の非決定性は出力カノニカル化で吸収、`hull_bin_is_deterministic_across_runs` で実証

Refs: #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)