### PR TITLE
feat(game-lexicon): ゲーム辞書フレーム + 9 ジャンル seed (仕様駆動)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ars-game-lexicon"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.2",
+]
+
+[[package]]
 name = "ars-mcp-server"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/ars-mcp-server",
     "crates/ars-data-organizer",
     "crates/ars-asset-importer",
+    "crates/ars-game-lexicon",
     "ars-editor/src-tauri",
 ]
 

--- a/crates/ars-game-lexicon/Cargo.toml
+++ b/crates/ars-game-lexicon/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ars-game-lexicon"
+version = "0.1.0"
+edition = "2021"
+description = "Ars game lexicon: spec-driven game terms / features / genres / presets"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+toml = "0.8"
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/ars-game-lexicon/README.md
+++ b/crates/ars-game-lexicon/README.md
@@ -1,0 +1,74 @@
+# ars-game-lexicon
+
+## 概要
+
+ゲーム制作の **用語 (Term)** ・ **機能 (Feature)** ・ **ジャンル (Genre)** ・ **プリセット (Preset)** を **仕様駆動 (spec-driven)** で集約するクレート。
+
+データは `spec/game-lexicon/` 配下の TOML を真とし、 このクレートはロード / 検証 / ID 引きを提供する。
+
+## ドメイン
+
+- **領域**: Ars エディタのウィザード / コード生成 / レベルデザイン支援
+- **用語**:
+  - `Genre`: ゲームジャンル (action / story-jrpg / open-world / shooter / runner / slg / rhythm / moba / fighting)
+  - `Feature`: 1 つのゲーム機能の抽象 (例: `health-system`, `combo-system`)
+  - `Preset`: ジャンルごとに既定で有効化する Feature 集合
+  - `Term`: ゲーム制作で出てくる用語の集合 (hitbox, hurtbox, iframe, ...)
+
+## 責務
+
+担う:
+- TOML のロード + マージ + 検証 (重複 ID / 参照整合性 / 循環依存)
+- ID 引きの API (`get_genre`, `get_feature`, `get_preset`, `get_term`)
+- Preset → Feature 集合への展開 (依存ソート)
+
+担わない:
+- ウィザード UI 自体 (ars-editor)
+- Feature の実装 (= ergo / unity / unreal プラグイン)
+- 永続化先の選定 (Layer 3 の責務)
+
+## 公開インタフェース
+
+```rust
+pub use ars_game_lexicon::{
+    Lexicon, Genre, Feature, Preset, Term,
+    GenreId, FeatureId, PresetId, TermId, TagId,
+    I18nName, FeatureParameter, ParameterType,
+    LexiconError, Result,
+    load_from_dir, GameLexiconRepository,
+};
+```
+
+## 依存関係
+
+| 依存 | 理由 |
+|------|------|
+| `serde` / `serde_json` | シリアライズ |
+| `toml` | TOML パース |
+| `thiserror` | エラー型 |
+| `async-trait` | Repository trait |
+
+ars-core には依存しない (このクレートは小さなドメイン辞書として完結する)。
+
+## 使用例
+
+```toml
+[dependencies]
+ars-game-lexicon = { path = "../ars-game-lexicon" }
+```
+
+```rust
+use ars_game_lexicon::{load_from_dir, PresetId};
+use std::path::Path;
+
+let lex = load_from_dir(Path::new("spec/game-lexicon"))?;
+let action_basic = lex.expand_preset(&PresetId::new("action-basic"))?;
+for feat in action_basic {
+    println!("{}: {}", feat.id, feat.summary);
+}
+```
+
+## 関連ドキュメント
+
+- モジュール仕様: [`spec/modules/game-lexicon.md`](../../spec/modules/game-lexicon.md)
+- データ形式: [`spec/game-lexicon/README.md`](../../spec/game-lexicon/README.md)

