### PR TITLE
feat(asset-importer): Tauri import_assets + minimal asset browser (#92 P5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "ars-asset-importer",
  "ars-codegen",
  "ars-core",
  "ars-project",
@@ -149,8 +150,10 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "time",
  "tokio",
+ "toml 0.8.2",
  "tower",
  "tower-http 0.5.2",
  "urlencoding",

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "2.5.6", optional = true }
 
 [features]
 default = ["tauri-app"]
-tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build"]
+tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build", "dep:ars-asset-importer"]
 web-server = [
     "dep:axum",
     "dep:tokio",
@@ -51,12 +51,14 @@ ars-core = { path = "../../crates/ars-core" }
 ars-codegen = { path = "../../crates/ars-codegen" }
 ars-secrets = { path = "../../crates/ars-secrets" }
 ars-project = { path = "../../crates/ars-project" }
+ars-asset-importer = { path = "../../crates/ars-asset-importer", optional = true }
 # ars-secrets: removed — secrets management moved to Cernere server
 # Common
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 async-trait = "0.1"
+toml = "0.8"
 tauri = { version = "2.10.3", optional = true }
 tauri-plugin-log = { version = "2", optional = true }
 dirs-next = "2.0"
@@ -78,3 +80,6 @@ dirs = { version = "6", optional = true }
 futures = { version = "0.3", optional = true }
 dashmap = { version = "6", optional = true }
 # Redis: removed — session management moved to Cernere server
+
+[dev-dependencies]
+tempfile = "3"

--- a/ars-editor/src-tauri/src/commands/asset.rs
+++ b/ars-editor/src-tauri/src/commands/asset.rs
@@ -1,0 +1,235 @@
+//! アセットインポート Tauri コマンド (P5)
+//!
+//! ars-asset-importer クレートを呼び出し、glTF/GLB アセットを Tier 1 成果物
+//! (`data/<id>/{source,proxy,hull,meta}`) として書き出す。
+//!
+//! ## セキュリティ
+//!
+//! - `path` はユーザーが選択したファイルなのでパス制約は課さない (D&D 由来)
+//! - `out_root` はプロジェクトの `data/` ディレクトリに固定 (パストラバーサル防止)
+//! - インポート結果は `ImportedAsset` で id / dir / cache_hit を返す
+
+use ars_asset_importer::{process, AssetMeta};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// `import_asset` が返す 1 アセット分の結果。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportedAsset {
+    pub id: String,
+    /// `data/<id>/` の絶対パス。
+    pub dir: String,
+    /// 既に同一 source_hash がキャッシュ済みだったか。
+    pub cache_hit: bool,
+    /// 原ファイル名 (拡張子付き)。
+    pub source_name: String,
+    /// インポート結果 meta (frontend で proxy/hull の有無を判別するため)。
+    pub meta: AssetMeta,
+}
+
+/// 1 つ以上のアセットファイルを `project_dir/data/` 配下にインポートする。
+///
+/// 失敗したファイルがあっても他は続行し、エラーはログに残してスキップする。
+/// 結果は成功した分のみ返す。
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+pub async fn import_assets(
+    project_dir: String,
+    paths: Vec<String>,
+) -> Result<Vec<ImportedAsset>, String> {
+    import_assets_impl(project_dir, paths)
+}
+
+pub fn import_assets_impl(
+    project_dir: String,
+    paths: Vec<String>,
+) -> Result<Vec<ImportedAsset>, String> {
+    let project_root = PathBuf::from(&project_dir);
+    if !project_root.is_dir() {
+        return Err(format!("project_dir does not exist: {project_dir}"));
+    }
+    let out_root = project_root.join("data");
+    std::fs::create_dir_all(&out_root)
+        .map_err(|e| format!("failed to create data dir: {e}"))?;
+
+    let mut results = Vec::with_capacity(paths.len());
+    for p in paths {
+        let src = PathBuf::from(&p);
+        match process(&src, &out_root, None) {
+            Ok(outcome) => {
+                let source_name = src
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                results.push(ImportedAsset {
+                    id: outcome.id.to_string(),
+                    dir: outcome.dir.to_string_lossy().to_string(),
+                    cache_hit: outcome.cache_hit,
+                    source_name,
+                    meta: outcome.meta,
+                });
+            }
+            Err(e) => {
+                log::warn!("import_asset failed for {p}: {e}");
+                // continue: don't abort the whole batch on a single failure
+            }
+        }
+    }
+    Ok(results)
+}
+
+/// 既存のインポート済みアセット一覧を返す (起動時 / D&D 完了後の refresh 用)。
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+pub fn list_imported_assets(project_dir: String) -> Result<Vec<ImportedAsset>, String> {
+    list_imported_assets_impl(project_dir)
+}
+
+pub fn list_imported_assets_impl(project_dir: String) -> Result<Vec<ImportedAsset>, String> {
+    let data_root = PathBuf::from(&project_dir).join("data");
+    if !data_root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut out = Vec::new();
+    let entries = std::fs::read_dir(&data_root)
+        .map_err(|e| format!("failed to read data dir: {e}"))?;
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let meta_path = dir.join("meta.toml");
+        if !meta_path.exists() {
+            continue;
+        }
+        match read_meta(&meta_path) {
+            Ok(meta) => {
+                let source_name = dir
+                    .join(format!("source.{}", meta.source_ext))
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string();
+                out.push(ImportedAsset {
+                    id: meta.id.to_string(),
+                    dir: dir.to_string_lossy().to_string(),
+                    cache_hit: true,
+                    source_name,
+                    meta,
+                });
+            }
+            Err(e) => {
+                log::warn!("failed to read meta.toml at {}: {e}", meta_path.display());
+            }
+        }
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
+fn read_meta(path: &Path) -> Result<AssetMeta, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("read meta: {e}"))?;
+    toml::from_str(&text).map_err(|e| format!("parse meta: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_minimal_glb(path: &Path) {
+        // 1 三角形の最小 GLB (statically embedded test fixture)
+        let verts: [[f32; 3]; 3] = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let mut bin = Vec::new();
+        for v in &verts {
+            for &c in v {
+                bin.extend_from_slice(&c.to_le_bytes());
+            }
+        }
+        let idx_off = bin.len();
+        for i in [0u16, 1, 2] {
+            bin.extend_from_slice(&i.to_le_bytes());
+        }
+        while bin.len() % 4 != 0 {
+            bin.push(0);
+        }
+
+        let json = format!(
+            r#"{{"asset":{{"version":"2.0"}},"buffers":[{{"byteLength":{}}}],"bufferViews":[{{"buffer":0,"byteOffset":0,"byteLength":36,"target":34962}},{{"buffer":0,"byteOffset":{},"byteLength":6,"target":34963}}],"accessors":[{{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3","min":[0,0,0],"max":[1,1,0]}},{{"bufferView":1,"componentType":5123,"count":3,"type":"SCALAR"}}],"meshes":[{{"primitives":[{{"attributes":{{"POSITION":0}},"indices":1,"mode":4}}]}}],"nodes":[{{"mesh":0}}],"scenes":[{{"nodes":[0]}}],"scene":0}}"#,
+            bin.len(), idx_off
+        );
+        let mut json_bytes = json.into_bytes();
+        while json_bytes.len() % 4 != 0 {
+            json_bytes.push(0x20);
+        }
+
+        let total = 12 + 8 + json_bytes.len() + 8 + bin.len();
+        let mut out = Vec::with_capacity(total);
+        out.extend_from_slice(&0x46546C67u32.to_le_bytes());
+        out.extend_from_slice(&2u32.to_le_bytes());
+        out.extend_from_slice(&(total as u32).to_le_bytes());
+        out.extend_from_slice(&(json_bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&0x4E4F534Au32.to_le_bytes());
+        out.extend_from_slice(&json_bytes);
+        out.extend_from_slice(&(bin.len() as u32).to_le_bytes());
+        out.extend_from_slice(&0x004E4942u32.to_le_bytes());
+        out.extend_from_slice(&bin);
+
+        fs::write(path, out).unwrap();
+    }
+
+    #[test]
+    fn import_two_assets_then_list_them() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().to_path_buf();
+        let a = project.join("a.glb");
+        let b = project.join("b.glb");
+        write_minimal_glb(&a);
+        write_minimal_glb(&b);
+
+        let imported = import_assets_impl(
+            project.to_string_lossy().to_string(),
+            vec![
+                a.to_string_lossy().to_string(),
+                b.to_string_lossy().to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(imported.len(), 2);
+
+        let listed = list_imported_assets_impl(project.to_string_lossy().to_string()).unwrap();
+        assert_eq!(listed.len(), 2);
+    }
+
+    #[test]
+    fn missing_project_dir_errors() {
+        let err = import_assets_impl("/nonexistent/path/xyz".into(), vec![]).unwrap_err();
+        assert!(err.contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn unsupported_format_is_skipped_not_aborted() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().to_path_buf();
+        let bad = project.join("bad.txt");
+        let good = project.join("good.glb");
+        std::fs::write(&bad, b"not a glb").unwrap();
+        write_minimal_glb(&good);
+
+        let imported = import_assets_impl(
+            project.to_string_lossy().to_string(),
+            vec![
+                bad.to_string_lossy().to_string(),
+                good.to_string_lossy().to_string(),
+            ],
+        )
+        .unwrap();
+        // bad は skip、good のみ成功
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].source_name, "good.glb");
+    }
+}

--- a/ars-editor/src-tauri/src/commands/mod.rs
+++ b/ars-editor/src-tauri/src/commands/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "tauri-app")]
+pub mod asset;
 pub mod project;
 
