### PR TITLE
feat(asset-importer): Axum multipart handler + ars-import CLI (#92 P6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",

--- a/ars-editor/src-tauri/Cargo.toml
+++ b/ars-editor/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "2.5.6", optional = true }
 
 [features]
 default = ["tauri-app"]
-tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build", "dep:ars-asset-importer"]
+tauri-app = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-build", "assets"]
 web-server = [
     "dep:axum",
     "dep:tokio",
@@ -33,7 +33,11 @@ web-server = [
     "dep:dirs",
     "dep:futures",
     "dep:dashmap",
+    "dep:tempfile",
+    "assets",
 ]
+# Asset importer integration (Tier 1 generation pipeline)
+assets = ["dep:ars-asset-importer"]
 
 [[bin]]
 name = "app"
@@ -62,7 +66,8 @@ toml = "0.8"
 tauri = { version = "2.10.3", optional = true }
 tauri-plugin-log = { version = "2", optional = true }
 dirs-next = "2.0"
-axum = { version = "0.7", features = ["ws"], optional = true }
+axum = { version = "0.7", features = ["ws", "multipart"], optional = true }
+tempfile = { version = "3", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 tower-http = { version = "0.5", features = ["cors", "fs"], optional = true }
 # HTTP client & Auth (Cernere proxy)

--- a/ars-editor/src-tauri/src/commands/mod.rs
+++ b/ars-editor/src-tauri/src/commands/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "tauri-app")]
+#[cfg(feature = "assets")]
 pub mod asset;
 pub mod project;
 
-#[cfg(feature = "tauri-app")]
+#[cfg(feature = "assets")]
 pub use asset::*;
 pub use project::*;

--- a/ars-editor/src-tauri/src/web_modules/asset.rs
+++ b/ars-editor/src-tauri/src/web_modules/asset.rs
@@ -1,0 +1,95 @@
+//! Asset import の Axum ハンドラ (P6)
+//!
+//! ブラウザからの multipart アップロードを受け取り、ars-asset-importer
+//! 経由で `data/<id>/` 配下に Tier 1 成果物を生成する。
+//!
+//! 共通実装は `commands::asset::{import_assets_impl, list_imported_assets_impl}`。
+
+use axum::{
+    extract::{Multipart, Query},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use serde::Deserialize;
+use tempfile::TempDir;
+
+use crate::commands::asset::{
+    import_assets_impl, list_imported_assets_impl, ImportedAsset,
+};
+
+#[derive(Deserialize)]
+struct ImportQuery {
+    project_dir: String,
+}
+
+#[derive(Deserialize)]
+struct ListQuery {
+    project_dir: String,
+}
+
+/// `multipart/form-data` で 1 つ以上のファイルを受け取り、
+/// 一時ディレクトリに書き出した上で import_assets_impl を呼ぶ。
+async fn api_import_assets(
+    Query(q): Query<ImportQuery>,
+    mut multipart: Multipart,
+) -> Result<Json<Vec<ImportedAsset>>, (StatusCode, String)> {
+    let tmp = TempDir::new()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("tmpdir: {e}")))?;
+
+    let mut paths = Vec::new();
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("multipart: {e}")))?
+    {
+        // file_name() を String 化 (field consume 前に取得)
+        let filename = field
+            .file_name()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "uploaded.bin".to_string());
+
+        // パストラバーサル対策: basename のみ
+        let safe_name = std::path::Path::new(&filename)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("uploaded.bin")
+            .to_string();
+
+        let bytes = field
+            .bytes()
+            .await
+            .map_err(|e| (StatusCode::BAD_REQUEST, format!("read field: {e}")))?;
+
+        let path = tmp.path().join(&safe_name);
+        std::fs::write(&path, &bytes)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("write tmp: {e}")))?;
+        paths.push(path.to_string_lossy().to_string());
+    }
+
+    if paths.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "no files in multipart".to_string()));
+    }
+
+    let result = import_assets_impl(q.project_dir, paths)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    // tmp はここで Drop され、一時ファイルは削除される
+    drop(tmp);
+    Ok(Json(result))
+}
+
+async fn api_list_assets(
+    Query(q): Query<ListQuery>,
+) -> Result<Json<Vec<ImportedAsset>>, (StatusCode, String)> {
+    list_imported_assets_impl(q.project_dir)
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/api/assets/import", post(api_import_assets))
+        .route("/api/assets/list", get(api_list_assets))
+}