--- a/crates/ars-game-lexicon/src/domain.rs
+++ b/crates/ars-game-lexicon/src/domain.rs
@@ -1,0 +1,210 @@
+//! ドメイン型: Genre / Feature / Preset / Term + ID newtype
+//!
+//! Layer 1 — 純粋データ。 I/O や永続化を持たない。
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+macro_rules! id_newtype {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub String);
+
+        impl $name {
+            pub fn new(s: impl Into<String>) -> Self {
+                Self(s.into())
+            }
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(s.to_string())
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+id_newtype!(GenreId);
+id_newtype!(FeatureId);
+id_newtype!(PresetId);
+id_newtype!(TermId);
+id_newtype!(TagId);
+
+/// 日本語 / 英語の表示名ペア
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct I18nName {
+    pub ja: String,
+    pub en: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ParameterType {
+    Int,
+    Float,
+    Bool,
+    String,
+    /// `values` が必須
+    Enum,
+}
+
+/// Feature が宣言するパラメータ (ウィザード入力フォームを駆動する)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureParameter {
+    pub id: String,
+    pub kind: ParameterType,
+    /// JSON-like default (TOML から serde_json::Value にする)
+    #[serde(default)]
+    pub default: Option<serde_json::Value>,
+    #[serde(default)]
+    pub range: Option<(f64, f64)>,
+    #[serde(default)]
+    pub values: Vec<String>,
+    #[serde(default)]
+    pub description_ja: String,
+    #[serde(default)]
+    pub description_en: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Genre {
+    pub id: GenreId,
+    pub names: I18nName,
+    pub summary: String,
+    #[serde(default)]
+    pub tags: Vec<TagId>,
+    #[serde(default)]
+    pub default_preset: Option<PresetId>,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Feature {
+    pub id: FeatureId,
+    pub names: I18nName,
+    pub summary: String,
+    #[serde(default)]
+    pub tags: Vec<TagId>,
+    #[serde(default)]
+    pub genres: Vec<GenreId>,
+    #[serde(default)]
+    pub depends_on: Vec<FeatureId>,
+    #[serde(default)]
+    pub conflicts_with: Vec<FeatureId>,
+    #[serde(default)]
+    pub parameters: Vec<FeatureParameter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Preset {
+    pub id: PresetId,
+    pub names: I18nName,
+    pub genre: GenreId,
+    pub summary: String,
+    pub features: Vec<FeatureId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Term {
+    pub id: TermId,
+    pub names: I18nName,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub definition: String,
+    #[serde(default)]
+    pub tags: Vec<TagId>,
+    #[serde(default)]
+    pub related_terms: Vec<TermId>,
+}
+
+/// ロード結果の root。 ID 引きを提供する。
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Lexicon {
+    pub genres: Vec<Genre>,
+    pub features: Vec<Feature>,
+    pub presets: Vec<Preset>,
+    pub terms: Vec<Term>,
+}
+
+impl Lexicon {
+    pub fn get_genre(&self, id: &GenreId) -> Option<&Genre> {
+        self.genres.iter().find(|g| &g.id == id)
+    }
+    pub fn get_feature(&self, id: &FeatureId) -> Option<&Feature> {
+        self.features.iter().find(|f| &f.id == id)
+    }
+    pub fn get_preset(&self, id: &PresetId) -> Option<&Preset> {
+        self.presets.iter().find(|p| &p.id == id)
+    }
+    pub fn get_term(&self, id: &TermId) -> Option<&Term> {
+        self.terms.iter().find(|t| &t.id == id)
+    }
+
+    /// Preset を Feature 集合に展開 (depends_on を再帰的に解決)
+    ///
+    /// 戻り値は **依存ソート済み** (依存先が先に来る) の Feature 配列。
+    /// 循環や未知 ID は `LexiconError` で返される。
+    pub fn expand_preset(
+        &self,
+        preset_id: &PresetId,
+    ) -> crate::Result<Vec<&Feature>> {
+        let preset = self
+            .get_preset(preset_id)
+            .ok_or_else(|| crate::LexiconError::UnknownPreset(preset_id.clone()))?;
+
+        let mut order: Vec<FeatureId> = Vec::new();
+        let mut visiting: HashMap<FeatureId, bool> = HashMap::new();
+
+        for fid in &preset.features {
+            self.visit_feature(fid, &mut order, &mut visiting)?;
+        }
+
+        Ok(order
+            .into_iter()
+            .filter_map(|fid| self.get_feature(&fid))
+            .collect())
+    }
+
+    fn visit_feature(
+        &self,
+        fid: &FeatureId,
+        order: &mut Vec<FeatureId>,
+        visiting: &mut HashMap<FeatureId, bool>,
+    ) -> crate::Result<()> {
+        if let Some(&done) = visiting.get(fid) {
+            if !done {
+                return Err(crate::LexiconError::CircularDependency(fid.clone()));
+            }
+            return Ok(());
+        }
+        visiting.insert(fid.clone(), false);
+        let feat = self
+            .get_feature(fid)
+            .ok_or_else(|| crate::LexiconError::UnknownFeature(fid.clone()))?;
+        for dep in &feat.depends_on {
+            self.visit_feature(dep, order, visiting)?;
+        }
+        visiting.insert(fid.clone(), true);
+        if !order.iter().any(|x| x == fid) {
+            order.push(fid.clone());
+        }
+        Ok(())
+    }
+}

--- a/crates/ars-game-lexicon/src/error.rs
+++ b/crates/ars-game-lexicon/src/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+use crate::domain::{FeatureId, GenreId, PresetId, TermId};
+
+pub type Result<T> = std::result::Result<T, LexiconError>;
+
+#[derive(Debug, Error)]
+pub enum LexiconError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("toml parse error in {path}: {source}")]
+    TomlParse {
+        path: String,
+        #[source]
+        source: toml::de::Error,
+    },
+
+    #[error("duplicate id: {kind} '{id}'")]
+    DuplicateId { kind: &'static str, id: String },
+
+    #[error("unknown genre: {0}")]
+    UnknownGenre(GenreId),
+
+    #[error("unknown feature: {0}")]
+    UnknownFeature(FeatureId),
+
+    #[error("unknown preset: {0}")]
+    UnknownPreset(PresetId),
+
+    #[error("unknown term: {0}")]
+    UnknownTerm(TermId),
+
+    #[error("circular dependency at feature: {0}")]
+    CircularDependency(FeatureId),
+
+    #[error("invalid parameter range for '{0}': min must be <= max")]
+    InvalidRange(String),
+
+    #[error("enum parameter '{0}' has no `values`")]
+    EnumWithoutValues(String),
+
+    #[error("validation: {0}")]
+    Validation(String),
+}

--- a/crates/ars-game-lexicon/src/lib.rs
+++ b/crates/ars-game-lexicon/src/lib.rs
@@ -1,0 +1,35 @@
+//! ars-game-lexicon: ゲーム辞書モジュール
+//!
+//! ゲーム制作の用語 (Term) ・ 機能 (Feature) ・ ジャンル (Genre) ・
+//! プリセット (Preset) を **仕様駆動 (spec-driven)** で集約する。
+//!
+//! データは `spec/game-lexicon/` 配下の TOML を真とし、 このクレートは
+//! ロード / 検証 / ID 引きを提供する Layer 1 + Layer 2 (純粋ローダ)。
+//!
+//! ## アーキテクチャ
+//!
+//! ```text
+//! Layer 3 (App/Web): Tauri Commands / Axum Handlers が `Lexicon` を呼ぶ
+//!     │
+//!     ▼
+//! Layer 2 (loader, この crate): TOML をパース → 検証 → `Lexicon`
+//!     │
+//!     ▼
+//! Layer 1 (domain, この crate): Genre / Feature / Preset / Term の純粋型
+//! ```
+//!
+//! 設計原則は [`spec/modules/game-lexicon.md`](../../../spec/modules/game-lexicon.md)、
+//! TOML スキーマは [`spec/game-lexicon/README.md`](../../../spec/game-lexicon/README.md)。
+
+pub mod domain;
+pub mod error;
+pub mod loader;
+pub mod repository;
+
+pub use domain::{
+    Feature, FeatureId, FeatureParameter, Genre, GenreId, I18nName, Lexicon, ParameterType,
+    Preset, PresetId, TagId, Term, TermId,
+};
+pub use error::{LexiconError, Result};
+pub use loader::load_from_dir;
+pub use repository::GameLexiconRepository;

--- a/crates/ars-game-lexicon/src/loader.rs
+++ b/crates/ars-game-lexicon/src/loader.rs
@@ -1,0 +1,412 @@
+//! TOML ローダ
+//!
+//! `spec/game-lexicon/` 配下のディレクトリを再帰的に読み、
+//! `Lexicon` を構築 + 検証する純粋関数。 I/O 以外の状態を持たない。
+
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::domain::{
+    Feature, FeatureId, FeatureParameter, Genre, GenreId, I18nName, Lexicon, ParameterType,
+    Preset, PresetId, TagId, Term, TermId,
+};
+use crate::error::{LexiconError, Result};
+
+// ── 中間 (TOML 形) 型 ─────────────────────────
+//
+// TOML 側はフラットなフィールド名 (`name_ja` / `name_en`) なので、
+// 一度 raw 構造体で受けてからドメインに変換する。
+
+#[derive(Debug, Deserialize)]
+struct RawGenre {
+    id: String,
+    name_ja: String,
+    name_en: String,
+    summary: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    default_preset: Option<String>,
+    #[serde(default)]
+    description: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFeature {
+    id: String,
+    name_ja: String,
+    name_en: String,
+    summary: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    genres: Vec<String>,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    #[serde(default)]
+    conflicts_with: Vec<String>,
+    #[serde(default, rename = "parameter")]
+    parameters: Vec<RawParameter>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawParameter {
+    id: String,
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    default: Option<toml::Value>,
+    #[serde(default)]
+    range: Option<(f64, f64)>,
+    #[serde(default)]
+    values: Vec<String>,
+    #[serde(default)]
+    description_ja: String,
+    #[serde(default)]
+    description_en: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPreset {
+    id: String,
+    name_ja: String,
+    name_en: String,
+    genre: String,
+    summary: String,
+    features: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTermsFile {
+    #[serde(default, rename = "term")]
+    terms: Vec<RawTerm>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTerm {
+    id: String,
+    name_ja: String,
+    name_en: String,
+    #[serde(default)]
+    aliases: Vec<String>,
+    definition: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    related_terms: Vec<String>,
+}
+
+// ── パブリック API ────────────────────────────
+
+/// `<root>/{genres,features,presets,terms}` を走査して `Lexicon` を構築する。
+pub fn load_from_dir(root: &Path) -> Result<Lexicon> {
+    let genres_dir = root.join("genres");
+    let features_dir = root.join("features");
+    let presets_dir = root.join("presets");
+    let terms_dir = root.join("terms");
+
+    let mut lexicon = Lexicon::default();
+
+    // genres
+    for path in toml_files_in(&genres_dir)? {
+        let raw: RawGenre = parse_toml(&path)?;
+        lexicon.genres.push(Genre {
+            id: GenreId::new(raw.id),
+            names: I18nName {
+                ja: raw.name_ja,
+                en: raw.name_en,
+            },
+            summary: raw.summary,
+            tags: raw.tags.into_iter().map(TagId::new).collect(),
+            default_preset: raw.default_preset.map(PresetId::new),
+            description: raw.description,
+        });
+    }
+
+    // features (ネストしたサブディレクトリを再帰)
+    for path in toml_files_in_recursive(&features_dir)? {
+        let raw: RawFeature = parse_toml(&path)?;
+        let parameters = raw
+            .parameters
+            .into_iter()
+            .map(|p| convert_parameter(&path, p))
+            .collect::<Result<Vec<_>>>()?;
+        lexicon.features.push(Feature {
+            id: FeatureId::new(raw.id),
+            names: I18nName {
+                ja: raw.name_ja,
+                en: raw.name_en,
+            },
+            summary: raw.summary,
+            tags: raw.tags.into_iter().map(TagId::new).collect(),
+            genres: raw.genres.into_iter().map(GenreId::new).collect(),
+            depends_on: raw.depends_on.into_iter().map(FeatureId::new).collect(),
+            conflicts_with: raw.conflicts_with.into_iter().map(FeatureId::new).collect(),
+            parameters,
+        });
+    }
+
+    // presets
+    for path in toml_files_in(&presets_dir)? {
+        let raw: RawPreset = parse_toml(&path)?;
+        lexicon.presets.push(Preset {
+            id: PresetId::new(raw.id),
+            names: I18nName {
+                ja: raw.name_ja,
+                en: raw.name_en,
+            },
+            genre: GenreId::new(raw.genre),
+            summary: raw.summary,
+            features: raw.features.into_iter().map(FeatureId::new).collect(),
+        });
+    }
+
+    // terms (1 ファイルに `[[term]]` 複数)
+    for path in toml_files_in(&terms_dir)? {
+        let raw: RawTermsFile = parse_toml(&path)?;
+        for t in raw.terms {
+            lexicon.terms.push(Term {
+                id: TermId::new(t.id),
+                names: I18nName {
+                    ja: t.name_ja,
+                    en: t.name_en,
+                },
+                aliases: t.aliases,
+                definition: t.definition,
+                tags: t.tags.into_iter().map(TagId::new).collect(),
+                related_terms: t.related_terms.into_iter().map(TermId::new).collect(),
+            });
+        }
+    }
+
+    validate(&lexicon)?;
+    Ok(lexicon)
+}
+
+// ── 内部ヘルパ ────────────────────────────────
+
+fn parse_toml<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let text = fs::read_to_string(path)?;
+    toml::from_str(&text).map_err(|source| LexiconError::TomlParse {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+fn toml_files_in(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn toml_files_in_recursive(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in fs::read_dir(&d)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn convert_parameter(path: &Path, p: RawParameter) -> Result<FeatureParameter> {
+    let kind = match p.kind.as_str() {
+        "int" => ParameterType::Int,
+        "float" => ParameterType::Float,
+        "bool" => ParameterType::Bool,
+        "string" => ParameterType::String,
+        "enum" => ParameterType::Enum,
+        other => {
+            return Err(LexiconError::Validation(format!(
+                "{}: unknown parameter type '{}' (id={})",
+                path.display(),
+                other,
+                p.id
+            )))
+        }
+    };
+    if matches!(kind, ParameterType::Enum) && p.values.is_empty() {
+        return Err(LexiconError::EnumWithoutValues(p.id.clone()));
+    }
+    if let Some((lo, hi)) = p.range {
+        if lo > hi {
+            return Err(LexiconError::InvalidRange(p.id.clone()));
+        }
+    }
+    let default = p.default.map(toml_to_json);
+    Ok(FeatureParameter {
+        id: p.id,
+        kind,
+        default,
+        range: p.range,
+        values: p.values,
+        description_ja: p.description_ja,
+        description_en: p.description_en,
+    })
+}
+
+fn toml_to_json(v: toml::Value) -> serde_json::Value {
+    match v {
+        toml::Value::String(s) => serde_json::Value::String(s),
+        toml::Value::Integer(i) => serde_json::Value::Number(i.into()),
+        toml::Value::Float(f) => serde_json::Number::from_f64(f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        toml::Value::Boolean(b) => serde_json::Value::Bool(b),
+        toml::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(toml_to_json).collect())
+        }
+        toml::Value::Table(t) => serde_json::Value::Object(
+            t.into_iter().map(|(k, v)| (k, toml_to_json(v))).collect(),
+        ),
+        toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
+    }
+}
+
+// ── 検証 ──────────────────────────────────────
+
+fn validate(lex: &Lexicon) -> Result<()> {
+    // V01: 重複 ID
+    check_unique(lex.genres.iter().map(|g| g.id.as_str()), "genre")?;
+    check_unique(lex.features.iter().map(|f| f.id.as_str()), "feature")?;
+    check_unique(lex.presets.iter().map(|p| p.id.as_str()), "preset")?;
+    check_unique(lex.terms.iter().map(|t| t.id.as_str()), "term")?;
+
+    // V02: 参照整合性
+    let genre_ids: HashSet<&str> =
+        lex.genres.iter().map(|g| g.id.as_str()).collect();
+    let feature_ids: HashSet<&str> =
+        lex.features.iter().map(|f| f.id.as_str()).collect();
+    let preset_ids: HashSet<&str> =
+        lex.presets.iter().map(|p| p.id.as_str()).collect();
+    let term_ids: HashSet<&str> = lex.terms.iter().map(|t| t.id.as_str()).collect();
+
+    for g in &lex.genres {
+        if let Some(p) = &g.default_preset {
+            if !preset_ids.contains(p.as_str()) {
+                return Err(LexiconError::UnknownPreset(p.clone()));
+            }
+        }
+    }
+    for f in &lex.features {
+        for gid in &f.genres {
+            if !genre_ids.contains(gid.as_str()) {
+                return Err(LexiconError::UnknownGenre(gid.clone()));
+            }
+        }
+        for dep in &f.depends_on {
+            if !feature_ids.contains(dep.as_str()) {
+                return Err(LexiconError::UnknownFeature(dep.clone()));
+            }
+        }
+        for c in &f.conflicts_with {
+            if !feature_ids.contains(c.as_str()) {
+                return Err(LexiconError::UnknownFeature(c.clone()));
+            }
+        }
+    }
+    for p in &lex.presets {
+        if !genre_ids.contains(p.genre.as_str()) {
+            return Err(LexiconError::UnknownGenre(p.genre.clone()));
+        }
+        for fid in &p.features {
+            if !feature_ids.contains(fid.as_str()) {
+                return Err(LexiconError::UnknownFeature(fid.clone()));
+            }
+        }
+    }
+    for t in &lex.terms {
+        for r in &t.related_terms {
+            if !term_ids.contains(r.as_str()) {
+                return Err(LexiconError::UnknownTerm(r.clone()));
+            }
+        }
+    }
+
+    // V03: 循環依存 — Lexicon::expand_preset と同じ DFS で全 preset を試す
+    for p in &lex.presets {
+        let _ = lex.expand_preset(&p.id)?;
+    }
+
+    Ok(())
+}
+
+fn check_unique<'a>(
+    iter: impl IntoIterator<Item = &'a str>,
+    kind: &'static str,
+) -> Result<()> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    for id in iter {
+        if !seen.insert(id) {
+            return Err(LexiconError::DuplicateId {
+                kind,
+                id: id.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+// ── tests ─────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 同梱 `spec/game-lexicon/` をロードできること
+    #[test]
+    fn load_builtin_seed() {
+        // crates/ars-game-lexicon/ から見て `../../spec/game-lexicon`
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let root = Path::new(manifest).join("../../spec/game-lexicon");
+        let lex = load_from_dir(&root).expect("load builtin");
+
+        // 期待: 9 ジャンル / 9 プリセット / Feature 多数 / 用語多数
+        assert_eq!(lex.genres.len(), 9, "9 genres expected");
+        assert_eq!(lex.presets.len(), 9, "9 presets expected");
+        assert!(lex.features.len() >= 30, "≥30 features");
+        assert!(lex.terms.len() >= 10, "≥10 terms");
+
+        // 既定プリセットが解決できる
+        for g in &lex.genres {
+            let p = g
+                .default_preset
+                .as_ref()
+                .expect("each genre has default_preset");
+            assert!(lex.get_preset(p).is_some(), "preset {p} found");
+        }
+
+        // action-basic を expand できる
+        let expanded = lex
+            .expand_preset(&PresetId::new("action-basic"))
+            .expect("expand action-basic");
+        let ids: Vec<&str> = expanded.iter().map(|f| f.id.as_str()).collect();
+        // 依存は順序的に被依存より前にいる
+        let pos_ib = ids.iter().position(|s| *s == "input-buffer").unwrap();
+        let pos_combo = ids.iter().position(|s| *s == "combo-system").unwrap();
+        assert!(pos_ib < pos_combo, "input-buffer before combo-system");
+    }
+}

--- a/crates/ars-game-lexicon/src/repository.rs
+++ b/crates/ars-game-lexicon/src/repository.rs
@@ -1,0 +1,21 @@
+//! `GameLexiconRepository` trait
+//!
+//! Layer 2 の use case (将来追加) はこの trait 越しにロード / 保存する。
+//! Layer 3 (App / Web) で具体実装を注入する。
+
+use async_trait::async_trait;
+
+use crate::domain::Lexicon;
+use crate::error::Result;
+
+#[async_trait]
+pub trait GameLexiconRepository: Send + Sync {
+    /// 組込みデータ (`spec/game-lexicon/` に同梱) をロード
+    async fn load_builtin(&self) -> Result<Lexicon>;
+
+    /// プロジェクト固有のオーバーレイをロード (未指定なら空 Lexicon)
+    async fn load_project_overlay(&self, project_id: &str) -> Result<Lexicon>;
+
+    /// プロジェクト固有のオーバーレイを保存
+    async fn save_project_overlay(&self, project_id: &str, overlay: &Lexicon) -> Result<()>;
+}

--- a/spec/game-lexicon/README.md
+++ b/spec/game-lexicon/README.md
@@ -1,0 +1,174 @@
+# spec/game-lexicon/ — ゲーム辞書のデータソース
+
+ここはゲーム制作の **用語 (Term)** ・ **機能 (Feature)** ・ **ジャンル (Genre)** ・ **プリセット (Preset)** を **TOML ファイル** で集約する場所。
+
+`crates/ars-game-lexicon` がここを **唯一の真実 (single source of truth)** として読む。 Rust コードに辞書を埋め込まない。
+
+## 0. ファイル配置
+
+```
+spec/game-lexicon/
+├── README.md                    # このファイル (データ形式)
+├── genres/                      # ジャンル定義
+│   ├── action.toml
+│   ├── story-jrpg.toml
+│   ├── open-world.toml
+│   ├── shooter.toml
+│   ├── runner.toml
+│   ├── slg.toml
+│   ├── rhythm.toml
+│   ├── moba.toml
+│   └── fighting.toml
+├── features/                    # 機能定義 (1 機能 = 1 ファイル)
+│   ├── core/                    # ジャンル横断
+│   │   ├── health.toml
+│   │   ├── input.toml
+│   │   └── ...
+│   ├── action/
+│   ├── story-jrpg/
+│   ├── ...
+│   └── fighting/
+├── presets/                     # ジャンル別プリセット
+│   ├── action-basic.toml
+│   ├── story-jrpg-basic.toml
+│   └── ...
+└── terms/                       # 用語集
+    ├── combat.toml
+    ├── progression.toml
+    └── ui.toml
+```
+
+ファイル名は **kebab-case** を推奨。 ID と一致しなくてもよいが揃えると探しやすい。
+
+## 1. 共通フィールド
+
+すべての TOML ファイルは以下の規約に従う:
+
+- `id`: snake_case の ASCII。 ファイル全域で一意。 後段の参照キーになるため変えない。
+- `name_ja` / `name_en`: 表示名。 必ず両方書く (`I18nName` は Rust 側で `{ ja, en }` 構造体)。
+- `summary`: 1〜2 文の説明 (UI のツールチップ用)。
+- `tags`: タグ ID の配列 (検索 / 分類用)。
+
+## 2. genres/<id>.toml
+
+```toml
+id = "action"
+name_ja = "アクション"
+name_en = "Action"
+summary = "リアルタイム戦闘を中心とした 3D / 2D のアクションゲーム"
+tags = ["realtime", "combat"]
+
+# 既定プリセット (任意)
+default_preset = "action-basic"
+
+# 説明文 (UI で展開表示する用、 Markdown 可)
+description = """
+プレイヤー操作 → 攻撃判定 → ヒット応答 のサイクルが核。
+カメラと当たり判定が重要。
+"""
+```
+
+## 3. features/<group>/<id>.toml
+
+```toml
+id = "combo-system"
+name_ja = "コンボシステム"
+name_en = "Combo System"
+summary = "連続入力で技をつなげる仕組み"
+tags = ["combat", "input"]
+
+# このフィーチャーが想定するジャンル
+genres = ["action", "fighting"]
+
+# 依存 / 競合 (id 配列)
+depends_on = ["input-buffer", "hitbox-system"]
+conflicts_with = []
+
+# パラメータ宣言 (ウィザードが入力 UI を出す)
+[[parameter]]
+id = "max_combo"
+type = "int"
+default = 8
+range = [1, 99]
+description_ja = "最大コンボ段数"
+
+[[parameter]]
+id = "buffer_window_ms"
+type = "int"
+default = 200
+range = [50, 1000]
+description_ja = "次入力を受け付ける時間 (ms)"
+```
+
+`type` は `int | float | bool | string | enum`。 `enum` のときは `values = [...]` を追加する。
+
+## 4. presets/<id>.toml
+
+```toml
+id = "action-basic"
+name_ja = "アクション (基本)"
+name_en = "Action (basic)"
+genre = "action"
+summary = "アクションゲームの最小構成"
+
+# 含める Feature の id 配列。 順序は assemble 順を意図 (依存逆順は loader が検出)
+features = [
+  "input-buffer",
+  "hitbox-system",
+  "health-system",
+  "combo-system",
+  "dodge-roll",
+]
+```
+
+## 5. terms/<group>.toml
+
+1 ファイルに複数の用語を `[[term]]` で並べる:
+
+```toml
+[[term]]
+id = "hitbox"
+name_ja = "ヒットボックス"
+name_en = "Hitbox"
+aliases = ["当たり判定", "コリジョン"]
+definition = "攻撃や被弾を判定する形状。 多くの場合、 表示モデルとは別の簡易形状を持つ"
+tags = ["combat"]
+related_terms = ["hurtbox", "iframe"]
+
+[[term]]
+id = "hurtbox"
+name_ja = "ハートボックス"
+name_en = "Hurtbox"
+aliases = ["被弾判定"]
+definition = "敵 / 自キャラがダメージを受ける範囲"
+tags = ["combat"]
+related_terms = ["hitbox"]
+```
+
+## 6. 検証ルール (loader が落とす)
+
+| ID | 検証 |
+|----|------|
+| V01 | `id` の重複 (同 kind 内) |
+| V02 | `genres / depends_on / conflicts_with / features / related_terms` で参照する ID が存在する |
+| V03 | `depends_on` の循環 |
+| V04 | `parameter.range` の `[min, max]` で min <= max |
+| V05 | `parameter.type = "enum"` のとき `values` 必須 |
+| V06 | `name_ja` / `name_en` / `summary` の空白 (どれか欠けたら警告) |
+
+## 7. 拡張ガイド
+
+新ジャンルを追加する手順:
+
+1. `genres/<id>.toml` を作る
+2. `features/<id>/` に最低 3 機能を作る (このジャンル特有のもの)
+3. 既に `features/core/` にある汎用機能を `genres = [...]` に追加する (例: `health-system` は多くのジャンルが使う)
+4. `presets/<id>-basic.toml` を作る
+5. `terms/` に必要なら追記
+6. `cargo test -p ars-game-lexicon` で loader が通ることを確認
+
+## 8. このフォーマットの非ゴール
+
+- バージョニング — 今は最新形を 1 つだけ持つ。 互換性破壊が必要になったら別ディレクトリで v2/ を切る
+- 翻訳テーブルの完全管理 — `name_ja` / `name_en` の 2 言語に絞る。 多言語化は別レイヤー
+- 実装コード — Feature の **実装** は ergo / unity / unreal プラグイン側。 ここは仕様だけ

--- a/spec/game-lexicon/features/action/camera-follow.toml
+++ b/spec/game-lexicon/features/action/camera-follow.toml
@@ -1,0 +1,21 @@
+id = "camera-follow"
+name_ja = "追従カメラ"
+name_en = "Camera Follow"
+summary = "プレイヤーを追従するカメラ。 ヒット時の小揺れもここで扱う"
+tags = ["camera"]
+genres = ["action", "shooter", "open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "smoothing"
+type = "float"
+default = 0.15
+range = [0.0, 1.0]
+description_ja = "追従の遅延係数 (0=即時、 1=動かない)"
+
+[[parameter]]
+id = "shake_on_hit"
+type = "bool"
+default = true
+description_ja = "ヒット時にカメラを揺らす"

--- a/spec/game-lexicon/features/action/combo-system.toml
+++ b/spec/game-lexicon/features/action/combo-system.toml
@@ -1,0 +1,22 @@
+id = "combo-system"
+name_ja = "コンボシステム"
+name_en = "Combo System"
+summary = "連続入力で技をつなげる仕組み"
+tags = ["combat", "input"]
+genres = ["action", "fighting"]
+depends_on = ["input-buffer", "hitbox-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "max_combo"
+type = "int"
+default = 8
+range = [1, 99]
+description_ja = "最大コンボ段数"
+
+[[parameter]]
+id = "cancel_window_ms"
+type = "int"
+default = 200
+range = [16, 1000]
+description_ja = "次入力を受け付ける時間 (ms)"

--- a/spec/game-lexicon/features/action/dodge-roll.toml
+++ b/spec/game-lexicon/features/action/dodge-roll.toml
@@ -1,0 +1,29 @@
+id = "dodge-roll"
+name_ja = "回避 (ローリング)"
+name_en = "Dodge Roll"
+summary = "短時間の i-frame を伴う緊急回避動作"
+tags = ["combat", "movement"]
+genres = ["action"]
+depends_on = ["input-buffer"]
+conflicts_with = []
+
+[[parameter]]
+id = "iframe_ms"
+type = "int"
+default = 400
+range = [50, 2000]
+description_ja = "無敵時間 (ms)"
+
+[[parameter]]
+id = "cooldown_ms"
+type = "int"
+default = 600
+range = [0, 5000]
+description_ja = "次回避まで待つ時間 (ms)"
+
+[[parameter]]
+id = "stamina_cost"
+type = "int"
+default = 25
+range = [0, 1000]
+description_ja = "スタミナ消費量"

--- a/spec/game-lexicon/features/action/hitstop.toml
+++ b/spec/game-lexicon/features/action/hitstop.toml
@@ -1,0 +1,21 @@
+id = "hitstop"
+name_ja = "ヒットストップ"
+name_en = "Hitstop"
+summary = "命中の瞬間に時間を止め、 打撃感を強調する演出"
+tags = ["combat", "feel"]
+genres = ["action", "fighting"]
+depends_on = ["hitbox-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "duration_ms"
+type = "int"
+default = 80
+range = [0, 500]
+description_ja = "停止時間 (ms)"
+
+[[parameter]]
+id = "scale_with_damage"
+type = "bool"
+default = true
+description_ja = "ダメージに応じて長さを変える"

--- a/spec/game-lexicon/features/core/health-system.toml
+++ b/spec/game-lexicon/features/core/health-system.toml
@@ -1,0 +1,28 @@
+id = "health-system"
+name_ja = "体力システム"
+name_en = "Health System"
+summary = "HP の減少 / 回復 / 死亡判定を扱う基礎機能"
+tags = ["combat", "stats"]
+genres = ["action", "story-jrpg", "open-world", "shooter", "moba", "fighting"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "max_hp"
+type = "int"
+default = 100
+range = [1, 99999]
+description_ja = "最大 HP の既定値"
+
+[[parameter]]
+id = "regen_per_second"
+type = "float"
+default = 0.0
+range = [0.0, 100.0]
+description_ja = "毎秒自動回復量 (0 で無効)"
+
+[[parameter]]
+id = "death_event"
+type = "bool"
+default = true
+description_ja = "HP=0 で death イベントを発火するか"

--- a/spec/game-lexicon/features/core/hitbox-system.toml
+++ b/spec/game-lexicon/features/core/hitbox-system.toml
@@ -1,0 +1,21 @@
+id = "hitbox-system"
+name_ja = "ヒットボックスシステム"
+name_en = "Hitbox System"
+summary = "攻撃判定 (hitbox) と被弾判定 (hurtbox) の交差検査"
+tags = ["combat", "physics"]
+genres = ["action", "shooter", "moba", "fighting"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "broadphase"
+type = "enum"
+default = "aabb"
+values = ["aabb", "sphere", "obb"]
+description_ja = "粗判定形状"
+
+[[parameter]]
+id = "damage_event"
+type = "bool"
+default = true
+description_ja = "交差時 damage イベントを発火する"

--- a/spec/game-lexicon/features/core/input-buffer.toml
+++ b/spec/game-lexicon/features/core/input-buffer.toml
@@ -1,0 +1,15 @@
+id = "input-buffer"
+name_ja = "入力バッファ"
+name_en = "Input Buffer"
+summary = "ボタン入力を一定時間保持して次アクションに引き継ぐ仕組み"
+tags = ["input"]
+genres = ["action", "shooter", "rhythm", "moba", "fighting"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "window_ms"
+type = "int"
+default = 200
+range = [16, 1000]
+description_ja = "入力受け付け時間 (ms)"

--- a/spec/game-lexicon/features/core/inventory.toml
+++ b/spec/game-lexicon/features/core/inventory.toml
@@ -1,0 +1,22 @@
+id = "inventory"
+name_ja = "インベントリ"
+name_en = "Inventory"
+summary = "アイテム所持と使用 / 装備の基本"
+tags = ["items", "ui"]
+genres = ["story-jrpg", "open-world", "shooter", "slg"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "max_slots"
+type = "int"
+default = 32
+range = [1, 9999]
+description_ja = "持てるスロット数 (0 = 重量制)"
+
+[[parameter]]
+id = "stack_limit"
+type = "int"
+default = 99
+range = [1, 99999]
+description_ja = "1 スロットあたりの重ね数上限"

--- a/spec/game-lexicon/features/core/save-load.toml
+++ b/spec/game-lexicon/features/core/save-load.toml
@@ -1,0 +1,22 @@
+id = "save-load"
+name_ja = "セーブ/ロード"
+name_en = "Save/Load"
+summary = "プレイヤー進行度の永続化と復元"
+tags = ["persistence"]
+genres = ["story-jrpg", "open-world", "slg"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "slot_count"
+type = "int"
+default = 8
+range = [1, 999]
+description_ja = "セーブスロット数"
+
+[[parameter]]
+id = "autosave_interval_sec"
+type = "int"
+default = 0
+range = [0, 3600]
+description_ja = "オートセーブ間隔 (秒、 0 で無効)"

--- a/spec/game-lexicon/features/core/score-system.toml
+++ b/spec/game-lexicon/features/core/score-system.toml
@@ -1,0 +1,20 @@
+id = "score-system"
+name_ja = "スコアシステム"
+name_en = "Score System"
+summary = "ゲーム内行為に応じてポイントを加算 / 表示する仕組み"
+tags = ["progression", "ui"]
+genres = ["shooter", "runner", "rhythm", "fighting"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "high_score_persist"
+type = "bool"
+default = true
+description_ja = "ハイスコアをローカル保存する"
+
+[[parameter]]
+id = "combo_multiplier"
+type = "bool"
+default = true
+description_ja = "コンボ倍率を掛けるか"

--- a/spec/game-lexicon/features/fighting/command-input.toml
+++ b/spec/game-lexicon/features/fighting/command-input.toml
@@ -1,0 +1,21 @@
+id = "command-input"
+name_ja = "コマンド入力"
+name_en = "Command Input"
+summary = "→↓↘+P のような方向 + ボタン列で技を出す入力解釈"
+tags = ["input", "combat"]
+genres = ["fighting"]
+depends_on = ["input-buffer"]
+conflicts_with = []
+
+[[parameter]]
+id = "max_motion_window_ms"
+type = "int"
+default = 400
+range = [50, 2000]
+description_ja = "コマンド成立とみなす最長時間 (ms)"
+
+[[parameter]]
+id = "shortcut_inputs"
+type = "bool"
+default = true
+description_ja = "短縮入力 (例: 623P → 23P) を許可"

--- a/spec/game-lexicon/features/fighting/frame-data.toml
+++ b/spec/game-lexicon/features/fighting/frame-data.toml
@@ -1,0 +1,21 @@
+id = "frame-data"
+name_ja = "フレームデータ"
+name_en = "Frame Data"
+summary = "技ごとに startup / active / recovery / hit-stun / block-stun を持たせる"
+tags = ["combat", "frame"]
+genres = ["fighting"]
+depends_on = ["hitbox-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "fps_lock"
+type = "int"
+default = 60
+range = [30, 240]
+description_ja = "ロックする内部フレームレート"
+
+[[parameter]]
+id = "expose_to_ui"
+type = "bool"
+default = false
+description_ja = "デバッグ UI にフレームを表示する"

--- a/spec/game-lexicon/features/fighting/guard-throw.toml
+++ b/spec/game-lexicon/features/fighting/guard-throw.toml
@@ -1,0 +1,21 @@
+id = "guard-throw"
+name_ja = "ガード / 投げ"
+name_en = "Guard / Throw"
+summary = "通常攻撃 / 投げ / ガードの三すくみと投げ抜けの解決"
+tags = ["combat", "interaction"]
+genres = ["fighting"]
+depends_on = ["frame-data"]
+conflicts_with = []
+
+[[parameter]]
+id = "throw_break_window_ms"
+type = "int"
+default = 100
+range = [16, 1000]
+description_ja = "投げ抜けの受付時間 (ms)"
+
+[[parameter]]
+id = "guard_chip_damage"
+type = "bool"
+default = true
+description_ja = "ガード時に削りダメージを与える"

--- a/spec/game-lexicon/features/fighting/round-system.toml
+++ b/spec/game-lexicon/features/fighting/round-system.toml
@@ -1,0 +1,22 @@
+id = "round-system"
+name_ja = "ラウンド制"
+name_en = "Round System"
+summary = "1 試合を複数ラウンドに分け、 先取で勝者を決める"
+tags = ["match-flow"]
+genres = ["fighting"]
+depends_on = ["health-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "rounds_to_win"
+type = "int"
+default = 2
+range = [1, 9]
+description_ja = "勝利に必要な先取数"
+
+[[parameter]]
+id = "time_limit_sec"
+type = "int"
+default = 99
+range = [1, 999]
+description_ja = "ラウンド時間 (秒)"

--- a/spec/game-lexicon/features/moba/hero-skill.toml
+++ b/spec/game-lexicon/features/moba/hero-skill.toml
@@ -1,0 +1,22 @@
+id = "hero-skill"
+name_ja = "ヒーロースキル"
+name_en = "Hero Skill"
+summary = "ヒーロー (キャラ) ごとに固有の Q/W/E/R 等のスキルセット"
+tags = ["combat", "ability"]
+genres = ["moba", "action"]
+depends_on = ["input-buffer", "stat-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "slot_count"
+type = "int"
+default = 4
+range = [1, 16]
+description_ja = "1 ヒーローのスキルスロット数"
+
+[[parameter]]
+id = "ultimate_unlock_level"
+type = "int"
+default = 6
+range = [1, 99]
+description_ja = "アルティメット解禁レベル"

--- a/spec/game-lexicon/features/moba/minion-wave.toml
+++ b/spec/game-lexicon/features/moba/minion-wave.toml
@@ -1,0 +1,22 @@
+id = "minion-wave"
+name_ja = "ミニオンウェーブ"
+name_en = "Minion Wave"
+summary = "一定間隔でレーンに送り出されるミニオンの群れ"
+tags = ["pve", "wave"]
+genres = ["moba"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "wave_interval_sec"
+type = "float"
+default = 30.0
+range = [1.0, 600.0]
+description_ja = "ウェーブ間隔 (秒)"
+
+[[parameter]]
+id = "minions_per_wave"
+type = "int"
+default = 6
+range = [1, 99]
+description_ja = "1 ウェーブあたりのミニオン数"

--- a/spec/game-lexicon/features/moba/rollback-netcode.toml
+++ b/spec/game-lexicon/features/moba/rollback-netcode.toml
@@ -1,0 +1,22 @@
+id = "rollback-netcode"
+name_ja = "ロールバックネットコード"
+name_en = "Rollback Netcode"
+summary = "対戦中の入力遅延を予測 / 巻き戻し再シミュレーションで隠蔽するネットワーク方式"
+tags = ["network", "competitive"]
+genres = ["moba", "fighting"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "max_rollback_frames"
+type = "int"
+default = 7
+range = [1, 60]
+description_ja = "最大巻き戻しフレーム数"
+
+[[parameter]]
+id = "input_delay_frames"
+type = "int"
+default = 2
+range = [0, 30]
+description_ja = "入力遅延フレーム数"

--- a/spec/game-lexicon/features/moba/tower-objective.toml
+++ b/spec/game-lexicon/features/moba/tower-objective.toml
@@ -1,0 +1,21 @@
+id = "tower-objective"
+name_ja = "タワー / オブジェクト"
+name_en = "Tower / Objective"
+summary = "破壊することで盤面が前進する固定建造物 / マップ目標"
+tags = ["objective", "map"]
+genres = ["moba"]
+depends_on = ["health-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "tower_per_lane"
+type = "int"
+default = 3
+range = [0, 10]
+description_ja = "1 レーンあたりのタワー数"
+
+[[parameter]]
+id = "ranged_attack"
+type = "bool"
+default = true
+description_ja = "タワーが射撃で反撃する"

--- a/spec/game-lexicon/features/open-world/day-night-cycle.toml
+++ b/spec/game-lexicon/features/open-world/day-night-cycle.toml
@@ -1,0 +1,21 @@
+id = "day-night-cycle"
+name_ja = "昼夜サイクル"
+name_en = "Day/Night Cycle"
+summary = "ゲーム内時刻と太陽 / 月の位置 / ライティングを連動させる"
+tags = ["world", "lighting"]
+genres = ["open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "day_length_minutes"
+type = "int"
+default = 24
+range = [1, 1440]
+description_ja = "1 日 (=24h) の実時間長 (分)"
+
+[[parameter]]
+id = "season_support"
+type = "bool"
+default = false
+description_ja = "季節サイクルもサポートする"

--- a/spec/game-lexicon/features/open-world/fast-travel.toml
+++ b/spec/game-lexicon/features/open-world/fast-travel.toml
@@ -1,0 +1,20 @@
+id = "fast-travel"
+name_ja = "ファストトラベル"
+name_en = "Fast Travel"
+summary = "発見済み地点へ即時に移動できる仕組み"
+tags = ["movement", "ui"]
+genres = ["open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "require_discovered"
+type = "bool"
+default = true
+description_ja = "未発見地点には飛べない"
+
+[[parameter]]
+id = "cost_resource"
+type = "string"
+default = ""
+description_ja = "消費するリソース ID (空で無料)"

--- a/spec/game-lexicon/features/open-world/mount-system.toml
+++ b/spec/game-lexicon/features/open-world/mount-system.toml
@@ -1,0 +1,21 @@
+id = "mount-system"
+name_ja = "騎乗 / 乗り物"
+name_en = "Mount / Vehicle"
+summary = "プレイヤーが馬・乗り物に乗って移動する仕組み"
+tags = ["movement"]
+genres = ["open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "mount_speed_factor"
+type = "float"
+default = 2.0
+range = [0.5, 10.0]
+description_ja = "徒歩比の速度倍率"
+
+[[parameter]]
+id = "stamina_drain"
+type = "bool"
+default = true
+description_ja = "スタミナ消費して長距離は休ませる必要がある"

--- a/spec/game-lexicon/features/open-world/world-streaming.toml
+++ b/spec/game-lexicon/features/open-world/world-streaming.toml
@@ -1,0 +1,22 @@
+id = "world-streaming"
+name_ja = "ワールドストリーミング"
+name_en = "World Streaming"
+summary = "プレイヤー位置に応じて地形 / アセットを動的にロード / アンロード"
+tags = ["streaming", "performance"]
+genres = ["open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "tile_size_m"
+type = "int"
+default = 256
+range = [16, 4096]
+description_ja = "1 タイルの一辺サイズ (メートル)"
+
+[[parameter]]
+id = "load_radius"
+type = "int"
+default = 3
+range = [1, 16]
+description_ja = "ロード半径 (タイル数)"

--- a/spec/game-lexicon/features/rhythm/audio-sync.toml
+++ b/spec/game-lexicon/features/rhythm/audio-sync.toml
@@ -1,0 +1,21 @@
+id = "audio-sync"
+name_ja = "音声同期"
+name_en = "Audio Sync"
+summary = "オーディオデバイスとゲームクロックの同期 / オフセット補正"
+tags = ["audio", "feel"]
+genres = ["rhythm"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "user_offset_ms"
+type = "int"
+default = 0
+range = [-500, 500]
+description_ja = "ユーザー調整オフセット (ms)"
+
+[[parameter]]
+id = "auto_calibration"
+type = "bool"
+default = true
+description_ja = "起動時に自動キャリブレーションする"

--- a/spec/game-lexicon/features/rhythm/combo-counter.toml
+++ b/spec/game-lexicon/features/rhythm/combo-counter.toml
@@ -1,0 +1,21 @@
+id = "combo-counter"
+name_ja = "コンボカウンタ"
+name_en = "Combo Counter"
+summary = "連続成功数を表示し、 MISS でリセット"
+tags = ["score", "ui"]
+genres = ["rhythm"]
+depends_on = ["timing-judge"]
+conflicts_with = []
+
+[[parameter]]
+id = "break_judge"
+type = "enum"
+default = "miss"
+values = ["miss", "good_or_below", "great_or_below"]
+description_ja = "コンボを切る最低判定"
+
+[[parameter]]
+id = "full_combo_event"
+type = "bool"
+default = true
+description_ja = "MISS 0 で full-combo イベントを発火"

--- a/spec/game-lexicon/features/rhythm/note-chart.toml
+++ b/spec/game-lexicon/features/rhythm/note-chart.toml
@@ -1,0 +1,22 @@
+id = "note-chart"
+name_ja = "ノート譜面"
+name_en = "Note Chart"
+summary = "楽曲の時間軸上にノーツを並べたデータ"
+tags = ["audio", "data"]
+genres = ["rhythm"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "format"
+type = "enum"
+default = "json"
+values = ["json", "toml", "osu", "bms"]
+description_ja = "譜面ファイル形式"
+
+[[parameter]]
+id = "lane_count"
+type = "int"
+default = 4
+range = [1, 16]
+description_ja = "判定レーン数"

--- a/spec/game-lexicon/features/rhythm/timing-judge.toml
+++ b/spec/game-lexicon/features/rhythm/timing-judge.toml
@@ -1,0 +1,29 @@
+id = "timing-judge"
+name_ja = "タイミング判定"
+name_en = "Timing Judge"
+summary = "ノートの正解時刻と入力時刻の差分から PERFECT / GREAT / GOOD / MISS を返す"
+tags = ["audio", "input"]
+genres = ["rhythm"]
+depends_on = ["note-chart"]
+conflicts_with = []
+
+[[parameter]]
+id = "perfect_ms"
+type = "int"
+default = 25
+range = [1, 200]
+description_ja = "PERFECT 判定窓 (±ms)"
+
+[[parameter]]
+id = "great_ms"
+type = "int"
+default = 60
+range = [1, 500]
+description_ja = "GREAT 判定窓 (±ms)"
+
+[[parameter]]
+id = "good_ms"
+type = "int"
+default = 120
+range = [1, 1000]
+description_ja = "GOOD 判定窓 (±ms)"

--- a/spec/game-lexicon/features/runner/auto-run.toml
+++ b/spec/game-lexicon/features/runner/auto-run.toml
@@ -1,0 +1,22 @@
+id = "auto-run"
+name_ja = "自動前進"
+name_en = "Auto Run"
+summary = "自機が常に一定速度で前進し、 入力は左右 / ジャンプ等に限定される"
+tags = ["movement", "core-loop"]
+genres = ["runner"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "base_speed"
+type = "float"
+default = 8.0
+range = [0.1, 1000.0]
+description_ja = "初期速度 (m/s)"
+
+[[parameter]]
+id = "speed_per_sec"
+type = "float"
+default = 0.05
+range = [0.0, 10.0]
+description_ja = "毎秒の自動加速 (m/s/s)"

--- a/spec/game-lexicon/features/runner/lane-system.toml
+++ b/spec/game-lexicon/features/runner/lane-system.toml
@@ -1,0 +1,22 @@
+id = "lane-system"
+name_ja = "レーン制"
+name_en = "Lane System"
+summary = "横方向は固定数のレーンに離散化し、 入力でレーン間を移動する"
+tags = ["movement", "input"]
+genres = ["runner"]
+depends_on = ["auto-run"]
+conflicts_with = []
+
+[[parameter]]
+id = "lane_count"
+type = "int"
+default = 3
+range = [1, 9]
+description_ja = "レーン数"
+
+[[parameter]]
+id = "lane_change_ms"
+type = "int"
+default = 150
+range = [0, 1000]
+description_ja = "レーン移動の補間時間 (ms)"

--- a/spec/game-lexicon/features/runner/pickup-system.toml
+++ b/spec/game-lexicon/features/runner/pickup-system.toml
@@ -1,0 +1,22 @@
+id = "pickup-system"
+name_ja = "収集アイテム"
+name_en = "Pickup System"
+summary = "コインなどの収集物の配置 / 触れて取得する仕組み"
+tags = ["items", "score"]
+genres = ["runner", "open-world"]
+depends_on = ["score-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "magnet_radius_m"
+type = "float"
+default = 0.0
+range = [0.0, 50.0]
+description_ja = "磁石効果の半径 (0 で無効)"
+
+[[parameter]]
+id = "value_default"
+type = "int"
+default = 1
+range = [0, 99999]
+description_ja = "1 個あたりの既定スコア"

--- a/spec/game-lexicon/features/runner/procedural-track.toml
+++ b/spec/game-lexicon/features/runner/procedural-track.toml
@@ -1,0 +1,22 @@
+id = "procedural-track"
+name_ja = "プロシージャル生成ステージ"
+name_en = "Procedural Track"
+summary = "前方のステージをチャンク単位で生成 / 後方は破棄する仕組み"
+tags = ["world", "streaming"]
+genres = ["runner"]
+depends_on = ["auto-run"]
+conflicts_with = []
+
+[[parameter]]
+id = "chunk_length_m"
+type = "float"
+default = 30.0
+range = [1.0, 1000.0]
+description_ja = "1 チャンク長 (m)"
+
+[[parameter]]
+id = "spawn_ahead"
+type = "int"
+default = 5
+range = [1, 50]
+description_ja = "プレイヤー前方に何チャンク先まで用意するか"

--- a/spec/game-lexicon/features/shooter/bullet-pattern.toml
+++ b/spec/game-lexicon/features/shooter/bullet-pattern.toml
@@ -1,0 +1,21 @@
+id = "bullet-pattern"
+name_ja = "弾幕パターン"
+name_en = "Bullet Pattern"
+summary = "扇 / 円 / 螺旋 等の発射パターンを宣言的に記述する"
+tags = ["combat", "danmaku"]
+genres = ["shooter"]
+depends_on = ["projectile-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "preset_shapes"
+type = "string"
+default = "spread,ring,spiral,homing"
+description_ja = "用意するパターン名 (CSV)"
+
+[[parameter]]
+id = "max_emitters"
+type = "int"
+default = 16
+range = [1, 256]
+description_ja = "同時 emitter 数"

--- a/spec/game-lexicon/features/shooter/projectile-system.toml
+++ b/spec/game-lexicon/features/shooter/projectile-system.toml
@@ -1,0 +1,29 @@
+id = "projectile-system"
+name_ja = "発射体システム"
+name_en = "Projectile System"
+summary = "弾 / 投擲物のスポーン・移動・寿命・命中処理"
+tags = ["combat", "physics"]
+genres = ["shooter"]
+depends_on = ["hitbox-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "max_alive"
+type = "int"
+default = 256
+range = [1, 100000]
+description_ja = "同時生存上限 (プール)"
+
+[[parameter]]
+id = "default_speed"
+type = "float"
+default = 30.0
+range = [0.1, 10000.0]
+description_ja = "既定速度 (m/s)"
+
+[[parameter]]
+id = "default_lifetime_sec"
+type = "float"
+default = 3.0
+range = [0.1, 60.0]
+description_ja = "既定寿命 (秒)"

--- a/spec/game-lexicon/features/shooter/recoil.toml
+++ b/spec/game-lexicon/features/shooter/recoil.toml
@@ -1,0 +1,22 @@
+id = "recoil"
+name_ja = "リコイル (反動)"
+name_en = "Recoil"
+summary = "発射ごとに照準が跳ねる反動の表現"
+tags = ["combat", "feel"]
+genres = ["shooter"]
+depends_on = ["weapon-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "vertical_kick"
+type = "float"
+default = 1.0
+range = [0.0, 30.0]
+description_ja = "1 発あたりの上振れ (度)"
+
+[[parameter]]
+id = "recovery_per_sec"
+type = "float"
+default = 4.0
+range = [0.0, 100.0]
+description_ja = "毎秒の自動戻り量 (度/秒)"

--- a/spec/game-lexicon/features/shooter/weapon-system.toml
+++ b/spec/game-lexicon/features/shooter/weapon-system.toml
@@ -1,0 +1,29 @@
+id = "weapon-system"
+name_ja = "武器システム"
+name_en = "Weapon System"
+summary = "武器の発射 / リロード / 切り替え / クールダウン"
+tags = ["combat", "items"]
+genres = ["shooter"]
+depends_on = ["projectile-system", "input-buffer"]
+conflicts_with = []
+
+[[parameter]]
+id = "rpm"
+type = "int"
+default = 600
+range = [1, 6000]
+description_ja = "発射レート (Rounds Per Minute)"
+
+[[parameter]]
+id = "magazine_size"
+type = "int"
+default = 30
+range = [1, 9999]
+description_ja = "マガジン弾数"
+
+[[parameter]]
+id = "reload_ms"
+type = "int"
+default = 1500
+range = [0, 30000]
+description_ja = "リロード時間 (ms)"

--- a/spec/game-lexicon/features/slg/hex-grid.toml
+++ b/spec/game-lexicon/features/slg/hex-grid.toml
@@ -1,0 +1,29 @@
+id = "hex-grid"
+name_ja = "ヘックス / グリッドマップ"
+name_en = "Hex/Grid Map"
+summary = "ターン制 SLG の盤面となるグリッド (六角 / 四角)"
+tags = ["world", "math"]
+genres = ["slg"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "grid_kind"
+type = "enum"
+default = "hex"
+values = ["hex", "square"]
+description_ja = "セル形状"
+
+[[parameter]]
+id = "width"
+type = "int"
+default = 24
+range = [1, 1024]
+description_ja = "横セル数"
+
+[[parameter]]
+id = "height"
+type = "int"
+default = 16
+range = [1, 1024]
+description_ja = "縦セル数"

--- a/spec/game-lexicon/features/slg/resource-economy.toml
+++ b/spec/game-lexicon/features/slg/resource-economy.toml
@@ -1,0 +1,21 @@
+id = "resource-economy"
+name_ja = "資源 / 経済"
+name_en = "Resource Economy"
+summary = "金 / 食料 / 兵力 等の資源を生産 / 消費 / 蓄積する仕組み"
+tags = ["economy"]
+genres = ["slg"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "resources"
+type = "string"
+default = "gold,food,manpower"
+description_ja = "管理資源名 (CSV)"
+
+[[parameter]]
+id = "tick_seconds"
+type = "int"
+default = 1
+range = [0, 3600]
+description_ja = "資源更新間隔 (秒、 0 でターン同期)"

--- a/spec/game-lexicon/features/slg/tech-tree.toml
+++ b/spec/game-lexicon/features/slg/tech-tree.toml
@@ -1,0 +1,22 @@
+id = "tech-tree"
+name_ja = "テック / 研究ツリー"
+name_en = "Tech Tree"
+summary = "研究を進めて新ユニット / アクションを解禁する依存ツリー"
+tags = ["progression"]
+genres = ["slg"]
+depends_on = ["resource-economy"]
+conflicts_with = []
+
+[[parameter]]
+id = "max_tier"
+type = "int"
+default = 5
+range = [1, 99]
+description_ja = "段階数"
+
+[[parameter]]
+id = "concurrent_research"
+type = "int"
+default = 1
+range = [1, 99]
+description_ja = "同時に研究できる数"

--- a/spec/game-lexicon/features/slg/unit-action.toml
+++ b/spec/game-lexicon/features/slg/unit-action.toml
@@ -1,0 +1,21 @@
+id = "unit-action"
+name_ja = "ユニット行動"
+name_en = "Unit Action"
+summary = "ターン内に各ユニットが移動 / 攻撃 / スキル / 待機を選ぶ"
+tags = ["combat", "turn-based"]
+genres = ["slg"]
+depends_on = ["hex-grid", "stat-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "actions_per_turn"
+type = "int"
+default = 2
+range = [1, 16]
+description_ja = "1 ターンあたりの行動回数"
+
+[[parameter]]
+id = "facing_matters"
+type = "bool"
+default = true
+description_ja = "向き / 側面攻撃を計算する"

--- a/spec/game-lexicon/features/story-jrpg/command-battle.toml
+++ b/spec/game-lexicon/features/story-jrpg/command-battle.toml
@@ -1,0 +1,22 @@
+id = "command-battle"
+name_ja = "コマンドバトル"
+name_en = "Command Battle"
+summary = "ターン制 / ATB 制でコマンドを選んで戦う戦闘システム"
+tags = ["combat", "turn-based"]
+genres = ["story-jrpg"]
+depends_on = ["health-system", "stat-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "turn_mode"
+type = "enum"
+default = "atb"
+values = ["turn", "atb", "ctb"]
+description_ja = "ターン制/ATB/CTB のいずれか"
+
+[[parameter]]
+id = "party_size"
+type = "int"
+default = 4
+range = [1, 8]
+description_ja = "パーティ最大人数"

--- a/spec/game-lexicon/features/story-jrpg/dialogue-system.toml
+++ b/spec/game-lexicon/features/story-jrpg/dialogue-system.toml
@@ -1,0 +1,27 @@
+id = "dialogue-system"
+name_ja = "会話/ダイアログ"
+name_en = "Dialogue System"
+summary = "キャラクター間の会話・選択肢・分岐を扱うシステム"
+tags = ["narrative", "ui"]
+genres = ["story-jrpg", "open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "branch_support"
+type = "bool"
+default = true
+description_ja = "選択肢分岐を扱う"
+
+[[parameter]]
+id = "voice_cue"
+type = "bool"
+default = true
+description_ja = "ボイス再生キューを扱う"
+
+[[parameter]]
+id = "auto_speed_cps"
+type = "int"
+default = 30
+range = [10, 200]
+description_ja = "自動表示速度 (文字/秒)"

--- a/spec/game-lexicon/features/story-jrpg/leveling.toml
+++ b/spec/game-lexicon/features/story-jrpg/leveling.toml
@@ -1,0 +1,22 @@
+id = "leveling"
+name_ja = "レベル / 経験値"
+name_en = "Leveling / XP"
+summary = "敵撃破などで経験値を貯めてレベルアップする仕組み"
+tags = ["progression"]
+genres = ["story-jrpg", "open-world", "moba"]
+depends_on = ["stat-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "max_level"
+type = "int"
+default = 99
+range = [1, 9999]
+description_ja = "最大レベル"
+
+[[parameter]]
+id = "curve"
+type = "enum"
+default = "polynomial"
+values = ["linear", "polynomial", "exponential", "table"]
+description_ja = "経験値必要量カーブ"

--- a/spec/game-lexicon/features/story-jrpg/quest-system.toml
+++ b/spec/game-lexicon/features/story-jrpg/quest-system.toml
@@ -1,0 +1,21 @@
+id = "quest-system"
+name_ja = "クエストシステム"
+name_en = "Quest System"
+summary = "受注 / 進行 / 達成 / 報酬の流れを管理"
+tags = ["progression", "narrative"]
+genres = ["story-jrpg", "open-world"]
+depends_on = []
+conflicts_with = []
+
+[[parameter]]
+id = "max_active"
+type = "int"
+default = 5
+range = [1, 999]
+description_ja = "同時受注可能数"
+
+[[parameter]]
+id = "track_in_minimap"
+type = "bool"
+default = true
+description_ja = "ミニマップ上に目的地を表示"

--- a/spec/game-lexicon/features/story-jrpg/stat-system.toml
+++ b/spec/game-lexicon/features/story-jrpg/stat-system.toml
@@ -1,0 +1,14 @@
+id = "stat-system"
+name_ja = "ステータス管理"
+name_en = "Stat System"
+summary = "HP / MP / 攻撃 / 防御 / 速さ 等の数値ステータス管理"
+tags = ["stats", "progression"]
+genres = ["story-jrpg", "open-world", "moba", "slg"]
+depends_on = ["health-system"]
+conflicts_with = []
+
+[[parameter]]
+id = "stats"
+type = "string"
+default = "hp,mp,atk,def,spd,luck"
+description_ja = "管理するステータス名 (CSV)"

--- a/spec/game-lexicon/genres/action.toml
+++ b/spec/game-lexicon/genres/action.toml
@@ -1,0 +1,10 @@
+id = "action"
+name_ja = "アクション"
+name_en = "Action"
+summary = "リアルタイム戦闘・移動操作を中心としたアクションゲーム"
+tags = ["realtime", "combat"]
+default_preset = "action-basic"
+description = """
+プレイヤー入力 → 攻撃判定 → ヒット応答 のサイクルが核。
+カメラ・当たり判定・i-frame・ヒットストップなど "気持ち良さ" を作るための要素が多い。
+"""

--- a/spec/game-lexicon/genres/fighting.toml
+++ b/spec/game-lexicon/genres/fighting.toml
@@ -1,0 +1,11 @@
+id = "fighting"
+name_ja = "格闘ゲーム"
+name_en = "Fighting"
+summary = "1v1 を基本とする格闘ゲーム。 フレームデータと入力技術が中核"
+tags = ["competitive", "frame-precise", "1v1"]
+default_preset = "fighting-basic"
+description = """
+コマンド入力 → モーションキャンセル → ヒット / ガード / 投げの三すくみ + コンボ
++ ゲージ管理 + ラウンド制が典型。
+ロールバックネットコードと正確なフレーム判定が技術要件。
+"""

--- a/spec/game-lexicon/genres/moba.toml
+++ b/spec/game-lexicon/genres/moba.toml
@@ -1,0 +1,11 @@
+id = "moba"
+name_ja = "MOBA"
+name_en = "MOBA"
+summary = "5v5 等の対人マルチアリーナバトル。 マップ占拠とキャラ性能が両軸"
+tags = ["multiplayer", "competitive", "team"]
+default_preset = "moba-basic"
+description = """
+ヒーロー (キャラ) ごとのスキルセット + ミニオンウェーブ + タワー / オブジェクト
++ 対人ネットワーキング (ロールバック / クライアント予測) が核。
+試合前の BAN/PICK + 試合中の経済 / アイテム購入もある。
+"""

--- a/spec/game-lexicon/genres/open-world.toml
+++ b/spec/game-lexicon/genres/open-world.toml
@@ -1,0 +1,10 @@
+id = "open-world"
+name_ja = "オープンワールド"
+name_en = "Open World"
+summary = "広大なシームレスマップを自由に探索するアクション/RPG"
+tags = ["exploration", "streaming", "sandbox"]
+default_preset = "open-world-basic"
+description = """
+シームレス読込み、 動的天候 / 時間帯、 派生クエスト、 移動手段 (騎乗 / 乗り物) が中心。
+プレイヤーがどこから来てもゲームが破綻しない "自走する世界" を組む必要がある。
+"""

--- a/spec/game-lexicon/genres/rhythm.toml
+++ b/spec/game-lexicon/genres/rhythm.toml
@@ -1,0 +1,10 @@
+id = "rhythm"
+name_ja = "音ゲー (リズムゲーム)"
+name_en = "Rhythm"
+summary = "音楽に合わせてノーツを叩くゲーム"
+tags = ["audio", "timing"]
+default_preset = "rhythm-basic"
+description = """
+楽曲 + ノーツ譜面 + 入力タイミング判定 + コンボ / スコアリングが核。
+ローレイテンシ入力と音声同期が技術的な鍵。
+"""

--- a/spec/game-lexicon/genres/runner.toml
+++ b/spec/game-lexicon/genres/runner.toml
@@ -1,0 +1,10 @@
+id = "runner"
+name_ja = "ランゲーム"
+name_en = "Endless Runner"
+summary = "自動前進する自機を、 障害物回避と収集で操作する片手プレイ向けゲーム"
+tags = ["mobile", "endless", "score"]
+default_preset = "runner-basic"
+description = """
+自機は常に進行、 プレイヤー入力は左右レーン変更 / ジャンプ / スライドのみ。
+プロシージャル生成で無限スクロールするステージ + コインなどの収集 + ハイスコア管理。
+"""

--- a/spec/game-lexicon/genres/shooter.toml
+++ b/spec/game-lexicon/genres/shooter.toml
@@ -1,0 +1,10 @@
+id = "shooter"
+name_ja = "シューティング"
+name_en = "Shooter"
+summary = "弾を撃ち合うゲーム全般 (STG / TPS / FPS / 弾幕)"
+tags = ["combat", "ranged"]
+default_preset = "shooter-basic"
+description = """
+発射体 (projectile) のライフサイクル管理、 リロード / 弾数、 命中判定、 リコイル、
+スコアリングが核。 弾幕系 (bullet hell) はパターン生成が独立した責務になる。
+"""

--- a/spec/game-lexicon/genres/slg.toml
+++ b/spec/game-lexicon/genres/slg.toml
@@ -1,0 +1,10 @@
+id = "slg"
+name_ja = "シミュレーション/ストラテジー"
+name_en = "Strategy/Simulation"
+summary = "ターン or リアルタイム制で経済・軍事・建築などを管理するゲーム"
+tags = ["strategy", "simulation", "macro"]
+default_preset = "slg-basic"
+description = """
+ヘックス / グリッドマップ + ユニット行動 + 資源収集 + テック / 研究ツリー が典型構成。
+リアルタイム制 (RTS) はゲームスピード制御も入る。
+"""

--- a/spec/game-lexicon/genres/story-jrpg.toml
+++ b/spec/game-lexicon/genres/story-jrpg.toml
@@ -1,0 +1,11 @@
+id = "story-jrpg"
+name_ja = "ストーリー型JRPG"
+name_en = "Story-driven JRPG"
+summary = "シナリオ進行とコマンドバトルを軸とした日本式ロールプレイングゲーム"
+tags = ["narrative", "turn-based", "progression"]
+default_preset = "story-jrpg-basic"
+description = """
+イベント (会話・CG・選択肢) → 探索 → エンカウント → コマンドバトル → レベルアップ
+の循環で進む。
+パーティ編成・装備・スキルツリー・状態異常など RPG の典型要素を抱える。
+"""

--- a/spec/game-lexicon/presets/action-basic.toml
+++ b/spec/game-lexicon/presets/action-basic.toml
@@ -1,0 +1,14 @@
+id = "action-basic"
+name_ja = "アクション (基本)"
+name_en = "Action (basic)"
+genre = "action"
+summary = "3D / 2D アクションの最小構成"
+features = [
+  "input-buffer",
+  "hitbox-system",
+  "health-system",
+  "combo-system",
+  "dodge-roll",
+  "camera-follow",
+  "hitstop",
+]

--- a/spec/game-lexicon/presets/fighting-basic.toml
+++ b/spec/game-lexicon/presets/fighting-basic.toml
@@ -1,0 +1,17 @@
+id = "fighting-basic"
+name_ja = "格闘 (基本)"
+name_en = "Fighting (basic)"
+genre = "fighting"
+summary = "1v1 格闘ゲームの最小構成"
+features = [
+  "input-buffer",
+  "command-input",
+  "hitbox-system",
+  "health-system",
+  "frame-data",
+  "combo-system",
+  "guard-throw",
+  "round-system",
+  "hitstop",
+  "rollback-netcode",
+]

--- a/spec/game-lexicon/presets/moba-basic.toml
+++ b/spec/game-lexicon/presets/moba-basic.toml
@@ -1,0 +1,17 @@
+id = "moba-basic"
+name_ja = "MOBA (基本)"
+name_en = "MOBA (basic)"
+genre = "moba"
+summary = "5v5 MOBA の最小構成"
+features = [
+  "input-buffer",
+  "hitbox-system",
+  "health-system",
+  "stat-system",
+  "leveling",
+  "hero-skill",
+  "minion-wave",
+  "tower-objective",
+  "rollback-netcode",
+  "camera-follow",
+]

--- a/spec/game-lexicon/presets/open-world-basic.toml
+++ b/spec/game-lexicon/presets/open-world-basic.toml
@@ -1,0 +1,18 @@
+id = "open-world-basic"
+name_ja = "オープンワールド (基本)"
+name_en = "Open World (basic)"
+genre = "open-world"
+summary = "OW タイトルの最小構成"
+features = [
+  "health-system",
+  "stat-system",
+  "world-streaming",
+  "day-night-cycle",
+  "fast-travel",
+  "mount-system",
+  "quest-system",
+  "dialogue-system",
+  "inventory",
+  "save-load",
+  "camera-follow",
+]

--- a/spec/game-lexicon/presets/rhythm-basic.toml
+++ b/spec/game-lexicon/presets/rhythm-basic.toml
@@ -1,0 +1,13 @@
+id = "rhythm-basic"
+name_ja = "音ゲー (基本)"
+name_en = "Rhythm (basic)"
+genre = "rhythm"
+summary = "音ゲーの最小構成"
+features = [
+  "input-buffer",
+  "note-chart",
+  "audio-sync",
+  "timing-judge",
+  "combo-counter",
+  "score-system",
+]

--- a/spec/game-lexicon/presets/runner-basic.toml
+++ b/spec/game-lexicon/presets/runner-basic.toml
@@ -1,0 +1,13 @@
+id = "runner-basic"
+name_ja = "ランゲーム (基本)"
+name_en = "Endless Runner (basic)"
+genre = "runner"
+summary = "片手プレイのエンドレスランナー最小構成"
+features = [
+  "auto-run",
+  "lane-system",
+  "procedural-track",
+  "pickup-system",
+  "score-system",
+  "health-system",
+]

--- a/spec/game-lexicon/presets/shooter-basic.toml
+++ b/spec/game-lexicon/presets/shooter-basic.toml
@@ -1,0 +1,15 @@
+id = "shooter-basic"
+name_ja = "シューティング (基本)"
+name_en = "Shooter (basic)"
+genre = "shooter"
+summary = "TPS / FPS / STG の最小構成"
+features = [
+  "input-buffer",
+  "hitbox-system",
+  "health-system",
+  "projectile-system",
+  "weapon-system",
+  "recoil",
+  "score-system",
+  "camera-follow",
+]

--- a/spec/game-lexicon/presets/slg-basic.toml
+++ b/spec/game-lexicon/presets/slg-basic.toml
@@ -1,0 +1,13 @@
+id = "slg-basic"
+name_ja = "SLG (基本)"
+name_en = "Strategy/Sim (basic)"
+genre = "slg"
+summary = "ターン制 SLG の最小構成"
+features = [
+  "hex-grid",
+  "stat-system",
+  "unit-action",
+  "resource-economy",
+  "tech-tree",
+  "save-load",
+]

--- a/spec/game-lexicon/presets/story-jrpg-basic.toml
+++ b/spec/game-lexicon/presets/story-jrpg-basic.toml
@@ -1,0 +1,15 @@
+id = "story-jrpg-basic"
+name_ja = "ストーリー型JRPG (基本)"
+name_en = "Story-driven JRPG (basic)"
+genre = "story-jrpg"
+summary = "JRPG の最小構成"
+features = [
+  "health-system",
+  "stat-system",
+  "leveling",
+  "command-battle",
+  "dialogue-system",
+  "quest-system",
+  "inventory",
+  "save-load",
+]

--- a/spec/game-lexicon/terms/combat.toml
+++ b/spec/game-lexicon/terms/combat.toml
@@ -1,0 +1,82 @@
+# 戦闘まわりの用語
+
+[[term]]
+id = "hitbox"
+name_ja = "ヒットボックス"
+name_en = "Hitbox"
+aliases = ["当たり判定 (攻撃)", "アタックボックス"]
+definition = "攻撃が命中したかどうかを判定する形状。 表示モデルとは別の簡易形状を持つことが多い"
+tags = ["combat", "physics"]
+related_terms = ["hurtbox", "iframe"]
+
+[[term]]
+id = "hurtbox"
+name_ja = "ハートボックス"
+name_en = "Hurtbox"
+aliases = ["被弾判定", "やられ判定"]
+definition = "敵 / 自キャラがダメージを受ける範囲"
+tags = ["combat", "physics"]
+related_terms = ["hitbox", "iframe"]
+
+[[term]]
+id = "iframe"
+name_ja = "無敵時間"
+name_en = "Invincibility Frames"
+aliases = ["i-frame", "iフレ"]
+definition = "ダメージを受け付けないフレーム / 時間。 回避や被弾後復帰直後によく付く"
+tags = ["combat"]
+related_terms = ["hurtbox"]
+
+[[term]]
+id = "hitstop"
+name_ja = "ヒットストップ"
+name_en = "Hitstop"
+aliases = ["打撃停止", "フリーズ演出"]
+definition = "命中の瞬間にキャラの動きを一時停止し、 打撃感を強調する演出"
+tags = ["combat", "feel"]
+related_terms = ["screen-shake"]
+
+[[term]]
+id = "frame-data"
+name_ja = "フレームデータ"
+name_en = "Frame Data"
+aliases = ["フレ表"]
+definition = "技ごとに startup / active / recovery を持たせる数値表。 主に格ゲー文化"
+tags = ["combat", "fighting"]
+related_terms = ["startup", "recovery"]
+
+[[term]]
+id = "startup"
+name_ja = "発生フレーム"
+name_en = "Startup"
+aliases = ["発生"]
+definition = "技を出し始めてから攻撃判定が出るまでのフレーム数"
+tags = ["fighting"]
+related_terms = ["recovery", "active"]
+
+[[term]]
+id = "active"
+name_ja = "持続フレーム"
+name_en = "Active Frames"
+aliases = ["持続"]
+definition = "技の攻撃判定が出ている期間のフレーム数"
+tags = ["fighting"]
+related_terms = ["startup", "recovery"]
+
+[[term]]
+id = "recovery"
+name_ja = "硬直 (技後)"
+name_en = "Recovery"
+aliases = ["後隙"]
+definition = "技の攻撃判定が消えた後、 次の行動に移れるまでのフレーム数"
+tags = ["fighting"]
+related_terms = ["startup", "active"]
+
+[[term]]
+id = "screen-shake"
+name_ja = "画面振動"
+name_en = "Screen Shake"
+aliases = ["カメラシェイク"]
+definition = "命中 / 爆発時にカメラを揺らす演出"
+tags = ["feel", "camera"]
+related_terms = ["hitstop"]

--- a/spec/game-lexicon/terms/progression.toml
+++ b/spec/game-lexicon/terms/progression.toml
@@ -1,0 +1,46 @@
+# 成長 / 進行まわりの用語
+
+[[term]]
+id = "xp"
+name_ja = "経験値"
+name_en = "XP"
+aliases = ["EXP", "経験"]
+definition = "敵撃破などで得られる、 レベルアップに必要なポイント"
+tags = ["progression"]
+related_terms = ["level"]
+
+[[term]]
+id = "level"
+name_ja = "レベル"
+name_en = "Level"
+aliases = ["LV", "Lv"]
+definition = "キャラの強さを表す段階。 XP がしきい値を超えると上がる"
+tags = ["progression"]
+related_terms = ["xp"]
+
+[[term]]
+id = "skill-tree"
+name_ja = "スキルツリー"
+name_en = "Skill Tree"
+aliases = ["タレントツリー"]
+definition = "前提スキルから派生する、 解禁ツリー状の強化要素"
+tags = ["progression"]
+related_terms = ["tech-tree"]
+
+[[term]]
+id = "tech-tree"
+name_ja = "テックツリー"
+name_en = "Tech Tree"
+aliases = ["研究ツリー"]
+definition = "SLG で資源を払って解禁していく技術 / ユニットの依存ツリー"
+tags = ["progression", "slg"]
+related_terms = ["skill-tree"]
+
+[[term]]
+id = "loot-table"
+name_ja = "ドロップテーブル"
+name_en = "Loot Table"
+aliases = ["ドロップ表"]
+definition = "敵 / 宝箱から出るアイテムの確率表"
+tags = ["progression", "items"]
+related_terms = []

--- a/spec/game-lexicon/terms/system.toml
+++ b/spec/game-lexicon/terms/system.toml
@@ -1,0 +1,46 @@
+# システム / 技術用語
+
+[[term]]
+id = "tick-rate"
+name_ja = "ティックレート"
+name_en = "Tick Rate"
+aliases = []
+definition = "1 秒あたりのゲームロジック更新回数。 ネットワーク同期では送受信レートでもある"
+tags = ["network", "performance"]
+related_terms = []
+
+[[term]]
+id = "rollback"
+name_ja = "ロールバック"
+name_en = "Rollback"
+aliases = ["巻き戻し"]
+definition = "対戦中に予測した相手入力が違っていた時、 過去の状態に戻して再シミュレーションする"
+tags = ["network", "competitive"]
+related_terms = ["input-delay"]
+
+[[term]]
+id = "input-delay"
+name_ja = "入力遅延"
+name_en = "Input Delay"
+aliases = []
+definition = "入力から画面反映までの遅延。 ネットコードや表示のチェーン全体で発生する"
+tags = ["network", "feel"]
+related_terms = ["rollback"]
+
+[[term]]
+id = "streaming"
+name_ja = "ストリーミングロード"
+name_en = "Streaming"
+aliases = ["動的ロード"]
+definition = "プレイ中に世界の一部を動的にロード / アンロードする手法。 OW で必須"
+tags = ["world", "performance"]
+related_terms = []
+
+[[term]]
+id = "deterministic"
+name_ja = "確定的"
+name_en = "Deterministic"
+aliases = ["決定的"]
+definition = "同じ入力なら同じ結果になる性質。 ロールバックや replay の前提"
+tags = ["network", "competitive"]
+related_terms = ["rollback"]

--- a/spec/modules/game-lexicon.md
+++ b/spec/modules/game-lexicon.md
@@ -1,0 +1,128 @@
+# ars-game-lexicon モジュール仕様書
+
+## 1. 目的
+
+ゲーム制作に出てくる**用語 (Term)** ・ **機能 (Feature)** ・ **ジャンル (Genre)** ・ **プリセット (Preset)** を **仕様駆動 (spec-driven)** で集約するモジュール。
+
+このモジュールは Ars エディタの **ウィザード** ・ **コード生成** ・ **レベルデザイン支援** のすべての上位機能の **共通辞書** として働く。たとえば「アクションゲームのプリセット」を選ぶと、 `combo` / `dodge` / `hitbox` 等の Feature が assemble 候補として並ぶ — その「アクションには何が必要か」 という知識自体は本モジュールに寄せる。
+
+## 2. 設計原則
+
+| # | 原則 |
+|---|------|
+| P1 | データは `spec/game-lexicon/` 配下の **TOML ファイル** に書く。 Rust に埋め込まない |
+| P2 | TOML スキーマは [`spec/game-lexicon/README.md`](../game-lexicon/README.md) に明文化する |
+| P3 | `Genre` / `Feature` / `Preset` / `Term` は ID で相互参照する (循環は許可、依存は明示) |
+| P4 | Feature には **依存** と **競合** を宣言できる (ウィザードはこれを検証する) |
+| P5 | プラグイン (ergo / pictor / unity 等) からも Feature を追加できる (将来) |
+| P6 | Layer 1 (このモジュール) は I/O を持たない純粋ドメイン。 Repository は trait のみ |
+| P7 | 言語は日本語と英語を併記する。 用語の正規化は ID (snake_case ASCII) で行う |
+
+## 3. ドメイン
+
+| 用語 | 定義 |
+|------|------|
+| **Genre** | ゲームジャンル (`action` / `rpg` / `shooter` / `puzzle` / `strategy` / `sandbox` / ...) |
+| **Term** | ゲーム制作上の用語。 ジャンル横断で出てくるもの (例: `hitbox`, `combo`, `xp`, `inventory`) |
+| **Feature** | 1 つのゲーム機能の抽象 (例: `health-system`, `combo-system`)。 後段でモジュール / ergo プラグイン / コード生成と紐付く |
+| **Preset** | あるジャンル向けに **デフォルトで有効化する Feature の組み合わせ** (例: `action-basic` = combo + dodge + hitbox + health) |
+| **Tag** | Feature や Term に付ける自由分類 (例: `combat`, `progression`, `ui`)。 検索 / フィルタ用 |
+| **Lexicon** | 上の全部を束ねた集合。 ロード結果の root |
+
+## 4. 責務
+
+### 担う
+
+- `spec/game-lexicon/` 配下の TOML を **ロード** ・ **マージ** ・ **検証** する
+- `Lexicon` を ID 引きできる API を提供する (`get_genre`, `get_feature`, `get_preset`, `search_terms`)
+- Feature の **依存** ・ **競合** の整合性検証 (循環依存検出を含む)
+- Preset を Feature 集合に展開する (`expand_preset`)
+- 後述する Repository trait 経由でプロジェクト固有の追加 Feature / 用語上書きを混ぜる (将来)
+
+### 担わない
+
+- ウィザード UI 自体 (ars-editor 側、Layer 3)
+- Feature の**実装** (= ergo / unity / unreal プラグイン側)
+- レベルデザインのデータ構造 (別モジュール `ars-level-design` を予定)
+- 永続化先の選定 (Layer 3 の責務)
+
+## 5. 公開インタフェース
+
+```rust
+pub mod domain;       // Genre, Term, Feature, Preset, Tag, Lexicon
+pub mod loader;       // load_from_dir(&Path) -> Result<Lexicon>
+pub mod repository;   // GameLexiconRepository trait (Layer 2 で使う)
+pub mod error;        // LexiconError, Result
+```
+
+主要型:
+
+```rust
+pub struct Lexicon {
+    pub genres: Vec<Genre>,
+    pub features: Vec<Feature>,
+    pub presets: Vec<Preset>,
+    pub terms: Vec<Term>,
+}
+
+pub struct Genre   { pub id: GenreId, pub names: I18nName, pub summary: String, pub default_preset: Option<PresetId>, pub tags: Vec<TagId> }
+pub struct Feature { pub id: FeatureId, pub names: I18nName, pub summary: String, pub genres: Vec<GenreId>, pub depends_on: Vec<FeatureId>, pub conflicts_with: Vec<FeatureId>, pub tags: Vec<TagId>, pub parameters: Vec<FeatureParameter> }
+pub struct Preset  { pub id: PresetId, pub names: I18nName, pub genre: GenreId, pub summary: String, pub features: Vec<FeatureId> }
+pub struct Term    { pub id: TermId, pub names: I18nName, pub aliases: Vec<String>, pub definition: String, pub tags: Vec<TagId>, pub related_terms: Vec<TermId> }
+```
+
+ID 型はすべて `String` の newtype (`GenreId(String)` 等)。 TS 側にも ts-rs で同期。
+
+`GameLexiconRepository` (Layer 2 が依存):
+
+```rust
+#[async_trait]
+pub trait GameLexiconRepository: Send + Sync {
+    /// 組込みデータ (`spec/game-lexicon/` に同梱) をロード
+    async fn load_builtin(&self) -> Result<Lexicon>;
+
+    /// プロジェクト固有のオーバーレイをロード (未指定なら空 Lexicon)
+    async fn load_project_overlay(&self, project_id: &str) -> Result<Lexicon>;
+
+    /// プロジェクト固有のオーバーレイを保存
+    async fn save_project_overlay(&self, project_id: &str, overlay: &Lexicon) -> Result<()>;
+}
+```
+
+## 6. 依存関係
+
+| 依存 | 理由 |
+|------|------|
+| `serde` / `serde_json` | TOML / JSON シリアライズ |
+| `toml` | TOML パース |
+| `thiserror` | エラー型 |
+| `async-trait` | Repository trait |
+| (`ars-core`) | エラー型を共通化したくなったら追加。 v0.1 では追加しない |
+
+依存方向は **Layer 1 = 単独**。 ars-core にも依存しない (このモジュールで完結する小さな辞書を提供したい)。
+
+## 7. ライフサイクル
+
+App スコープ (= プロジェクト未 Open でも参照可)。 起動時に `load_builtin()` を 1 回呼んでメモリに保持し、 プロジェクト Open 時に `load_project_overlay()` をマージする。
+
+## 8. v0.1 で出すもの
+
+- TOML ローダ + ドメイン型 + Repository trait
+- 組込み seed: `action` / `rpg` / `shooter` の 3 ジャンル × 各 4-5 Feature + 1 Preset
+- 共通用語 (combat / progression / ui の 3 タグで 〜10 件)
+- ローダ単体テスト (TOML 1 セットを `tests/data/` に置いて読めることを確認)
+
+## 9. ロードマップ
+
+| バージョン | 内容 |
+|-----------|------|
+| v0.1 | 上記 |
+| v0.2 | use case 関数 (`apply_preset` 等)、 ウィザード API |
+| v0.3 | プラグイン Feature 拡張点 (ergo / pictor が Feature を提供) |
+| v0.4 | レベルデザイン側との連携 (`ars-level-design` で Feature を pacing curve に紐付け) |
+
+## 10. 関連ドキュメント
+
+- データ形式: [`spec/game-lexicon/README.md`](../game-lexicon/README.md)
+- モジュール一覧: [`spec/modules/overview.md`](./overview.md)
+- ドキュメントルール: [`spec/rule/module-documentation-rules.md`](../rule/module-documentation-rules.md)

--- a/spec/modules/overview.md
+++ b/spec/modules/overview.md
@@ -63,6 +63,7 @@ App版（Tauri Desktop）とWeb版（Axum Server）の**両方で同一ビジネ
 | ars-module-registry | `module-registry` | Ergoモジュール定義の発見・解析・キャッシュ | 設計のみ |
 | ars-resource-depot | `resource-depot` | アセット管理 | 設計のみ |
 | ars-data-organizer | `data-organizer` | Blackboard変数、ゲーム設定値 | 設計のみ |
+| **ars-game-lexicon** | `game-lexicon` | ゲーム辞書 (Genre / Feature / Preset / Term)、 仕様駆動の seed データ + ローダ | **v0.1 (フレーム + 9 ジャンル seed)** |
 | ars-auth | `auth` | 認証、セッション管理 | 設計のみ |
 | ars-collab | `collab` | WebSocket同期、プレゼンス、ロック | 設計のみ |
 | ars-secrets | `secrets` | シークレット管理（Keychain + TOML） | 設計のみ |


### PR DESCRIPTION
## 目的
ゲーム制作の **用語 / 機能 / ジャンル / プリセット** を **仕様駆動 (spec-driven)** で集約する `ars-game-lexicon` クレートを新設。 後続の **ウィザード** ・ **コード生成** ・ **レベルデザイン支援** の共通辞書として働く。

## 9 ジャンルの整理
- action / story-jrpg / open-world / shooter / runner / slg / rhythm / moba / fighting
- 各ジャンルに 4-5 個の固有 Feature + 1 つの basic Preset
- 共通 Feature は `features/core/` に集約 (health / input-buffer / inventory / save-load / score / hitbox)
- 用語集は combat / progression / system の 3 カテゴリ 計 18 用語

## 構成
```
spec/modules/game-lexicon.md           # モジュール仕様
spec/game-lexicon/
├── README.md                          # TOML スキーマ + 拡張ガイド
├── genres/*.toml                      # 9
├── features/{core,action,...}/*.toml  # 30+
├── presets/*.toml                     # 9
└── terms/*.toml                       # 3 ファイル × 計 18 用語

crates/ars-game-lexicon/
├── Cargo.toml / README.md
└── src/
    ├── lib.rs               # public surface
    ├── domain.rs            # Genre / Feature / Preset / Term + ID newtype
    ├── loader.rs            # TOML 再帰ロード + 検証 + DFS 依存解決
    ├── repository.rs        # GameLexiconRepository trait
    └── error.rs             # LexiconError (thiserror)
```

## 検証
- `cargo check -p ars-game-lexicon` ✅
- `cargo test -p ars-game-lexicon` ✅ (同梱 seed をロード + `action-basic` の依存ソート確認)
- `cargo check --workspace` ✅ (既存 warning は無関係)

## 非ゴール
- ウィザード UI (ars-editor 側、 別 PR)
- Feature の実装 (ergo / unity / unreal プラグイン)
- レベルデザイン側との連携 (`ars-level-design`、 v0.4 計画)

🤖 Generated with [Claude Code](https://claude.com/claude-code)