+#[cfg(feature = "tauri-app")]
+pub use asset::*;
 pub use project::*;

--- a/ars-editor/src-tauri/src/lib.rs
+++ b/ars-editor/src-tauri/src/lib.rs
@@ -61,6 +61,8 @@ pub fn run() {
             commands::save_project,
             commands::load_project,
             commands::get_default_project_path,
+            commands::import_assets,
+            commands::list_imported_assets,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ars-editor/src/features/asset-browser/AssetBrowser.tsx
+++ b/ars-editor/src/features/asset-browser/AssetBrowser.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  importAssets,
+  listImportedAssets,
+  isTauri,
+  type ImportedAsset,
+} from '@/lib/backend';
+import { getDefaultProjectPath } from '@/lib/tauri-commands';
+
+/**
+ * 最小限のアセットブラウザ (P5)。
+ *
+ * - Tauri ウィンドウへのファイル D&D を listen し、ars_asset_importer 経由で
+ *   `data/<id>/` に Tier 1 成果物を生成する
+ * - インポート済みアセットを meta.toml から再構成して一覧表示する
+ *
+ * UI は最小限のリスト表示のみ。3D プレビュー / サムネ表示等は後続フェーズで
+ * Pictor 連携と合わせて拡充する。
+ */
+export function AssetBrowser() {
+  const [projectDir, setProjectDir] = useState<string>('');
+  const [assets, setAssets] = useState<ImportedAsset[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [dropHover, setDropHover] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDefaultProjectPath().then((dir) => {
+      if (!cancelled) {
+        setProjectDir(dir);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!projectDir) return;
+    try {
+      const list = await listImportedAssets(projectDir);
+      setAssets(list);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [projectDir]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Tauri webview drag-drop event は OS から受け取った絶対パスをそのまま渡せる。
+  // ブラウザ版は File オブジェクト経由になるためパスが取れず、現状未対応 (P6 で multipart)。
+  useEffect(() => {
+    if (!isTauri() || !projectDir) return;
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      const { getCurrentWebview } = await import('@tauri-apps/api/webview');
+      const webview = getCurrentWebview();
+      const handle = await webview.onDragDropEvent(async (event) => {
+        if (event.payload.type === 'enter' || event.payload.type === 'over') {
+          setDropHover(true);
+        } else if (event.payload.type === 'leave') {
+          setDropHover(false);
+        } else if (event.payload.type === 'drop') {
+          setDropHover(false);
+          const paths = event.payload.paths.filter(
+            (p) => p.toLowerCase().endsWith('.glb') || p.toLowerCase().endsWith('.gltf'),
+          );
+          if (paths.length === 0) return;
+          setImporting(true);
+          setError(null);
+          try {
+            await importAssets(projectDir, paths);
+            await refresh();
+          } catch (e) {
+            setError(String(e));
+          } finally {
+            setImporting(false);
+          }
+        }
+      });
+      unlisten = handle;
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, [projectDir, refresh]);
+
+  return (
+    <div
+      className="flex flex-col h-full p-4 gap-3"
+      style={{
+        background: 'var(--bg)',
+        color: 'var(--text)',
+        outline: dropHover ? '2px dashed var(--accent)' : 'none',
+      }}
+    >
+      <header className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Assets</h2>
+        <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+          {projectDir ? `data/ in ${projectDir}` : '(no project dir)'}
+        </div>
+      </header>
+
+      {!isTauri() && (
+        <div
+          className="text-sm rounded p-3"
+          style={{ background: 'var(--surface)', color: 'var(--text-muted)' }}
+        >
+          ファイル D&D は現在デスクトップ版のみ対応です (Web は P6 multipart 予定)。
+        </div>
+      )}
+
+      {importing && (
+        <div className="text-sm" style={{ color: 'var(--text-muted)' }}>
+          Importing...
+        </div>
+      )}
+      {error && (
+        <div className="text-sm" style={{ color: 'var(--danger, #f87171)' }}>
+          {error}
+        </div>
+      )}
+
+      <ul className="flex-1 overflow-auto rounded" style={{ background: 'var(--surface)' }}>
+        {assets.length === 0 ? (
+          <li className="p-3 text-sm" style={{ color: 'var(--text-muted)' }}>
+            まだアセットがありません。`.glb` / `.gltf` ファイルをウィンドウにドラッグしてください。
+          </li>
+        ) : (
+          assets.map((a) => (
+            <li
+              key={a.id}
+              className="px-3 py-2 border-b text-sm"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <div className="font-mono text-xs" style={{ color: 'var(--text-muted)' }}>
+                {a.id}
+              </div>
+              <div className="font-medium">{a.sourceName || a.meta.name}</div>
+              <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                {a.meta.triangle_count} tri / {a.meta.vertex_count} v
+                {typeof a.meta.proxy_triangle_count === 'number' &&
+                  ` · proxy ${a.meta.proxy_triangle_count}`}
+                {typeof a.meta.hull_triangle_count === 'number' &&
+                  ` · hull ${a.meta.hull_vertex_count}v ${a.meta.hull_triangle_count}t`}
+              </div>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/ars-editor/src/features/asset-browser/index.ts
+++ b/ars-editor/src/features/asset-browser/index.ts
@@ -1,0 +1,1 @@
+export { AssetBrowser } from './AssetBrowser';

--- a/ars-editor/src/lib/backend.ts
+++ b/ars-editor/src/lib/backend.ts
@@ -107,4 +107,54 @@ export async function codegenApply(
   });
 }
 
+// ── Asset Importer (Tier 1) ─────────────────────────
+
+export interface AssetMeta {
+  version: number;
+  id: string;
+  name: string;
+  source_ext: string;
+  source_hash: string;
+  aabb: { min: [number, number, number]; max: [number, number, number] };
+  obb: {
+    center: [number, number, number];
+    axes: [[number, number, number], [number, number, number], [number, number, number]];
+    half_extents: [number, number, number];
+  };
+  pivot: [number, number, number];
+  triangle_count: number;
+  vertex_count: number;
+  proxy_triangle_count?: number;
+  hull_vertex_count?: number;
+  hull_triangle_count?: number;
+}
+
+export interface ImportedAsset {
+  id: string;
+  dir: string;
+  cacheHit: boolean;
+  sourceName: string;
+  meta: AssetMeta;
+}
+
+export async function importAssets(
+  projectDir: string,
+  paths: string[],
+): Promise<ImportedAsset[]> {
+  if (isTauri()) {
+    return tauriInvoke<ImportedAsset[]>('import_assets', { projectDir, paths });
+  }
+  // Web: not implemented — needs multipart upload (P6)
+  throw new Error('importAssets is desktop-only in this build');
+}
+
+export async function listImportedAssets(projectDir: string): Promise<ImportedAsset[]> {
+  if (isTauri()) {
+    return tauriInvoke<ImportedAsset[]>('list_imported_assets', { projectDir });
+  }
+  return webFetch<ImportedAsset[]>(
+    `/assets/list?projectDir=${encodeURIComponent(projectDir)}`,
+  );
+}
+
 export { isTauri };

--- a/ars-editor/src/routes.tsx
+++ b/ars-editor/src/routes.tsx
@@ -3,6 +3,7 @@ import { ReactFlowProvider } from '@xyflow/react';
 import { AppLayout } from './AppLayout';
 import { EditorPage } from './features/editor-page';
 import { ProjectSettingsPage } from './features/project-settings';
+import { AssetBrowser } from './features/asset-browser';
 import { OAuthCallback } from './components/OAuthCallback';
 
 export const routes: RouteObject[] = [
@@ -19,6 +20,7 @@ export const routes: RouteObject[] = [
         ),
       },
       { path: 'settings', element: <ProjectSettingsPage /> },
+      { path: 'assets', element: <AssetBrowser /> },
     ],
   },
   { path: '/auth/callback', element: <OAuthCallback /> },


### PR DESCRIPTION
Closes (partially) #92 — P5 フェーズ分。元 PR #96 が base 削除で close されたため再作成。

## Summary

### Backend (`ars-editor/src-tauri`)
- `commands/asset.rs`: `import_assets` / `list_imported_assets` Tauri コマンド (バッチ内 1 件失敗でも続行)
- `ars-asset-importer` を `tauri-app` feature 限定の optional dep に (P6 で web 経路を整理)

### Frontend (`ars-editor/src`)
- `lib/backend.ts`: `importAssets` / `listImportedAssets` + 型定義
- `features/asset-browser/AssetBrowser.tsx`: 最小ブラウザ
  - Tauri webview の `onDragDropEvent` を listen → `.glb`/`.gltf` 自動インポート
  - meta.toml から再構成して proxy 三角形数 / hull v/t を表示
- `routes.tsx`: `/assets` 追加

## Test plan
- [x] cargo test --features tauri-app commands::asset 3/3
- [x] cargo clippy --features web-server -- -D warnings (CI と同条件)
- [x] npx tsc -b / npm run lint pass

Refs: #92, 元PR #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)