--- a/ars-editor/src-tauri/src/web_modules/mod.rs
+++ b/ars-editor/src-tauri/src/web_modules/mod.rs
@@ -1,2 +1,4 @@
 pub mod editor;
 pub mod module_manager;
+#[cfg(feature = "assets")]
+pub mod asset;

--- a/ars-editor/src-tauri/src/web_server.rs
+++ b/ars-editor/src-tauri/src/web_server.rs
@@ -45,6 +45,8 @@ pub async fn serve(addr: std::net::SocketAddr, static_dir: Option<String>) -> Re
 
     let editor_router = web_modules::editor::router(state.clone());
     let module_router = web_modules::module_manager::router(state);
+    #[cfg(feature = "assets")]
+    let asset_router = web_modules::asset::router();
 
     // コラボレーションWebSocketルート
     let collab_router = Router::new()
@@ -57,8 +59,10 @@ pub async fn serve(addr: std::net::SocketAddr, static_dir: Option<String>) -> Re
     let app = editor_router
         .merge(module_router)
         .merge(collab_router)
-        .merge(health_router)
-        .layer(cors);
+        .merge(health_router);
+    #[cfg(feature = "assets")]
+    let app = app.merge(asset_router);
+    let app = app.layer(cors);
 
     let app = if let Some(ref dir) = static_dir {
         let index_path = format!("{}/index.html", dir);

--- a/crates/ars-asset-importer/Cargo.toml
+++ b/crates/ars-asset-importer/Cargo.toml
@@ -18,5 +18,9 @@ meshopt = "0.6"
 byteorder = "1"
 chull = "0.2"
 
+[[bin]]
+name = "ars-import"
+path = "src/bin/ars-import.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ars-asset-importer/src/bin/ars-import.rs
+++ b/crates/ars-asset-importer/src/bin/ars-import.rs
@@ -1,0 +1,99 @@
+//! `ars-import` CLI (P6)
+//!
+//! ディレクトリを再帰探索し、`.glb` / `.gltf` を `<project_dir>/data/` 配下に
+//! インポートする。CI で「再生成しても diff ゼロ」を verify するために使う。
+//!
+//! ## 使い方
+//!
+//! ```bash
+//! cargo run -p ars-asset-importer --bin ars-import -- <project_dir> <src_dir>
+//! ```
+//!
+//! - `project_dir`: 出力先プロジェクト (`data/<id>/...` が生成される)
+//! - `src_dir`: 入力アセットディレクトリ (再帰探索)
+//!
+//! 既存の同一 source_hash アセットはキャッシュヒットでスキップ。
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use ars_asset_importer::process;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: ars-import <project_dir> <src_dir>");
+        return ExitCode::from(2);
+    }
+    let project_dir = PathBuf::from(&args[1]);
+    let src_dir = PathBuf::from(&args[2]);
+
+    if !project_dir.is_dir() {
+        eprintln!("project_dir does not exist: {}", project_dir.display());
+        return ExitCode::from(2);
+    }
+    if !src_dir.is_dir() {
+        eprintln!("src_dir does not exist: {}", src_dir.display());
+        return ExitCode::from(2);
+    }
+
+    let out_root = project_dir.join("data");
+    if let Err(e) = std::fs::create_dir_all(&out_root) {
+        eprintln!("failed to create {}: {e}", out_root.display());
+        return ExitCode::from(1);
+    }
+
+    let mut sources = Vec::new();
+    if let Err(e) = collect_sources(&src_dir, &mut sources) {
+        eprintln!("scan error: {e}");
+        return ExitCode::from(1);
+    }
+    sources.sort(); // 決定性: ファイル走査順を OS から独立化
+
+    let mut ok = 0u32;
+    let mut hit = 0u32;
+    let mut fail = 0u32;
+    for src in &sources {
+        match process(src, &out_root, None) {
+            Ok(o) => {
+                if o.cache_hit {
+                    hit += 1;
+                    println!("[hit ] {} ({})", src.display(), o.id);
+                } else {
+                    ok += 1;
+                    println!("[new ] {} ({})", src.display(), o.id);
+                }
+            }
+            Err(e) => {
+                fail += 1;
+                eprintln!("[fail] {}: {e}", src.display());
+            }
+        }
+    }
+
+    println!(
+        "summary: imported={ok}, cache_hit={hit}, failed={fail}, total_seen={}",
+        sources.len()
+    );
+    if fail > 0 {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn collect_sources(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.is_dir() {
+            collect_sources(&p, out)?;
+        } else if matches!(
+            p.extension().and_then(|e| e.to_str()).map(|s| s.to_ascii_lowercase()).as_deref(),
+            Some("glb") | Some("gltf")
+        ) {
+            out.push(p);
+        }
+    }
+    Ok(())
+}

