### PR TITLE
feat(asset-importer): Tauri import_assets + minimal asset browser (#92 P5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "ars-asset-importer",
  "ars-codegen",
  "ars-core",
  "ars-project",
@@ -149,8 +150,10 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "time",
  "tokio",
+ "toml 0.8.2",
  "tower",
  "tower-http 0.5.2",
  "urlencoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "ars-core",
  "blake3",
  "byteorder",
+ "chull",
  "glam",
  "gltf",
  "meshopt",
@@ -756,6 +757,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chull"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977db54e5eec96279bea3032dcf41d3844e90d62e5cfeded48f8d53b1a755d7a"
+dependencies = [
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -2892,10 +2903,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,8 +175,10 @@ version = "0.1.0"
 dependencies = [
  "ars-core",
  "blake3",
+ "byteorder",
  "glam",
  "gltf",
+ "meshopt",
  "serde",
  "serde_json",
  "tempfile",
@@ -1391,6 +1393,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2722,6 +2733,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meshopt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01e77ead21976b3a9f01ec1724f766923da74f0726364e2b0f425658935d71a"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "float-cmp",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "2.5.6", optional = true }
 
 [features]
 default = ["tauri-app"]
-tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build"]
+tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build", "dep:ars-asset-importer"]
 web-server = [
     "dep:axum",
     "dep:tokio",
@@ -51,12 +51,14 @@ ars-core = { path = "../../crates/ars-core" }
 ars-codegen = { path = "../../crates/ars-codegen" }
 ars-secrets = { path = "../../crates/ars-secrets" }
 ars-project = { path = "../../crates/ars-project" }
+ars-asset-importer = { path = "../../crates/ars-asset-importer", optional = true }
 # ars-secrets: removed — secrets management moved to Cernere server
 # Common
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 async-trait = "0.1"
+toml = "0.8"
 tauri = { version = "2.10.3", optional = true }
 tauri-plugin-log = { version = "2", optional = true }
 dirs-next = "2.0"
@@ -78,3 +80,6 @@ dirs = { version = "6", optional = true }
 futures = { version = "0.3", optional = true }
 dashmap = { version = "6", optional = true }
 # Redis: removed — session management moved to Cernere server
+
+[dev-dependencies]
+tempfile = "3"

--- a/ars-editor/src-tauri/src/commands/asset.rs
+++ b/ars-editor/src-tauri/src/commands/asset.rs
@@ -1,0 +1,235 @@
+//! アセットインポート Tauri コマンド (P5)
+//!
+//! ars-asset-importer クレートを呼び出し、glTF/GLB アセットを Tier 1 成果物
+//! (`data/<id>/{source,proxy,hull,meta}`) として書き出す。
+//!
+//! ## セキュリティ
+//!
+//! - `path` はユーザーが選択したファイルなのでパス制約は課さない (D&D 由来)
+//! - `out_root` はプロジェクトの `data/` ディレクトリに固定 (パストラバーサル防止)
+//! - インポート結果は `ImportedAsset` で id / dir / cache_hit を返す
+
+use ars_asset_importer::{process, AssetMeta};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// `import_asset` が返す 1 アセット分の結果。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportedAsset {
+    pub id: String,
+    /// `data/<id>/` の絶対パス。
+    pub dir: String,
+    /// 既に同一 source_hash がキャッシュ済みだったか。
+    pub cache_hit: bool,
+    /// 原ファイル名 (拡張子付き)。
+    pub source_name: String,
+    /// インポート結果 meta (frontend で proxy/hull の有無を判別するため)。
+    pub meta: AssetMeta,
+}
+
+/// 1 つ以上のアセットファイルを `project_dir/data/` 配下にインポートする。
+///
+/// 失敗したファイルがあっても他は続行し、エラーはログに残してスキップする。
+/// 結果は成功した分のみ返す。
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+pub async fn import_assets(
+    project_dir: String,
+    paths: Vec<String>,
+) -> Result<Vec<ImportedAsset>, String> {
+    import_assets_impl(project_dir, paths)
+}
+
+pub fn import_assets_impl(
+    project_dir: String,
+    paths: Vec<String>,
+) -> Result<Vec<ImportedAsset>, String> {
+    let project_root = PathBuf::from(&project_dir);
+    if !project_root.is_dir() {
+        return Err(format!("project_dir does not exist: {project_dir}"));
+    }
+    let out_root = project_root.join("data");
+    std::fs::create_dir_all(&out_root)
+        .map_err(|e| format!("failed to create data dir: {e}"))?;
+
+    let mut results = Vec::with_capacity(paths.len());
+    for p in paths {
+        let src = PathBuf::from(&p);
+        match process(&src, &out_root, None) {
+            Ok(outcome) => {
+                let source_name = src
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                results.push(ImportedAsset {
+                    id: outcome.id.to_string(),
+                    dir: outcome.dir.to_string_lossy().to_string(),
+                    cache_hit: outcome.cache_hit,
+                    source_name,
+                    meta: outcome.meta,
+                });
+            }
+            Err(e) => {
+                log::warn!("import_asset failed for {p}: {e}");
+                // continue: don't abort the whole batch on a single failure
+            }
+        }
+    }
+    Ok(results)
+}
+
+/// 既存のインポート済みアセット一覧を返す (起動時 / D&D 完了後の refresh 用)。
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+pub fn list_imported_assets(project_dir: String) -> Result<Vec<ImportedAsset>, String> {
+    list_imported_assets_impl(project_dir)
+}
+
+pub fn list_imported_assets_impl(project_dir: String) -> Result<Vec<ImportedAsset>, String> {
+    let data_root = PathBuf::from(&project_dir).join("data");
+    if !data_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut out = Vec::new();
+    let entries = std::fs::read_dir(&data_root)
+        .map_err(|e| format!("failed to read data dir: {e}"))?;
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let meta_path = dir.join("meta.toml");
+        if !meta_path.exists() {
+            continue;
+        }
+        match read_meta(&meta_path) {
+            Ok(meta) => {
+                let source_name = dir
+                    .join(format!("source.{}", meta.source_ext))
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                out.push(ImportedAsset {
+                    id: meta.id.to_string(),
+                    dir: dir.to_string_lossy().to_string(),
+                    cache_hit: true,
+                    source_name,
+                    meta,
+                });
+            }
+            Err(e) => {
+                log::warn!("failed to read meta.toml at {}: {e}", meta_path.display());
+            }
+        }
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
+fn read_meta(path: &Path) -> Result<AssetMeta, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read meta: {e}"))?;
+    toml::from_str(&text).map_err(|e| format!("parse meta: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_minimal_glb(path: &Path) {
+        // 1 三角形の最小 GLB (statically embedded test fixture)
+        let verts: [[f32; 3]; 3] = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let mut bin = Vec::new();
+        for v in &verts {
+            for &c in v {
+                bin.extend_from_slice(&c.to_le_bytes());
+            }
+        }
+        let idx_off = bin.len();
+        for i in [0u16, 1, 2] {
+            bin.extend_from_slice(&i.to_le_bytes());
+        }
+        while bin.len() % 4 != 0 {
+            bin.push(0);
+        }
+
+        let json = format!(
+            r#"{{"asset":{{"version":"2.0"}},"buffers":[{{"byteLength":{}}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":36,"target":34962}},{{"buffer":0,"byteOffset":{},"byteLength":6,"target":34963}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3","min":[0,0,0],"max":[1,1,0]}},{{"bufferView":1,"componentType":5123,"count":3,"type":"SCALAR"}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":4}}]}}],"nodes":[{{"mesh":0}}],"scenes":[{{"nodes":[0]}}],"scene":0}}"#,
+            bin.len(), idx_off
+        );
+        let mut json_bytes = json.into_bytes();
+        while json_bytes.len() % 4 != 0 {
+            json_bytes.push(0x20);
+        }
+
+        let total = 12 + 8 + json_bytes.len() + 8 + bin.len();
+        let mut out = Vec::with_capacity(total);
+        out.extend_from_slice(&0x46546C67u32.to_le_bytes());
+        out.extend_from_slice(&2u32.to_le_bytes());
+        out.extend_from_slice(&(total as u32).to_le_bytes());
+        out.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&0x4E4F534Au32.to_le_bytes());
+        out.extend_from_slice(&json_bytes);
+        out.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+        out.extend_from_slice(&0x004E4942u32.to_le_bytes());
+        out.extend_from_slice(&bin);
+
+        fs::write(path, out).unwrap();
+    }
+
+    #[test]
+    fn import_two_assets_then_list_them() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().to_path_buf();
+        let a = project.join("a.glb");
+        let b = project.join("b.glb");
+        write_minimal_glb(&a);
+        write_minimal_glb(&b);
+
+        let imported = import_assets_impl(
+            project.to_string_lossy().to_string(),
+            vec![
+                a.to_string_lossy().to_string(),
+                b.to_string_lossy().to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(imported.len(), 2);
+
+        let listed = list_imported_assets_impl(project.to_string_lossy().to_string()).unwrap();
+        assert_eq!(listed.len(), 2);
+    }
+
+    #[test]
+    fn missing_project_dir_errors() {
+        let err = import_assets_impl("/nonexistent/path/xyz".into(), vec![]).unwrap_err();
+        assert!(err.contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn unsupported_format_is_skipped_not_aborted() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().to_path_buf();
+        let bad = project.join("bad.txt");
+        let good = project.join("good.glb");
+        std::fs::write(&bad, b"not a glb").unwrap();
+        write_minimal_glb(&good);
+
+        let imported = import_assets_impl(
+            project.to_string_lossy().to_string(),
+            vec![
+                bad.to_string_lossy().to_string(),
+                good.to_string_lossy().to_string(),
+            ],
+        )
+        .unwrap();
+        // bad は skip、good のみ成功
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].source_name, "good.glb");
+    }
+}

--- a/ars-editor/src-tauri/src/commands/mod.rs
+++ b/ars-editor/src-tauri/src/commands/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "tauri-app")]
+pub mod asset;
 pub mod project;
 
+#[cfg(feature = "tauri-app")]
+pub use asset::*;
 pub use project::*;

--- a/ars-editor/src-tauri/src/lib.rs
+++ b/ars-editor/src-tauri/src/lib.rs
@@ -61,6 +61,8 @@ pub fn run() {
             commands::save_project,
             commands::load_project,
             commands::get_default_project_path,
+            commands::import_assets,
+            commands::list_imported_assets,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ars-editor/src/features/asset-browser/AssetBrowser.tsx
+++ b/ars-editor/src/features/asset-browser/AssetBrowser.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  importAssets,
+  listImportedAssets,
+  isTauri,
+  type ImportedAsset,
+} from '@/lib/backend';
+import { getDefaultProjectPath } from '@/lib/tauri-commands';
+
+/**
+ * 最小限のアセットブラウザ (P5)。
+ *
+ * - Tauri ウィンドウへのファイル D&D を listen し、ars_asset_importer 経由で
+ *   `data/<id>/` に Tier 1 成果物を生成する
+ * - インポート済みアセットを meta.toml から再構成して一覧表示する
+ *
+ * UI は最小限のリスト表示のみ。3D プレビュー / サムネ表示等は後続フェーズで
+ * Pictor 連携と合わせて拡充する。
+ */
+export function AssetBrowser() {
+  const [projectDir, setProjectDir] = useState<string>('');
+  const [assets, setAssets] = useState<ImportedAsset[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [dropHover, setDropHover] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDefaultProjectPath().then((dir) => {
+      if (!cancelled) {
+        setProjectDir(dir);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!projectDir) return;
+    try {
+      const list = await listImportedAssets(projectDir);
+      setAssets(list);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [projectDir]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Tauri webview drag-drop event は OS から受け取った絶対パスをそのまま渡せる。
+  // ブラウザ版は File オブジェクト経由になるためパスが取れず、現状未対応 (P6 で multipart)。
+  useEffect(() => {
+    if (!isTauri() || !projectDir) return;
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      const { getCurrentWebview } = await import('@tauri-apps/api/webview');
+      const webview = getCurrentWebview();
+      const handle = await webview.onDragDropEvent(async (event) => {
+        if (event.payload.type === 'enter' || event.payload.type === 'over') {
+          setDropHover(true);
+        } else if (event.payload.type === 'leave') {
+          setDropHover(false);
+        } else if (event.payload.type === 'drop') {
+          setDropHover(false);
+          const paths = event.payload.paths.filter(
+            (p) => p.toLowerCase().endsWith('.glb') || p.toLowerCase().endsWith('.gltf'),
+          );
+          if (paths.length === 0) return;
+          setImporting(true);
+          setError(null);
+          try {
+            await importAssets(projectDir, paths);
+            await refresh();
+          } catch (e) {
+            setError(String(e));
+          } finally {
+            setImporting(false);
+          }
+        }
+      });
+      unlisten = handle;
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, [projectDir, refresh]);
+
+  return (
+    <div
+      className="flex flex-col h-full p-4 gap-3"
+      style={{
+        background: 'var(--bg)',
+        color: 'var(--text)',
+        outline: dropHover ? '2px dashed var(--accent)' : 'none',
+      }}
+    >
+      <header className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Assets</h2>
+        <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+          {projectDir ? `data/ in ${projectDir}` : '(no project dir)'}
+        </div>
+      </header>
+
+      {!isTauri() && (
+        <div
+          className="text-sm rounded p-3"
+          style={{ background: 'var(--surface)', color: 'var(--text-muted)' }}
+        >
+          ファイル D&D は現在デスクトップ版のみ対応です (Web は P6 multipart 予定)。
+        </div>
+      )}
+
+      {importing && (
+        <div className="text-sm" style={{ color: 'var(--text-muted)' }}>
+          Importing...
+        </div>
+      )}
+      {error && (
+        <div className="text-sm" style={{ color: 'var(--danger, #f87171)' }}>
+          {error}
+        </div>
+      )}
+
+      <ul className="flex-1 overflow-auto rounded" style={{ background: 'var(--surface)' }}>
+        {assets.length === 0 ? (
+          <li className="p-3 text-sm" style={{ color: 'var(--text-muted)' }}>
+            まだアセットがありません。`.glb` / `.gltf` ファイルをウィンドウにドラッグしてください。
+          </li>
+        ) : (
+          assets.map((a) => (
+            <li
+              key={a.id}
+              className="px-3 py-2 border-b text-sm"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <div className="font-mono text-xs" style={{ color: 'var(--text-muted)' }}>
+                {a.id}
+              </div>
+              <div className="font-medium">{a.sourceName || a.meta.name}</div>
+              <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                {a.meta.triangle_count} tri / {a.meta.vertex_count} v
+                {typeof a.meta.proxy_triangle_count === 'number' &&
+                  ` · proxy ${a.meta.proxy_triangle_count}`}
+                {typeof a.meta.hull_triangle_count === 'number' &&
+                  ` · hull ${a.meta.hull_vertex_count}v ${a.meta.hull_triangle_count}t`}
+              </div>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/ars-editor/src/features/asset-browser/index.ts
+++ b/ars-editor/src/features/asset-browser/index.ts
@@ -1,0 +1,1 @@
+export { AssetBrowser } from './AssetBrowser';

--- a/ars-editor/src/lib/backend.ts
+++ b/ars-editor/src/lib/backend.ts
@@ -107,4 +107,54 @@ export async function codegenApply(
   });
 }
 
+// ── Asset Importer (Tier 1) ─────────────────────────
+
+export interface AssetMeta {
+  version: number;
+  id: string;
+  name: string;
+  source_ext: string;
+  source_hash: string;
+  aabb: { min: [number, number, number]; max: [number, number, number] };
+  obb: {
+    center: [number, number, number];
+    axes: [[number, number, number], [number, number, number], [number, number, number]];
+    half_extents: [number, number, number];
+  };
+  pivot: [number, number, number];
+  triangle_count: number;
+  vertex_count: number;
+  proxy_triangle_count?: number;
+  hull_vertex_count?: number;
+  hull_triangle_count?: number;
+}
+
+export interface ImportedAsset {
+  id: string;
+  dir: string;
+  cacheHit: boolean;
+  sourceName: string;
+  meta: AssetMeta;
+}
+
+export async function importAssets(
+  projectDir: string,
+  paths: string[],
+): Promise<ImportedAsset[]> {
+  if (isTauri()) {
+    return tauriInvoke<ImportedAsset[]>('import_assets', { projectDir, paths });
+  }
+  // Web: not implemented — needs multipart upload (P6)
+  throw new Error('importAssets is desktop-only in this build');
+}
+
+export async function listImportedAssets(projectDir: string): Promise<ImportedAsset[]> {
+  if (isTauri()) {
+    return tauriInvoke<ImportedAsset[]>('list_imported_assets', { projectDir });
+  }
+  return webFetch<ImportedAsset[]>(
+    `/assets/list?projectDir=${encodeURIComponent(projectDir)}`,
+  );
+}
+
 export { isTauri };

--- a/ars-editor/src/routes.tsx
+++ b/ars-editor/src/routes.tsx
@@ -3,6 +3,7 @@ import { ReactFlowProvider } from '@xyflow/react';
 import { AppLayout } from './AppLayout';
 import { EditorPage } from './features/editor-page';
 import { ProjectSettingsPage } from './features/project-settings';
+import { AssetBrowser } from './features/asset-browser';
 import { OAuthCallback } from './components/OAuthCallback';
 
 export const routes: RouteObject[] = [
@@ -19,6 +20,7 @@ export const routes: RouteObject[] = [
         ),
       },
       { path: 'settings', element: <ProjectSettingsPage /> },
+      { path: 'assets', element: <AssetBrowser /> },
     ],
   },
   { path: '/auth/callback', element: <OAuthCallback /> },

--- a/crates/ars-asset-importer/Cargo.toml
+++ b/crates/ars-asset-importer/Cargo.toml
@@ -16,6 +16,7 @@ blake3 = "1"
 toml = "0.8"
 meshopt = "0.6"
 byteorder = "1"
+chull = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ars-asset-importer/Cargo.toml
+++ b/crates/ars-asset-importer/Cargo.toml
@@ -14,6 +14,8 @@ gltf = { version = "1.4", default-features = false, features = ["import", "utils
 glam = { version = "0.29", features = ["serde"] }
 blake3 = "1"
 toml = "0.8"
+meshopt = "0.6"
+byteorder = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ars-asset-importer/src/hull.rs
+++ b/crates/ars-asset-importer/src/hull.rs
@@ -1,6 +1,145 @@
-//! 凸包生成 (stub — P3)
+//! 凸包生成 (P3)
 //!
-//! 本モジュールは Phase 3 で `chull` / `qhull-rs` による実装に差し替える予定。
-//! 現在はビルドを通すためのプレースホルダのみ提供する。
+//! `chull` クレート (pure Rust QuickHull 系) で原メッシュ頂点群の凸包を求め、
+//! 三角形化されたメッシュとして返す。Tier 1 のコリジョン/配置プレビュー目的。
+//!
+//! 退化入力 (頂点数 < 4 / 共面 / 共線 / 重複頂点) の場合は `None` を返す。
 
-// 実装なし: Phase 3 で chull / qhull-rs を導入する。
+use glam::Vec3;
+
+/// 凸包の三角形メッシュ表現。indices は三角形ごとに 3 要素ずつ。
+#[derive(Debug, Clone, PartialEq)]
+pub struct HullMesh {
+    pub vertices: Vec<Vec3>,
+    pub indices: Vec<u32>,
+}
+
+impl HullMesh {
+    pub fn triangle_count(&self) -> u32 {
+        (self.indices.len() / 3) as u32
+    }
+
+    pub fn vertex_count(&self) -> u32 {
+        self.vertices.len() as u32
+    }
+}
+
+/// `points` の 3D 凸包を計算する。
+///
+/// 退化入力 (頂点数不足 / 共面) の場合は `None`。
+pub fn compute(points: &[Vec3]) -> Option<HullMesh> {
+    if points.len() < 4 {
+        return None;
+    }
+
+    let raw: Vec<Vec<f64>> = points
+        .iter()
+        .map(|p| vec![p.x as f64, p.y as f64, p.z as f64])
+        .collect();
+
+    // chull::ConvexHullWrapper::try_new(points, max_iter)
+    let hull = chull::ConvexHullWrapper::try_new(&raw, None).ok()?;
+    let (verts_f64, faces) = hull.vertices_indices();
+
+    if verts_f64.is_empty() || faces.is_empty() {
+        return None;
+    }
+
+    let vertices: Vec<Vec3> = verts_f64
+        .iter()
+        .map(|v| Vec3::new(v[0] as f32, v[1] as f32, v[2] as f32))
+        .collect();
+
+    let indices: Vec<u32> = faces.iter().map(|&i| i as u32).collect();
+
+    // chull の内部反復順は非決定的 (HashMap 由来) なため三角形配列を
+    // カノニカル化する: 各三角形を「最小 index が先頭」へ回転 (winding 保持)
+    // → 三角形配列を辞書順ソート。
+    let indices = canonicalize_triangles(&indices);
+
+    Some(HullMesh { vertices, indices })
+}
+
+fn canonicalize_triangles(indices: &[u32]) -> Vec<u32> {
+    let mut tris: Vec<[u32; 3]> = indices
+        .chunks_exact(3)
+        .map(|c| rotate_min_first([c[0], c[1], c[2]]))
+        .collect();
+    tris.sort_unstable();
+    tris.into_iter().flat_map(|t| t.into_iter()).collect()
+}
+
+/// `[a, b, c]` を最小要素が先頭になるよう回転する。winding は保持。
+fn rotate_min_first(t: [u32; 3]) -> [u32; 3] {
+    let m = t.iter().enumerate().min_by_key(|(_, v)| **v).unwrap().0;
+    match m {
+        0 => t,
+        1 => [t[1], t[2], t[0]],
+        _ => [t[2], t[0], t[1]],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cube_corners() -> Vec<Vec3> {
+        vec![
+            Vec3::new(-1.0, -1.0, -1.0),
+            Vec3::new(1.0, -1.0, -1.0),
+            Vec3::new(-1.0, 1.0, -1.0),
+            Vec3::new(1.0, 1.0, -1.0),
+            Vec3::new(-1.0, -1.0, 1.0),
+            Vec3::new(1.0, -1.0, 1.0),
+            Vec3::new(-1.0, 1.0, 1.0),
+            Vec3::new(1.0, 1.0, 1.0),
+        ]
+    }
+
+    #[test]
+    fn cube_hull_has_8_vertices_and_12_triangles() {
+        let hull = compute(&cube_corners()).expect("cube has hull");
+        assert_eq!(hull.vertex_count(), 8);
+        // 立方体の凸包は 6 面 = 12 三角形 (各面 2 三角形)
+        assert_eq!(hull.triangle_count(), 12);
+    }
+
+    #[test]
+    fn interior_points_are_culled() {
+        // 立方体 + 中心の点 → 凸包の頂点数は 8 のまま
+        let mut pts = cube_corners();
+        pts.push(Vec3::ZERO);
+        let hull = compute(&pts).expect("cube hull");
+        assert_eq!(hull.vertex_count(), 8);
+    }
+
+    #[test]
+    fn too_few_points_returns_none() {
+        let pts = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+        ];
+        assert!(compute(&pts).is_none());
+    }
+
+    #[test]
+    fn coplanar_points_returns_none() {
+        // すべて z=0 平面上 → 退化、None を期待
+        let pts = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 0.0, 0.0),
+            Vec3::new(0.0, 1.0, 0.0),
+            Vec3::new(1.0, 1.0, 0.0),
+        ];
+        assert!(compute(&pts).is_none());
+    }
+
+    #[test]
+    fn deterministic() {
+        let a = compute(&cube_corners()).unwrap();
+        let b = compute(&cube_corners()).unwrap();
+        assert_eq!(a.vertices, b.vertices);
+        assert_eq!(a.indices, b.indices);
+    }
+}

--- a/crates/ars-asset-importer/src/hull_writer.rs
+++ b/crates/ars-asset-importer/src/hull_writer.rs
@@ -1,0 +1,103 @@
+//! `hull.bin` バイナリフォーマットの writer/reader (P3)
+//!
+//! Tier 1 凸包を最小限のバイナリで永続化する。glTF より軽量で
+//! ランタイム (Pictor) は mmap して頂点/インデックスを直接読める。
+//!
+//! ## レイアウト (little-endian, 4-byte alignment)
+//!
+//! ```text
+//! offset  size    field
+//! 0       4       magic "HULL"
+//! 4       4       u32  version (= 1)
+//! 8       4       u32  vertex_count
+//! 12      4       u32  triangle_count
+//! 16      12*V    [f32; 3] * V    vertices
+//! 16+12V  12*T    [u32; 3] * T    triangles
+//! ```
+//!
+//! 全フィールド固定幅 + 12 バイト要素なので 4-byte aligned で padding 不要。
+
+use std::io::Write;
+use std::path::Path;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use crate::hull::HullMesh;
+use crate::{AssetImporterError, Result};
+
+const HULL_MAGIC: u32 = 0x4C4C_5548; // "HULL" (little-endian: 0x48 0x55 0x4C 0x4C)
+const HULL_VERSION: u32 = 1;
+
+pub fn encode(hull: &HullMesh) -> Vec<u8> {
+    let v_count = hull.vertices.len();
+    let t_count = (hull.indices.len() / 3) as u32;
+    let total = 16 + 12 * v_count + 4 * hull.indices.len();
+    let mut out = Vec::with_capacity(total);
+
+    out.write_u32::<LittleEndian>(HULL_MAGIC).unwrap();
+    out.write_u32::<LittleEndian>(HULL_VERSION).unwrap();
+    out.write_u32::<LittleEndian>(v_count as u32).unwrap();
+    out.write_u32::<LittleEndian>(t_count).unwrap();
+
+    for v in &hull.vertices {
+        out.write_f32::<LittleEndian>(v.x).unwrap();
+        out.write_f32::<LittleEndian>(v.y).unwrap();
+        out.write_f32::<LittleEndian>(v.z).unwrap();
+    }
+    for &i in &hull.indices {
+        out.write_u32::<LittleEndian>(i).unwrap();
+    }
+
+    debug_assert_eq!(out.len(), total);
+    out
+}
+
+pub fn write(hull: &HullMesh, path: &Path) -> Result<()> {
+    let bytes = encode(hull);
+    let mut f = std::fs::File::create(path).map_err(|e| AssetImporterError::io(path, e))?;
+    f.write_all(&bytes)
+        .map_err(|e| AssetImporterError::io(path, e))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hull;
+    use glam::Vec3;
+
+    fn cube_hull() -> HullMesh {
+        let corners = vec![
+            Vec3::new(-1.0, -1.0, -1.0),
+            Vec3::new(1.0, -1.0, -1.0),
+            Vec3::new(-1.0, 1.0, -1.0),
+            Vec3::new(1.0, 1.0, -1.0),
+            Vec3::new(-1.0, -1.0, 1.0),
+            Vec3::new(1.0, -1.0, 1.0),
+            Vec3::new(-1.0, 1.0, 1.0),
+            Vec3::new(1.0, 1.0, 1.0),
+        ];
+        hull::compute(&corners).unwrap()
+    }
+
+    #[test]
+    fn header_layout_is_correct() {
+        let bytes = encode(&cube_hull());
+        // magic
+        assert_eq!(&bytes[0..4], b"HULL");
+        // version
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 1);
+        // vertex_count = 8
+        assert_eq!(u32::from_le_bytes(bytes[8..12].try_into().unwrap()), 8);
+        // triangle_count = 12
+        assert_eq!(u32::from_le_bytes(bytes[12..16].try_into().unwrap()), 12);
+        // total length: 16 + 12*8 + 4*36 = 16 + 96 + 144 = 256
+        assert_eq!(bytes.len(), 256);
+    }
+
+    #[test]
+    fn deterministic_byte_for_byte() {
+        let h = cube_hull();
+        assert_eq!(encode(&h), encode(&h));
+    }
+}

--- a/crates/ars-asset-importer/src/lib.rs
+++ b/crates/ars-asset-importer/src/lib.rs
@@ -22,9 +22,15 @@
 //!
 //! - meshopt による mesh simplification
 //! - `proxy.glb` (positions + indices のみの最小 GLB) 書き出し
+//!
+//! ## P3 (`#92` の Phase 3)
+//!
+//! - chull (pure Rust QuickHull 系) で 3D 凸包を生成
+//! - 独自バイナリ `hull.bin` (HULL magic + 頂点 + 三角形) で書き出し
 
 pub mod error;
 pub mod hull;
+pub mod hull_writer;
 pub mod loaders;
 pub mod obb;
 pub mod pipeline;

--- a/crates/ars-asset-importer/src/lib.rs
+++ b/crates/ars-asset-importer/src/lib.rs
@@ -11,20 +11,24 @@
 //!
 //! 本クレートは **Tier 1 の生成**を担当する。描画側の対応は Pictor#37 を参照。
 //!
-//! ## P1 スコープ (本コミット)
+//! ## P1 (`#92` の Phase 1)
 //!
 //! - glTF ローダー
 //! - AABB / OBB 算出
 //! - source hash によるキャッシュ判定
 //! - `data/<id>/` レイアウト書き出し
 //!
-//! P2 以降 (meshopt simplify / 凸包 / サムネ) は stub として存在する。
+//! ## P2 (`#92` の Phase 2)
+//!
+//! - meshopt による mesh simplification
+//! - `proxy.glb` (positions + indices のみの最小 GLB) 書き出し
 
 pub mod error;
 pub mod hull;
 pub mod loaders;
 pub mod obb;
 pub mod pipeline;
+pub mod proxy_writer;
 pub mod schema;
 pub mod simplify;
 pub mod thumbnail;

--- a/crates/ars-asset-importer/src/pipeline.rs
+++ b/crates/ars-asset-importer/src/pipeline.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::loaders::{self, MeshData};
 use crate::schema::{AssetId, AssetMeta, Bounds, CacheLayout};
-use crate::{obb, proxy_writer, simplify, AssetImporterError, Result};
+use crate::{hull, hull_writer, obb, proxy_writer, simplify, AssetImporterError, Result};
 
 /// `process` の結果。キャッシュヒットかどうかを呼び出し側に伝える。
 #[derive(Debug, Clone)]
@@ -77,6 +77,16 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
     proxy_writer::write_glb(&proxy_mesh, &layout.proxy_path())?;
     let proxy_triangle_count = Some(proxy_mesh.triangle_count());
 
+    // hull.bin (P3): 3D 凸包を独自バイナリで書き出し
+    // 共面/退化メッシュは凸包不可なので Option として扱う
+    let (hull_vertex_count, hull_triangle_count) = match hull::compute(&mesh.positions) {
+        Some(h) => {
+            hull_writer::write(&h, &layout.hull_path())?;
+            (Some(h.vertex_count()), Some(h.triangle_count()))
+        }
+        None => (None, None),
+    };
+
     let meta = AssetMeta {
         version: AssetMeta::CURRENT_VERSION,
         id: id.clone(),
@@ -89,6 +99,8 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
         triangle_count: mesh.triangle_count(),
         vertex_count: mesh.vertex_count(),
         proxy_triangle_count,
+        hull_vertex_count,
+        hull_triangle_count,
     };
 
     // meta.toml

--- a/crates/ars-asset-importer/src/pipeline.rs
+++ b/crates/ars-asset-importer/src/pipeline.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 use crate::loaders::{self, MeshData};
 use crate::schema::{AssetId, AssetMeta, Bounds, CacheLayout};
-use crate::{obb, AssetImporterError, Result};
+use crate::{obb, proxy_writer, simplify, AssetImporterError, Result};
 
 /// `process` の結果。キャッシュヒットかどうかを呼び出し側に伝える。
 #[derive(Debug, Clone)]
@@ -65,6 +65,18 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
     let obb = obb::compute(&mesh.positions).ok_or(AssetImporterError::EmptyGeometry)?;
     let pivot = aabb.center().to_array();
 
+    // 書き出し (アトミックではないがローカル前提)
+    fs::create_dir_all(&dir).map_err(|e| AssetImporterError::io(&dir, e))?;
+
+    // 原アセットをコピー
+    let dst_src = layout.source_path(&source_ext);
+    fs::copy(src, &dst_src).map_err(|e| AssetImporterError::io(&dst_src, e))?;
+
+    // proxy.glb (P2): meshopt で decimate → 最小 GLB を書き出し
+    let proxy_mesh = simplify::simplify(&mesh, simplify::DEFAULT_TARGET_TRIANGLES);
+    proxy_writer::write_glb(&proxy_mesh, &layout.proxy_path())?;
+    let proxy_triangle_count = Some(proxy_mesh.triangle_count());
+
     let meta = AssetMeta {
         version: AssetMeta::CURRENT_VERSION,
         id: id.clone(),
@@ -76,14 +88,8 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
         pivot,
         triangle_count: mesh.triangle_count(),
         vertex_count: mesh.vertex_count(),
+        proxy_triangle_count,
     };
-
-    // 書き出し (アトミックではないがローカル前提)
-    fs::create_dir_all(&dir).map_err(|e| AssetImporterError::io(&dir, e))?;
-
-    // 原アセットをコピー
-    let dst_src = layout.source_path(&source_ext);
-    fs::copy(src, &dst_src).map_err(|e| AssetImporterError::io(&dst_src, e))?;
 
     // meta.toml
     write_meta(&layout.meta_path(), &meta)?;

--- a/crates/ars-asset-importer/src/proxy_writer.rs
+++ b/crates/ars-asset-importer/src/proxy_writer.rs
@@ -1,0 +1,263 @@
+//! 最小 GLB (glTF 2.0 binary) writer (P2)
+//!
+//! プロキシメッシュ (positions + 32-bit indices のみ) を表現する最小限の
+//! GLB ファイルをバイト列で生成する。ノード変換 / マテリアル / 法線 / UV
+//! 等は持たない。
+//!
+//! 決定性: JSON は固定順のキーで手書き、padding 文字も glTF 仕様準拠
+//! (JSON chunk は 0x20、BIN chunk は 0x00) で固定する。同一入力に対し
+//! 常に同一バイト列を返す。
+//!
+//! ## ファイルレイアウト (glTF 2.0 spec)
+//!
+//! ```text
+//! [12B header] [JSON chunk] [BIN chunk]
+//!
+//! header: magic "glTF" (4B) + version=2 (4B) + total length (4B)
+//! chunk:  length (4B) + type (4B "JSON" or "BIN\0") + data + padding to 4B align
+//! ```
+
+use std::io::Write;
+use std::path::Path;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use crate::loaders::MeshData;
+use crate::{AssetImporterError, Result};
+
+const GLB_MAGIC: u32 = 0x4654_6C67; // "glTF"
+const GLB_VERSION: u32 = 2;
+const CHUNK_TYPE_JSON: u32 = 0x4E4F_534A; // "JSON"
+const CHUNK_TYPE_BIN: u32 = 0x004E_4942; // "BIN\0"
+
+const COMPONENT_TYPE_FLOAT: u32 = 5126;
+const COMPONENT_TYPE_UNSIGNED_INT: u32 = 5125;
+const TARGET_ARRAY_BUFFER: u32 = 34962;
+const TARGET_ELEMENT_ARRAY_BUFFER: u32 = 34963;
+const MODE_TRIANGLES: u32 = 4;
+
+/// `mesh` を GLB 形式のバイト列にエンコードする。
+///
+/// `mesh.positions` が空の場合はエラーを返す。`mesh.indices` が空の場合は
+/// non-indexed として連番インデックスを生成する。
+pub fn encode_glb(mesh: &MeshData) -> Result<Vec<u8>> {
+    if mesh.positions.is_empty() {
+        return Err(AssetImporterError::EmptyGeometry);
+    }
+
+    // ---- BIN chunk (positions then indices) を組み立て ----
+    let pos_count = mesh.positions.len();
+    let pos_bytes = pos_count * std::mem::size_of::<[f32; 3]>();
+
+    let indices_owned: Vec<u32>;
+    let indices: &[u32] = if mesh.indices.is_empty() {
+        indices_owned = (0..pos_count as u32).collect();
+        &indices_owned
+    } else {
+        &mesh.indices
+    };
+    let idx_count = indices.len();
+    let idx_bytes = std::mem::size_of_val(indices);
+
+    let mut bin: Vec<u8> = Vec::with_capacity(pos_bytes + idx_bytes);
+    for v in &mesh.positions {
+        bin.write_f32::<LittleEndian>(v.x).unwrap();
+        bin.write_f32::<LittleEndian>(v.y).unwrap();
+        bin.write_f32::<LittleEndian>(v.z).unwrap();
+    }
+    let pos_byte_offset = 0usize;
+    let idx_byte_offset = bin.len();
+    for &i in indices {
+        bin.write_u32::<LittleEndian>(i).unwrap();
+    }
+    pad_to_4(&mut bin, 0x00);
+    let bin_chunk_len = bin.len();
+
+    // ---- AABB (POSITION accessor の min/max) ----
+    let (mn, mx) = aabb_min_max(&mesh.positions);
+
+    // ---- JSON chunk を手書きで決定的に組み立て ----
+    let json = build_json(
+        bin_chunk_len,
+        pos_byte_offset,
+        pos_bytes,
+        idx_byte_offset,
+        idx_bytes,
+        pos_count,
+        idx_count,
+        mn,
+        mx,
+    );
+    let mut json_bytes = json.into_bytes();
+    pad_to_4(&mut json_bytes, 0x20);
+    let json_chunk_len = json_bytes.len();
+
+    // ---- 全体組み立て ----
+    let total_len = 12 + 8 + json_chunk_len + 8 + bin_chunk_len;
+    let mut out = Vec::with_capacity(total_len);
+
+    // header
+    out.write_u32::<LittleEndian>(GLB_MAGIC).unwrap();
+    out.write_u32::<LittleEndian>(GLB_VERSION).unwrap();
+    out.write_u32::<LittleEndian>(total_len as u32).unwrap();
+
+    // JSON chunk
+    out.write_u32::<LittleEndian>(json_chunk_len as u32).unwrap();
+    out.write_u32::<LittleEndian>(CHUNK_TYPE_JSON).unwrap();
+    out.extend_from_slice(&json_bytes);
+
+    // BIN chunk
+    out.write_u32::<LittleEndian>(bin_chunk_len as u32).unwrap();
+    out.write_u32::<LittleEndian>(CHUNK_TYPE_BIN).unwrap();
+    out.extend_from_slice(&bin);
+
+    debug_assert_eq!(out.len(), total_len);
+    Ok(out)
+}
+
+/// `encode_glb` の結果を `path` に書き出す。
+pub fn write_glb(mesh: &MeshData, path: &Path) -> Result<()> {
+    let bytes = encode_glb(mesh)?;
+    let mut f = std::fs::File::create(path).map_err(|e| AssetImporterError::io(path, e))?;
+    f.write_all(&bytes)
+        .map_err(|e| AssetImporterError::io(path, e))?;
+    Ok(())
+}
+
+fn pad_to_4(buf: &mut Vec<u8>, fill: u8) {
+    let rem = buf.len() % 4;
+    if rem != 0 {
+        buf.resize(buf.len() + (4 - rem), fill);
+    }
+}
+
+fn aabb_min_max(positions: &[glam::Vec3]) -> ([f32; 3], [f32; 3]) {
+    let mut mn = positions[0];
+    let mut mx = positions[0];
+    for &p in &positions[1..] {
+        mn = mn.min(p);
+        mx = mx.max(p);
+    }
+    (mn.to_array(), mx.to_array())
+}
+
+/// JSON を決定的な順序で手書き構築する。
+///
+/// `serde_json` を経由しない理由: BTreeMap によるキーソートでは accessors/
+/// bufferViews 内の順序まで完全には制御できないため、バイト一致テストの
+/// 安全性を最大化するために手書きで固定する。
+#[allow(clippy::too_many_arguments)]
+fn build_json(
+    bin_chunk_len: usize,
+    pos_byte_offset: usize,
+    pos_bytes: usize,
+    idx_byte_offset: usize,
+    idx_bytes: usize,
+    pos_count: usize,
+    idx_count: usize,
+    mn: [f32; 3],
+    mx: [f32; 3],
+) -> String {
+    format!(
+        concat!(
+            r#"{{"asset":{{"version":"2.0","generator":"ars-asset-importer"}},"#,
+            r#""buffers":[{{"byteLength":{bin_len}}}],"#,
+            r#""bufferViews":["#,
+            r#"{{"buffer":0,"byteOffset":{pos_off},"byteLength":{pos_len},"target":{pos_target}}},"#,
+            r#"{{"buffer":0,"byteOffset":{idx_off},"byteLength":{idx_len},"target":{idx_target}}}"#,
+            r#"],"#,
+            r#""accessors":["#,
+            r#"{{"bufferView":0,"componentType":{ct_f32},"count":{vc},"type":"VEC3","min":[{mnx},{mny},{mnz}],"max":[{mxx},{mxy},{mxz}]}},"#,
+            r#"{{"bufferView":1,"componentType":{ct_u32},"count":{ic},"type":"SCALAR"}}"#,
+            r#"],"#,
+            r#""meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":{mode}}}]}}],"#,
+            r#""nodes":[{{"mesh":0}}],"#,
+            r#""scenes":[{{"nodes":[0]}}],"#,
+            r#""scene":0}}"#,
+        ),
+        bin_len = bin_chunk_len,
+        pos_off = pos_byte_offset,
+        pos_len = pos_bytes,
+        pos_target = TARGET_ARRAY_BUFFER,
+        idx_off = idx_byte_offset,
+        idx_len = idx_bytes,
+        idx_target = TARGET_ELEMENT_ARRAY_BUFFER,
+        ct_f32 = COMPONENT_TYPE_FLOAT,
+        vc = pos_count,
+        mnx = format_float(mn[0]),
+        mny = format_float(mn[1]),
+        mnz = format_float(mn[2]),
+        mxx = format_float(mx[0]),
+        mxy = format_float(mx[1]),
+        mxz = format_float(mx[2]),
+        ct_u32 = COMPONENT_TYPE_UNSIGNED_INT,
+        ic = idx_count,
+        mode = MODE_TRIANGLES,
+    )
+}
+
+/// 浮動小数点を決定的に整形する。
+///
+/// Rust の `Display for f32` (Grisu/Ryu) は同じ値に対し常に同じ表現を返すので、
+/// プラットフォーム差は出ない。NaN/Inf は仕様外なので 0 として扱う。
+fn format_float(v: f32) -> String {
+    if v.is_finite() {
+        format!("{v}")
+    } else {
+        "0".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    fn triangle_mesh() -> MeshData {
+        MeshData {
+            name: "tri".into(),
+            positions: vec![
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(1.0, 0.0, 0.0),
+                Vec3::new(0.0, 1.0, 0.0),
+            ],
+            indices: vec![0, 1, 2],
+        }
+    }
+
+    #[test]
+    fn header_is_correct() {
+        let bytes = encode_glb(&triangle_mesh()).unwrap();
+        // magic
+        assert_eq!(&bytes[0..4], b"glTF");
+        // version
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 2);
+        // length matches
+        let len = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+        assert_eq!(len, bytes.len());
+    }
+
+    #[test]
+    fn deterministic_byte_for_byte() {
+        let m = triangle_mesh();
+        let a = encode_glb(&m).unwrap();
+        let b = encode_glb(&m).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn round_trip_via_gltf_crate() {
+        // 出力が gltf クレートで再ロード可能であることを確認
+        let bytes = encode_glb(&triangle_mesh()).unwrap();
+        let g = gltf::Gltf::from_slice(&bytes).expect("valid GLB");
+        let mesh = g.document.meshes().next().expect("has mesh");
+        let prim = mesh.primitives().next().expect("has primitive");
+        assert_eq!(prim.mode(), gltf::mesh::Mode::Triangles);
+    }
+
+    #[test]
+    fn empty_mesh_errors() {
+        let m = MeshData::default();
+        assert!(encode_glb(&m).is_err());
+    }
+}

--- a/crates/ars-asset-importer/src/schema.rs
+++ b/crates/ars-asset-importer/src/schema.rs
@@ -118,6 +118,14 @@ pub struct AssetMeta {
     /// で `None` として読み込まれる。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proxy_triangle_count: Option<u32>,
+    /// `hull.bin` の頂点数 (P3 以降で書き込まれる)。
+    ///
+    /// 共面/退化メッシュ等で凸包生成に失敗した場合は `None`。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hull_vertex_count: Option<u32>,
+    /// `hull.bin` の三角形数 (P3 以降で書き込まれる)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hull_triangle_count: Option<u32>,
 }
 
 impl AssetMeta {

--- a/crates/ars-asset-importer/src/schema.rs
+++ b/crates/ars-asset-importer/src/schema.rs
@@ -112,6 +112,12 @@ pub struct AssetMeta {
     pub triangle_count: u32,
     /// 頂点数 (原メッシュ)
     pub vertex_count: u32,
+    /// `proxy.glb` の三角形数 (P2 以降で書き込まれる)。
+    ///
+    /// P1 で生成された meta は本フィールドを持たないため、`#[serde(default)]`
+    /// で `None` として読み込まれる。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_triangle_count: Option<u32>,
 }
 
 impl AssetMeta {

--- a/crates/ars-asset-importer/src/simplify.rs
+++ b/crates/ars-asset-importer/src/simplify.rs
@@ -1,6 +1,138 @@
-//! メッシュ簡略化 (stub — P2)
+//! メッシュ簡略化 (P2)
 //!
-//! Phase 2 で `meshopt` クレートによる decimate を実装する予定。
-//! 現在は proxy.glb を原メッシュからそのまま生成しない (meta のみ書く) 構成。
+//! `meshopt` (Arseny Kapoulkine) の simplification API で原メッシュを decimate し、
+//! 目標 triangle 数以下のプロキシメッシュを生成する。
+//!
+//! `meshopt::simplify` は擬似乱数を使わない決定的アルゴリズムなので、
+//! 同一入力 + 同一バージョンで常に同一バイト列の結果を返す。
 
-// 実装なし: Phase 2 で meshopt による simplification を導入する。
+use meshopt::{SimplifyOptions, VertexDataAdapter};
+
+use crate::loaders::MeshData;
+
+/// 簡略化の上限 triangle 数 (Tier 1 仕様: < 256 tri を目標)。
+pub const DEFAULT_TARGET_TRIANGLES: u32 = 256;
+
+/// 許容誤差 (絶対値)。`meshopt::simplify` の `target_error`。
+///
+/// 0.05 は「モデル直径の 5%」相当の誤差を許容することを意味する。
+/// プレビュー目的なので過度に小さくしない (収束しないと target に届かない)。
+pub const DEFAULT_TARGET_ERROR: f32 = 0.05;
+
+/// `mesh` を `target_triangles` 以下まで簡略化した新しい [`MeshData`] を返す。
+///
+/// 入力が既に target 以下の場合は (再構築無しで) クローンを返す。
+/// 結果メッシュは indexed (positions の重複を保ったまま indices だけ縮約) になる。
+pub fn simplify(mesh: &MeshData, target_triangles: u32) -> MeshData {
+    if mesh.is_empty() {
+        return mesh.clone();
+    }
+    if mesh.triangle_count() <= target_triangles {
+        return mesh.clone();
+    }
+
+    // meshopt は VertexDataAdapter で位置オフセット付きバイト列を受ける。
+    // [Vec3; N] (= [f32; 3] * N) として直接 byte slice 化する。
+    let position_bytes: &[u8] = bytemuck_cast(&mesh.positions);
+    let adapter = VertexDataAdapter::new(
+        position_bytes,
+        std::mem::size_of::<[f32; 3]>(),
+        0,
+    )
+    .expect("VertexDataAdapter from Vec3 slice");
+
+    let target_index_count = (target_triangles as usize) * 3;
+
+    let new_indices = meshopt::simplify(
+        &mesh.indices,
+        &adapter,
+        target_index_count,
+        DEFAULT_TARGET_ERROR,
+        SimplifyOptions::None,
+        None,
+    );
+
+    MeshData {
+        name: mesh.name.clone(),
+        positions: mesh.positions.clone(),
+        indices: new_indices,
+    }
+}
+
+/// `Vec<glam::Vec3>` → `&[u8]` の安全な再解釈。
+///
+/// `glam::Vec3` は `repr(C)` で `[f32; 3]` 同等のレイアウトなので
+/// `meshopt` (および GPU バッファ) で扱う `[f32; 3]` 列としてそのまま参照できる。
+fn bytemuck_cast(positions: &[glam::Vec3]) -> &[u8] {
+    let len = std::mem::size_of_val(positions);
+    // SAFETY: glam::Vec3 is #[repr(C)] of three f32; reading as bytes is sound.
+    unsafe { std::slice::from_raw_parts(positions.as_ptr() as *const u8, len) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+
+    fn unit_grid_mesh(side: u32) -> MeshData {
+        // side x side の四角形格子を 2 三角形/quad で展開
+        let mut positions = Vec::new();
+        let mut indices = Vec::new();
+        let s = side as f32;
+        for y in 0..=side {
+            for x in 0..=side {
+                positions.push(Vec3::new(x as f32 / s, y as f32 / s, 0.0));
+            }
+        }
+        let row = side + 1;
+        for y in 0..side {
+            for x in 0..side {
+                let i0 = y * row + x;
+                let i1 = i0 + 1;
+                let i2 = i0 + row;
+                let i3 = i2 + 1;
+                indices.extend_from_slice(&[i0, i1, i2, i1, i3, i2]);
+            }
+        }
+        MeshData {
+            name: "grid".into(),
+            positions,
+            indices,
+        }
+    }
+
+    #[test]
+    fn passthrough_when_under_target() {
+        let mesh = unit_grid_mesh(2); // 2*2*2 = 8 tri
+        let out = simplify(&mesh, 256);
+        assert_eq!(out.triangle_count(), mesh.triangle_count());
+    }
+
+    #[test]
+    fn reduces_high_tri_mesh_below_target() {
+        // 32x32 = 2048 tri、target 256
+        let mesh = unit_grid_mesh(32);
+        assert!(mesh.triangle_count() > 256);
+        let out = simplify(&mesh, 256);
+        assert!(
+            out.triangle_count() <= 256,
+            "got {} tri after simplify",
+            out.triangle_count()
+        );
+    }
+
+    #[test]
+    fn deterministic_repeated_calls() {
+        let mesh = unit_grid_mesh(16); // 512 tri
+        let a = simplify(&mesh, 64);
+        let b = simplify(&mesh, 64);
+        assert_eq!(a.indices, b.indices);
+    }
+
+    #[test]
+    fn empty_mesh_passthrough() {
+        let mesh = MeshData::default();
+        let out = simplify(&mesh, 256);
+        assert!(out.is_empty());
+    }
+}

--- a/crates/ars-asset-importer/tests/pipeline_test.rs
+++ b/crates/ars-asset-importer/tests/pipeline_test.rs
@@ -106,6 +106,56 @@ fn proxy_glb_is_deterministic_across_runs() {
 }
 
 #[test]
+fn tetrahedron_hull_is_written_and_recorded() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("tet.glb");
+    write_tetra_glb(&src);
+    let out_root = tmp.path().join("data");
+
+    let outcome = process(&src, &out_root, Some(AssetId::from_string("tet"))).unwrap();
+
+    let hull_path = outcome.dir.join("hull.bin");
+    assert!(hull_path.exists(), "hull.bin should be written");
+
+    let bytes = fs::read(&hull_path).unwrap();
+    assert_eq!(&bytes[0..4], b"HULL", "hull.bin must have HULL magic");
+
+    // 四面体の凸包: 4 頂点 / 4 三角形
+    assert_eq!(outcome.meta.hull_vertex_count, Some(4));
+    assert_eq!(outcome.meta.hull_triangle_count, Some(4));
+}
+
+#[test]
+fn hull_bin_is_deterministic_across_runs() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("det_tet.glb");
+    write_tetra_glb(&src);
+    let out_root = tmp.path().join("data");
+
+    let a = process(&src, &out_root, Some(AssetId::from_string("a"))).unwrap();
+    let b = process(&src, &out_root, Some(AssetId::from_string("b"))).unwrap();
+
+    let bytes_a = fs::read(a.dir.join("hull.bin")).unwrap();
+    let bytes_b = fs::read(b.dir.join("hull.bin")).unwrap();
+    assert_eq!(bytes_a, bytes_b, "hull.bin must be byte-deterministic");
+}
+
+#[test]
+fn flat_triangle_has_no_hull() {
+    // 3 頂点の単一三角形 → hull は退化、None。エラーにはならない
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("flat.glb");
+    write_minimal_glb(&src, &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+    let out_root = tmp.path().join("data");
+
+    let outcome = process(&src, &out_root, Some(AssetId::from_string("flat"))).unwrap();
+
+    assert!(outcome.meta.hull_vertex_count.is_none());
+    assert!(outcome.meta.hull_triangle_count.is_none());
+    assert!(!outcome.dir.join("hull.bin").exists());
+}
+
+#[test]
 fn changed_source_invalidates_cache() {
     let tmp = TempDir::new().unwrap();
     let src = tmp.path().join("mutable.glb");
@@ -124,6 +174,79 @@ fn changed_source_invalidates_cache() {
     assert!(!second.cache_hit, "mutated source must invalidate cache");
     assert_ne!(second.meta.source_hash, first.meta.source_hash);
     assert!((second.meta.aabb.max[0] - 5.0).abs() < 1e-5);
+}
+
+/// 四面体 (4 頂点 / 4 三角形) の最小 GLB を書き出す。hull テスト用。
+fn write_tetra_glb(path: &Path) {
+    let verts: [[f32; 3]; 4] = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ];
+    let tris: [u16; 12] = [0, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3];
+    write_glb_arbitrary(path, &verts, &tris);
+}
+
+fn write_glb_arbitrary(path: &Path, verts: &[[f32; 3]], tris: &[u16]) {
+    let pos_bytes_len = verts.len() * 12;
+    let idx_bytes_len = tris.len() * 2;
+
+    let mut bin = Vec::with_capacity(pos_bytes_len + idx_bytes_len + 4);
+    for v in verts {
+        for &c in v {
+            bin.extend_from_slice(&c.to_le_bytes());
+        }
+    }
+    let idx_offset = bin.len();
+    for &i in tris {
+        bin.extend_from_slice(&i.to_le_bytes());
+    }
+    while bin.len() % 4 != 0 {
+        bin.push(0);
+    }
+
+    let (mut min, mut max) = ([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]);
+    for v in verts {
+        for i in 0..3 {
+            if v[i] < min[i] {
+                min[i] = v[i];
+            }
+            if v[i] > max[i] {
+                max[i] = v[i];
+            }
+        }
+    }
+
+    let json = format!(
+        r#"{{"asset":{{"version":"2.0"}},"buffers":[{{"byteLength":{bin_len}}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":{pl},"target":34962}},{{"buffer":0,"byteOffset":{io},"byteLength":{il},"target":34963}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":{vc},"type":"VEC3","min":[{n0},{n1},{n2}],"max":[{x0},{x1},{x2}]}},{{"bufferView":1,"componentType":5123,"count":{ic},"type":"SCALAR"}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":4}}]}}],"nodes":[{{"mesh":0}}],"scenes":[{{"nodes":[0]}}],"scene":0}}"#,
+        bin_len = bin.len(),
+        pl = pos_bytes_len,
+        io = idx_offset,
+        il = idx_bytes_len,
+        vc = verts.len(),
+        ic = tris.len(),
+        n0 = min[0], n1 = min[1], n2 = min[2],
+        x0 = max[0], x1 = max[1], x2 = max[2],
+    );
+    let mut json_bytes = json.into_bytes();
+    while json_bytes.len() % 4 != 0 {
+        json_bytes.push(0x20);
+    }
+
+    let total_len = 12 + 8 + json_bytes.len() + 8 + bin.len();
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(&0x46546C67u32.to_le_bytes());
+    out.extend_from_slice(&2u32.to_le_bytes());
+    out.extend_from_slice(&(total_len as u32).to_le_bytes());
+    out.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0x4E4F534Au32.to_le_bytes());
+    out.extend_from_slice(&json_bytes);
+    out.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+    out.extend_from_slice(&0x004E4942u32.to_le_bytes());
+    out.extend_from_slice(&bin);
+
+    fs::write(path, out).unwrap();
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ars-asset-importer/tests/pipeline_test.rs
+++ b/crates/ars-asset-importer/tests/pipeline_test.rs
@@ -63,6 +63,49 @@ fn reprocessing_same_source_hits_cache() {
 }
 
 #[test]
+fn proxy_glb_is_written_and_recorded_in_meta() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("p2.glb");
+    write_minimal_glb(&src, &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]);
+
+    let out_root = tmp.path().join("data");
+    let id = AssetId::from_string("p2-asset");
+
+    let outcome = process(&src, &out_root, Some(id.clone())).unwrap();
+
+    let proxy_path = outcome.dir.join("proxy.glb");
+    assert!(proxy_path.exists(), "proxy.glb should be written");
+
+    let proxy_bytes = fs::read(&proxy_path).unwrap();
+    assert_eq!(&proxy_bytes[0..4], b"glTF", "proxy.glb must have GLB magic");
+
+    // gltf クレートで再ロードできること
+    let g = gltf::Gltf::from_slice(&proxy_bytes).expect("proxy.glb must be valid GLB");
+    let mesh = g.document.meshes().next().expect("proxy has mesh");
+    let prim = mesh.primitives().next().expect("proxy has primitive");
+    assert_eq!(prim.mode(), gltf::mesh::Mode::Triangles);
+
+    // meta に proxy_triangle_count が記録されている
+    assert_eq!(outcome.meta.proxy_triangle_count, Some(1));
+}
+
+#[test]
+fn proxy_glb_is_deterministic_across_runs() {
+    // 同一 src を別 ID でインポート → proxy.glb がバイト一致 (id は GLB に入らない)
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("det.glb");
+    write_minimal_glb(&src, &[[0.0, 0.0, 0.0], [1.0, 2.0, 3.0], [4.0, 0.0, 0.0]]);
+    let out_root = tmp.path().join("data");
+
+    let a = process(&src, &out_root, Some(AssetId::from_string("a"))).unwrap();
+    let b = process(&src, &out_root, Some(AssetId::from_string("b"))).unwrap();
+
+    let bytes_a = fs::read(a.dir.join("proxy.glb")).unwrap();
+    let bytes_b = fs::read(b.dir.join("proxy.glb")).unwrap();
+    assert_eq!(bytes_a, bytes_b, "proxy.glb must be deterministic");
+}
+
+#[test]
 fn changed_source_invalidates_cache() {
     let tmp = TempDir::new().unwrap();
     let src = tmp.path().join("mutable.glb");


### PR DESCRIPTION
Closes (partially) #92 — P5 フェーズ分。

**Stacked on top of #95 (P3) → #94 (P2) → main**. 順次マージで自動的に main へ向かう。

## Summary

### Backend (`ars-editor/src-tauri`)
- `commands/asset.rs`: 2 つの Tauri コマンド
  - `import_assets(projectDir, paths) -> ImportedAsset[]` — 複数ファイル一括、1 件失敗でも続行
  - `list_imported_assets(projectDir) -> ImportedAsset[]` — meta.toml から再構成
- `ars-asset-importer` を `tauri-app` feature 限定の optional dep に
  - 理由: P1 既存の clippy 警告が web-server build (CI で `-D warnings`) を壊すのを回避
  - P6 で web ハンドラを実装する際に既存警告も整理する想定

### Frontend (`ars-editor/src`)
- `lib/backend.ts`: `importAssets` / `listImportedAssets` + `ImportedAsset` / `AssetMeta` 型
- `features/asset-browser/AssetBrowser.tsx`: 最小アセットブラウザ
  - Tauri webview の `onDragDropEvent` を listen → `.glb` / `.gltf` を抽出 → 自動インポート
  - インポート済みリストは meta から re-render (proxy 三角形数 / hull v/t を表示)
  - ブラウザ版は \"P6 multipart 予定\" のメッセージを表示
- `routes.tsx`: `/assets` ルート追加

## 非スコープ (後続 PR)
- P6 Axum ハンドラ (multipart upload) + CLI
- P7 決定性 CI
- 3D サムネ表示 (Pictor#37 P1 連携)
- Asset → Scene へのドロップ (placement)

## Test plan
- [x] `cargo test --features tauri-app` で `commands::asset` 3 件 pass
  - import 2 件 → list で 2 件
  - 不正 project_dir はエラー
  - サポート外フォーマットは skip され他は続行
- [x] `cargo clippy --features web-server --no-default-features --bin ars-web-server -- -D warnings` pass (CI と同条件)
- [x] `npx tsc -b` 全 green
- [x] `npm run lint` (ESLint) 全 green

Refs: #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)