--- a/crates/ars-asset-importer/src/obb.rs
+++ b/crates/ars-asset-importer/src/obb.rs
@@ -75,6 +75,9 @@ pub fn compute(points: &[Vec3]) -> Option<OrientedBox> {
 ///
 /// 戻り値: (固有ベクトル行列の行 = 各固有ベクトル, 固有値)
 /// 固有値の降順にソート。
+// Jacobi eigenvalue solver: 3x3 行列の固定 0..3 インデックスがアルゴリズム上自然なので
+// needless_range_loop を抑止する。
+#[allow(clippy::needless_range_loop)]
 fn jacobi_eigen(mut a: [[f32; 3]; 3]) -> ([[f32; 3]; 3], [f32; 3]) {
     // V = 単位行列から始め、回転を右から掛けて固有ベクトルを蓄積
     let mut v = [

--- a/crates/ars-asset-importer/src/pipeline.rs
+++ b/crates/ars-asset-importer/src/pipeline.rs
@@ -37,7 +37,7 @@ pub fn process(src: &Path, out_root: &Path, id: Option<AssetId>) -> Result<Proce
         .unwrap_or("bin")
         .to_ascii_lowercase();
 
-    let id = id.unwrap_or_else(AssetId::new);
+    let id = id.unwrap_or_default();
     let layout = CacheLayout::new(out_root, &id);
     let dir = layout.dir();
 

--- a/crates/ars-asset-importer/src/schema.rs
+++ b/crates/ars-asset-importer/src/schema.rs
@@ -35,6 +35,12 @@ impl AssetId {
     }
 }
 
+impl Default for AssetId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl std::fmt::Display for AssetId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)


### PR DESCRIPTION
Closes (partially) #92 — P6 フェーズ分。元 PR #97 が base 削除で close されたため再作成。

## Summary

### Web (Axum)
- `web_modules/asset.rs`: POST /api/assets/import (multipart) + GET /api/assets/list
- パストラバーサル対策: filename basename のみ採用

### CLI (`ars-import`)
- `crates/ars-asset-importer/src/bin/ars-import.rs`: 再帰インポート、ファイル走査順 sort で OS 非依存

### Feature 整理
- `assets = ["dep:ars-asset-importer"]` 新設、tauri-app/web-server 双方から enable

### Chore (clippy 解消)
- `obb::jacobi_eigen` に `#[allow(needless_range_loop)]` (3x3 固定 index は数学上自然)
- `schema::AssetId` に Default 実装、pipeline 側を unwrap_or_default に
- これで `cargo clippy --features web-server -- -D warnings` (CI 条件) pass

## Test plan
- [x] cargo test -p ars-asset-importer 25/25
- [x] cargo build --features web-server ... pass
- [x] cargo clippy --features web-server ... -D warnings pass

Refs: #92, 元PR #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)