### PR TITLE
docs(game-template): 17 ジャンル分の実装ガイド

### DIFF
--- a/spec/game-template/README.md
+++ b/spec/game-template/README.md
@@ -1,0 +1,75 @@
+# spec/game-template/ — ゲームジャンル別テンプレート
+
+各ファイルは「あるジャンルでゲームを作るときに、 最初に決めるべき骨格」 を 1 ジャンル 1 ドキュメントで集約する。
+[`spec/game-lexicon/`](../game-lexicon/) が **用語 / 機能の辞書** であるのに対し、 こちらは **ジャンル単位の実装ガイド** で、 game-lexicon の Feature を組み合わせた **想定構成** を示す。
+
+## 0. 目次
+
+| ID | ファイル | 代表作 |
+|----|---------|--------|
+| `action` | [action.md](action.md) | SEKIRO / Bayonetta |
+| `platformer` | [platformer.md](platformer.md) | Super Mario Bros |
+| `vampire_survivors_like` | [vampire_survivors_like.md](vampire_survivors_like.md) | Vampire Survivors |
+| `slg_grid` | [slg_grid.md](slg_grid.md) | Fire Emblem / FFT |
+| `strategy_4x` | [strategy_4x.md](strategy_4x.md) | Civilization |
+| `puzzle_casual` | [puzzle_casual.md](puzzle_casual.md) | Royal Match / Candy Crush |
+| `roguelike_berlin` | [roguelike_berlin.md](roguelike_berlin.md) | NetHack / DCSS |
+| `deckbuilder_roguelike` | [deckbuilder_roguelike.md](deckbuilder_roguelike.md) | Slay the Spire |
+| `moba` | [moba.md](moba.md) | League of Legends |
+| `metroidvania` | [metroidvania.md](metroidvania.md) | Super Metroid / Symphony of the Night |
+| `hack_and_slash` | [hack_and_slash.md](hack_and_slash.md) | Diablo / Path of Exile |
+| `fighting` | [fighting.md](fighting.md) | Street Fighter / Guilty Gear |
+| `rhythm` | [rhythm.md](rhythm.md) | Beatmania / DDR |
+| `jrpg` | [jrpg.md](jrpg.md) | Dragon Quest / Final Fantasy |
+| `open_world` | [open_world.md](open_world.md) | Zelda BotW / Skyrim |
+| `shmup` | [shmup.md](shmup.md) | Gradius / 東方 |
+| `fps` | [fps.md](fps.md) | Counter-Strike / Apex |
+
+## 1. ファイルフォーマット
+
+各テンプレは以下の節を必ず持つ:
+
+```markdown
+# <ジャンル日本語名> テンプレート
+
+## 概要
+代表作、 コアループ、 「これがあるとこのジャンル」 と言える要素を 2-4 段落で。
+
+## 必要不可欠な機能実装
+箇条書きで feature 候補を列挙。 各項目は `[<feature_id>]` を冒頭に置いて
+[`spec/game-lexicon/features/`](../game-lexicon/features/) と相互参照可能にする。
+リンク先がまだ無い場合は ID だけ書いて将来追加に備える。
+
+## コアドメイン設計
+DDD 寄り。 主要な aggregate / entity / value object と境界づけられたコンテキスト
+を Mermaid 図 + 短い説明で。
+
+## 対応するコード設計
+具体的な layer / module 分割案。 Ars のアクター + Ergo モジュールに乗せた場合
+の 「典型的な配置」 を疑似 Rust / 疑似 C++17 で。
+```
+
+## 2. game-lexicon との関係
+
+- **game-lexicon** = 「Feature 単体の辞書」 (`combo-system`, `health-system` など)
+- **game-template** = 「ジャンルごとに上記 Feature をどう束ねるか」
+
+ウィザードや AI 補助は両方を読む:
+
+```text
+ユーザー → ウィザード
+                  ├─ game-template/<genre>.md  (どの Feature を入れるか)
+                  └─ game-lexicon/features/*.toml (各 Feature の詳細)
+                              │
+                              ▼
+                         Project assembly
+```
+
+## 3. 拡張ガイド
+
+新ジャンルを追加する手順:
+
+1. `spec/game-template/<id>.md` を本 README §1 のフォーマットで書く
+2. 必要な Feature が `spec/game-lexicon/features/` に無ければ追加
+3. 上の §0 目次表に行を追加
+4. (任意) `spec/modules/overview.md` で参照

--- a/spec/game-template/action.md
+++ b/spec/game-template/action.md
@@ -1,0 +1,128 @@
+# アクションゲーム テンプレート
+
+## 概要
+
+リアルタイム戦闘 + 移動操作を中核とする 3D / 2D アクションゲーム。
+代表作は **SEKIRO**、 **Bayonetta**、 **Devil May Cry**、 **Nioh**、 **Elden Ring** (派生)。
+
+コアループ:
+
+> 入力 → 攻撃 / 回避 → ヒット判定 → ヒット応答 (ヒットストップ・体力減少・スタガー) → 次入力
+
+「気持ち良さ」 (game feel) が成功の鍵。 ヒットストップ・カメラシェイク・i-frame・パリィ受付窓の長さ・敵の硬直値・コンボのキャンセル猶予 — これらの **数値の調律** がそのままゲームの個性になる。
+
+技術的には:
+- 60 fps を維持できるシンプルな当たり判定 (AABB / 球 / OBB) + ブロードフェーズ
+- アニメーションのキャンセル可能フレームを定義した「フレームデータ」
+- カメラの自動追従 + ロックオン
+- 敵 AI の限定行動表 (idle / chase / attack pattern / recover)
+
+## 必要不可欠な機能実装
+
+- `[input-buffer]` 入力バッファ — 攻撃 / 回避入力を 100-200ms 保持して次アクションに引き継ぐ
+- `[hitbox-system]` 攻撃判定 / 被弾判定の交差検査 (AABB / sphere / OBB)
+- `[health-system]` HP コンテナ + ダメージ / 回復 / 死亡コールバック
+- `[combo-system]` 連続入力で技をつなげる (cancel window 必須)
+- `[dodge-roll]` i-frame を伴う緊急回避
+- `[hitstop]` 命中時の時間停止演出 (打撃感)
+- `[camera-follow]` 追従カメラ + シェイク
+- `[lockon]` (新規) 近接敵をロックして攻撃方向を補正 — SEKIRO / DMC で必須
+- `[parry-system]` (新規) 直前ブロックでガード崩し → 敵スタガー
+- `[posture-stagger]` (新規) 体幹 / スタガーゲージ。 SEKIRO 直系
+- `[enemy-ai-states]` 敵の有限状態機械 (idle / chase / attack / recover / stunned)
+- `[stamina-system]` (新規 / 任意) 行動コスト管理。 ダクソ系で必須
+- `save-load` チェックポイント方式 (篝火 / 神社) のセーブ
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Player[Player Actor] -->|emits| Input[Input Stream]
+  Input --> Cmd[Command<br/>e.g. Attack/Dodge/Parry]
+  Cmd -->|consumed by| FSM[Player FSM]
+  FSM -->|generates| Move[Move Action]
+  Move -->|spawns| Hitbox[Hitbox Volume]
+  Hitbox -->|overlaps| Hurtbox[Enemy Hurtbox]
+  Hurtbox -->|triggers| HitResolution[Hit Resolution]
+  HitResolution --> Damage
+  HitResolution --> Hitstop
+  HitResolution --> Stagger[Posture+1]
+  Damage --> EnemyHP[Enemy Health]
+  Stagger --> EnemyFSM[Enemy FSM]
+  Stagger -->|threshold| EnemyState[忍殺チャンス / よろけ]
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Player | `PlayerActor`, `PlayerFSM`, `InputBuffer`, `StaminaPool`, `Posture` |
+| Enemy | `EnemyActor`, `EnemyFSM`, `AggroState`, `Posture` |
+| Combat | `Hitbox`, `Hurtbox`, `HitEvent`, `DamageResolver`, `Hitstop` |
+| Camera | `CameraRig`, `LockOnTarget`, `Shake` |
+| World | `Checkpoint`, `Region`, `Spawner` |
+
+## 対応するコード設計
+
+Ars アクターモデル上の典型配置 (疑似 Rust + Ergo モジュール):
+
+```rust
+// crates/game-action/src/player.rs
+pub struct PlayerActor {
+    fsm: PlayerFSM,
+    input: ergo_input_buffer::Buffer,   // 200ms
+    health: ergo_health::Health,        // ergo_health
+    posture: Posture,                   // ゲーム固有
+    stamina: StaminaPool,
+    transform: Transform,
+}
+
+impl Actor for PlayerActor {
+    fn tick(&mut self, dt: f32, ctx: &mut TickCtx) {
+        self.input.tick(dt);
+        if let Some(cmd) = self.input.next_command() {
+            self.fsm.dispatch(cmd, dt);
+        }
+        self.fsm.tick(dt, ctx);
+        self.posture.regen(dt);
+        self.stamina.regen(dt);
+        self.health.tick(dt);
+    }
+}
+
+// crates/game-action/src/combat.rs
+pub fn resolve_hit(
+    attacker: &mut Combatant,
+    defender: &mut Combatant,
+    hit: &HitEvent,
+) {
+    if defender.is_parrying() && hit.is_meleable() {
+        defender.posture.add(0);
+        attacker.posture.add(hit.parry_punish);
+        attacker.fsm.go_to(State::Staggered);
+        spawn_parry_vfx(attacker.transform);
+        return;
+    }
+    let dmg = hit.compute_damage(defender);
+    defender.health.apply_damage(dmg);
+    defender.posture.add(hit.posture_damage);
+    spawn_hit_vfx(defender.transform);
+    enter_hitstop(hit.hitstop_ms);
+}
+```
+
+```text
+src/
+  player/        Actor + FSM + Input
+  enemy/         Actor + AI states
+  combat/        Hitbox / Hurtbox / Resolver / Hitstop
+  camera/        Follow / LockOn / Shake
+  world/         Checkpoint / Spawner / Region
+```
+
+依存:
+- `ergo_health` (HP)
+- `ergo_input_buffer` (入力バッファ — game-lexicon §2)
+- `ergo_hitbox` (新規想定)
+- `ergo_frame` (フレームカウンタ)
+- `ergo_world_time` (ヒットストップ用 time-scale)

--- a/spec/game-template/deckbuilder_roguelike.md
+++ b/spec/game-template/deckbuilder_roguelike.md
@@ -1,0 +1,155 @@
+# デッキビルドローグライク テンプレート
+
+## 概要
+
+**Slay the Spire** が確立した「カードゲーム + ノードマップ + 永続死」 ジャンル。 代表作は **Slay the Spire**, **Monster Train**, **Inscryption (一部)**, **Dawncaster**, **Balatro (派生)**。
+
+コアループ:
+
+> マップノード選択 → 戦闘 (カードを引く / プレイ) → 報酬で新カード入手 → 蛇足 / レリック / 焚火 → ボス → 次の章 → 死亡 / 勝利
+
+特徴:
+
+- **デッキ**は 1 ランで動的に膨らむ (10 → 30 枚)
+- カード相互の **シナジー設計** が強さの肝 (毒 build / strength build / discard build...)
+- **レリック / アーティファクト** = 永続パッシブ。 コンボの起点
+- **戦闘** はターン制 + エナジー (毎ターン 3 等) + プレイ → 終了
+- **ノードマップ** (上方向に分岐) で道選びがメタ戦略
+
+## 必要不可欠な機能実装
+
+- `[card-pile]` (新規) Deck / Hand / Discard / Exhaust の 4 山を Card 配列で
+- `[draw-shuffle]` (新規) drawN / 補充時の shuffle (seeded)
+- `[energy]` (新規) ターン頭にリセットされるエナジー
+- `[card-effect]` (新規) attack / block / draw / status / power などのカード効果 DSL
+- `[targeting]` (新規) self / enemy / random / all / pick
+- `[turn-cycle]` (新規) Player draw → play → end → enemies → start of player
+- `[enemy-intent]` (新規) 次ターンの行動を「予告」する (Slay the Spire 由来)
+- `[health-system]` プレイヤー HP は永続、 戦闘内で削れる。 焚火で全快
+- `[block-armor]` (新規) ターン終了で消える防御値
+- `[status-power]` (新規) 状態 (Vulnerable, Weak, Poison) + パワー (Strength, Dexterity)
+- `[relic]` (新規) 永続パッシブ (戦闘前 / ターン頭 / 攻撃時 etc にトリガ)
+- `[node-map]` (新規) DAG 形式の章ごとのマップ (BFS で生成)
+- `[reward]` (新規) 戦闘後のカード選択 / ゴールド / レリック
+- `[shop]` (新規) ゴールドでカード / レリック / 削除
+- `[campfire]` (新規) 全快 / カードアップグレード / 任意イベント
+- `[run-record]` (新規) 死亡時の死因 / デッキ状態 + メタ通貨
+- `[seeded-rng]` (新規) リプレイ可能 seed
+- `[card-database]` (新規) カード定義 (TOML / JSON) — 数百種
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Run[Run] --> NodeMap
+  NodeMap --> Combat
+  NodeMap --> Shop
+  NodeMap --> Campfire
+  NodeMap --> Event
+  NodeMap --> Boss
+  Combat --> CardPiles
+  CardPiles -->|draw| Hand
+  Hand -->|play| Effect[Card Effect]
+  Effect --> EnemyIntent
+  Effect --> PlayerStatus
+  Effect --> EnemyStatus
+  Effect --> Block
+  Effect --> Damage
+  Damage --> Health
+  TurnEnd --> EnemiesAct
+  EnemiesAct --> Effect
+  CombatEnd --> Reward --> Deck
+  Run --> Relics
+  Relics -.->|trigger hooks| Effect
+  RunEnd --> Memorial
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Run | `Run`, `Seed`, `Floor`, `MetaCurrency`, `Memorial` |
+| Map | `NodeMap`, `Node (Combat/Shop/Campfire/Boss)`, `Edge` |
+| Deck | `CardPile (Deck/Hand/Discard/Exhaust)`, `Card`, `CardDatabase` |
+| Combat | `CombatState`, `Energy`, `TurnPhase`, `Block`, `StatusBag`, `PowerBag` |
+| Effect | `EffectScript`, `Targeting`, `EffectResolver` |
+| Enemy | `EnemyDef`, `Intent`, `EnemyAI`, `EnemyInstance` |
+| Relic | `Relic`, `RelicHook (OnPlay, OnTurnStart, OnDamage, ...)` |
+
+## 対応するコード設計
+
+戦闘は **イベントループ** + **小さな effect DSL** が安定する:
+
+```rust
+// crates/game-deckbuilder/src/card.rs
+#[derive(Clone)]
+pub struct Card {
+    pub id: CardId,
+    pub name: String,
+    pub cost: i32,           // -1 = X 消費 / 無消費
+    pub effects: Vec<EffectScript>,
+    pub kind: CardKind,      // Attack / Skill / Power
+    pub upgraded: bool,
+}
+
+pub enum EffectScript {
+    DealDmg { amount: Val, target: Target },
+    GainBlock { amount: Val },
+    ApplyStatus { status: StatusKind, amount: Val, target: Target },
+    GainEnergy(Val),
+    Draw(Val),
+    Custom(CustomFn),        // レアな例外用
+}
+
+// crates/game-deckbuilder/src/combat.rs
+pub struct CombatState {
+    pub player: PlayerCombat,
+    pub enemies: Vec<EnemyCombat>,
+    pub piles: CardPiles,
+    pub energy: i32,
+    pub turn: u32,
+    pub event_log: Vec<CombatEvent>,
+}
+
+pub fn play_card(state: &mut CombatState, hand_idx: usize, target: TargetSel) -> Result<()> {
+    let card = state.piles.hand.remove(hand_idx);
+    if state.energy < card.cost { return Err(NotEnoughEnergy); }
+    state.energy -= card.cost;
+    for eff in &card.effects {
+        resolve_effect(state, eff, target);
+    }
+    fire_relic_hook(state, RelicHook::OnPlay { card: &card });
+    if card.kind == CardKind::Power {
+        state.piles.power.push(card);
+    } else {
+        state.piles.discard.push(card);
+    }
+    Ok(())
+}
+
+// 敵 AI の intent: 次ターンに何をするか「先に見せる」
+pub fn enemy_intent(enemy: &EnemyCombat, rng: &mut Rng) -> Intent {
+    enemy.def.move_set.choose(rng)
+}
+```
+
+```text
+src/
+  run/           Run + NodeMap + Floor + Memorial
+  card/          Card definitions + CardDatabase (TOML)
+  pile/          Deck / Hand / Discard / Exhaust
+  combat/        CombatState + Energy + TurnPhase
+  effect/        EffectScript DSL + Resolver
+  enemy/         EnemyDef + Intent + AI
+  relic/         Relic + RelicHook
+  reward/        CardChoice + Gold + Relic drop
+  shop/          Pricing + Removal
+  campfire/      Rest / Smith
+  event/         Map ? events
+  ui/            CombatUI + DeckViewer + MapUI + RewardUI
+  rng/           Seeded Rng + DeterminismCheck
+```
+
+依存:
+- `ergo_health` `ergo_input`
+- カード定義は **TOML 駆動**にしてバランス調整を非エンジニアでも回せるようにする

--- a/spec/game-template/fighting.md
+++ b/spec/game-template/fighting.md
@@ -1,0 +1,150 @@
+# 格闘ゲーム テンプレート
+
+## 概要
+
+1v1 を基本とする 2D / 3D 格闘ゲーム。 代表作は **Street Fighter**, **Tekken**, **Guilty Gear**, **Mortal Kombat**, **King of Fighters**。
+
+コアループ:
+
+> ラウンド開始 → 間合い管理 → 起き攻め / コンボ / 投げ / ガード → ライフバー減少 → KO で 1 ラウンド勝利 → ベストオブ N で勝者決定
+
+特徴:
+
+- **フレーム精度** が命: 60 fps 固定 + 各技 startup / active / recovery
+- 三すくみ: **打撃** vs **投げ** vs **ガード** + 投げ抜けの確定割り込み
+- **コンボ** = 硬直差を利用した連続技。 「コンボ補正」 で長すぎないよう減衰
+- **画面端コンボ** = 受け側の壁ハメで延長
+- **ロールバックネットコード** が品質指標 (近年は MOBA 同様必須)
+- 1 試合 30-90 秒 → 短く再戦しやすい
+
+## 必要不可欠な機能実装
+
+- `[command-input]` →↓↘+P 等のコマンド解釈 (記号化 / モーション窓 / 短縮入力許可)
+- `[input-buffer]` 入力バッファ
+- `[frame-data]` 技ごとの startup / active / recovery / hit-stun / block-stun
+- `[hitbox-system]` 攻撃ボックス + 食らいボックス + push ボックス + 投げボックス
+- `[guard-throw]` 三すくみ + 投げ抜け
+- `[combo-system]` ヒット中はキャンセル可、 補正 (ダメージ減衰 + スケーリング)
+- `[health-system]` HP バー
+- `[round-system]` ベストオブ N + タイムオーバー判定
+- `[hitstop]` 命中で時間停止
+- `[super-meter]` (新規) 超必殺ゲージ (攻撃 / 被弾 / ガードで増加)
+- `[burst-defense]` (新規 / 任意) ガード不能脱出 (GG 系)
+- `[counter-hit]` (新規) 確定反撃時の補正 + ダメージ増
+- `[corner-detect]` (新規) 画面端での挙動分岐
+- `[character-roster]` (新規) 各キャラのスキル + フレームデータ + ヒットボックス定義
+- `[rollback-netcode]` 対人戦のロールバック実装
+- `[training-mode]` (新規) 操作・コンボ練習モード
+- `[replay]` (新規) 入力ログから完全再生
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Input -->|frame-perfect| Parser[Command Parser]
+  Parser --> Move[Selected Move]
+  Move --> FSM[Character FSM]
+  FSM -->|active frame| Hitbox
+  FSM --> Hurtbox
+  Hitbox -->|overlap| OtherHurt[Other Hurtbox]
+  OtherHurt --> HitResolve
+  HitResolve --> Damage --> HP
+  HitResolve --> StunFrames
+  StunFrames --> OtherFSM[Other Char FSM]
+  HitResolve --> ComboCounter
+  ComboCounter --> DamageScale
+  HitResolve --> Hitstop
+  HitResolve --> SuperMeter
+  RoundClock --> RoundEnd
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Character | `CharacterDef`, `CharacterInstance`, `FSM`, `MoveSet`, `FrameData` |
+| Input | `InputFrame`, `CommandParser`, `MotionTable` |
+| Combat | `Hitbox`, `Hurtbox`, `PushBox`, `ThrowBox`, `HitResolve` |
+| Combo | `ComboCounter`, `DamageScaling`, `HitStunStack` |
+| Match | `RoundController`, `MatchResult`, `Stage`, `CornerDetect` |
+| Net | `RollbackEngine`, `Snapshot`, `Reconcile` |
+
+## 対応するコード設計
+
+整数演算 + 60Hz 固定 + 全状態シリアライザブル:
+
+```rust
+// crates/game-fight/src/character.rs
+pub struct CharacterInstance {
+    pub def: &'static CharacterDef,
+    pub state: StateId,           // Stand / Crouch / Air / Block / HitStun ...
+    pub frame_in_state: u16,      // フレームカウンタ (state 内)
+    pub hp: i32,
+    pub super_meter: i32,
+    pub pos: FixedVec2,           // 整数 / 固定小数
+    pub vel: FixedVec2,
+    pub facing: Facing,
+    pub hit_stun: u16,
+    pub block_stun: u16,
+    pub combo_count: u16,
+    pub combo_scale: u16,         // % (100 = 通常)
+}
+
+// crates/game-fight/src/move.rs
+#[derive(Clone)]
+pub struct MoveDef {
+    pub name: String,
+    pub cmd: CommandPattern,           // ex. "236P"
+    pub startup: u16,
+    pub active:  u16,
+    pub recovery: u16,
+    pub hit_stun: u16,
+    pub block_stun: u16,
+    pub hit_dmg:   i32,
+    pub guard_dmg: i32,
+    pub hitboxes: Vec<HitboxKey>,      // active 中のフレームごとの形状
+    pub cancel_window: Vec<CancelInto>,// このフレーム以降このムーブにキャンセル可
+}
+
+// crates/game-fight/src/parser.rs
+pub fn parse_command(buffer: &InputBuffer, motions: &MotionTable, current_state: StateId) -> Option<&'static MoveDef> {
+    // 例: "236P" = 下 → 下右 → 右 + P 押下、 ms 窓 400 内に成立
+    // motions table を新しい順 / 高優先度順で評価
+    motions.iter()
+        .filter(|m| m.allowed_in(current_state))
+        .find(|m| m.matches(buffer))
+}
+
+// crates/game-fight/src/combat.rs
+pub fn resolve_hit(att: &mut CharacterInstance, def: &mut CharacterInstance, hitbox: &Hitbox) {
+    let blocked = def.is_blocking(hitbox);
+    if blocked {
+        let dmg = scale(hitbox.guard_dmg, def.combo_scale);
+        def.hp -= dmg.max(1);                         // 削りダメージ
+        def.block_stun = hitbox.block_stun;
+    } else {
+        let dmg = scale(hitbox.hit_dmg, def.combo_scale);
+        def.hp -= dmg;
+        def.hit_stun = hitbox.hit_stun;
+        def.combo_count += 1;
+        def.combo_scale = scaling_after(def.combo_count);
+    }
+    enter_hitstop(hitbox.hitstop);
+    att.super_meter += hitbox.meter_gain_attacker;
+    def.super_meter += hitbox.meter_gain_defender;
+}
+```
+
+```text
+crates/
+  game-fight-sim/      決定論シム (i32 / 固定小数)
+  game-fight-data/     キャラ + 技 + フレームデータ (TOML)
+  game-fight-net/      ロールバック + 入力遅延制御
+  game-fight-replay/   入力ログ + ステップ再生
+  game-fight-train/    トレモ (フレーム可視化 / 入力履歴)
+  game-fight-client/   描画 + UI
+```
+
+依存:
+- `ergo_health`
+- 60 Hz 固定 tick + すべての state を `Clone + Serialize` にする (ロールバック前提)

--- a/spec/game-template/fps.md
+++ b/spec/game-template/fps.md
@@ -1,0 +1,170 @@
+# FPS テンプレート
+
+## 概要
+
+一人称視点シューター。 代表作は **Counter-Strike**, **Apex Legends**, **Call of Duty**, **Valorant**, **Halo**, **DOOM Eternal**。
+
+コアループ:
+
+> マッチ開始 → ラウンド開始 → 配置 / 索敵 → 交戦 (撃ち合い) → キル / デス → 次ラウンドへ → ベストオブ N → マッチ結果
+
+特徴:
+
+- **エイム** が中心スキル。 一発の遅延 (latency) と命中精度がプレイ感を決める
+- **対戦ネットコード** は MOBA 同等 (むしろよりシビア — 1ms ラグで撃ち負ける)
+- **マップデザイン** が試合の半分。 ライン / ローテーション / 視認性 / オーディオキュー
+- **武器バランス** + **マスターチェック** (ヘッドショット倍率 / ダメージ減衰 / リコイルパターン)
+- **アンチチート** が事業継続の前提
+- 1 ラウンド 30 秒-2 分、 1 マッチ 15-40 分
+
+## 必要不可欠な機能実装
+
+- `[fps-controller]` (新規) 一人称カメラ + WASD + ジャンプ + クラウチ + スプリント
+- `[mouse-aim]` (新規) raw input + sensitivity + invert + DPI 補正
+- `[weapon-system]` 発射 + リロード + 切替 + クールダウン
+- `[recoil]` 発射ごとの照準跳ね + 自動戻り + パターン
+- `[hitscan]` (新規) 即着弾射撃 (光線で当たり判定)
+- `[projectile-system]` ロケット / グレネード / 弾道計算 (gravity / drag)
+- `[hitbox-system]` 部位別 (ヘッド / 胴 / 手足) ダメージ倍率
+- `[health-system]` HP + アーマー + 回復遅延
+- `[round-system]` ラウンド勝敗 + 時間 + 経済 (CS 系)
+- `[map-loading]` (新規) 大規模マップロード + ナビメッシュ
+- `[sound-occlusion]` (新規) 足音 / 銃声の壁 / 距離減衰 (FPS では情報源として超重要)
+- `[footstep-system]` (新規) 移動速度別の足音
+- `[killcam-replay]` (新規) 死亡視点リプレイ (1-3 秒前から)
+- `[scoreboard]` (新規) リアルタイム K/D/A
+- `[chat-voice]` (新規) チーム / 全体 / VC
+- `[matchmaking]` (新規) MMR + ロビー
+- `[anti-cheat]` (新規) クライアント完全性 + 統計検出
+- `[server-authoritative]` (新規) サーバ権威モデル (チート抑止)
+- `[lag-compensation]` (新規) shoot 時の被弾者位置を時間補正
+- `[loadout]` (新規 / 任意) 武器カスタム + 携行武器選択
+- `[ranking]` (新規) シーズン制 + ランクポイント
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Match --> Map
+  Match --> Teams
+  Teams --> Players
+  Players --> Loadout
+  Players --> Position
+  Players -->|input| Aim & Move & Shoot
+  Shoot -->|hitscan or projectile| HitResolve
+  HitResolve -->|server side + lag comp| Damage
+  Damage --> HP
+  HP -->|0| Death --> Killfeed & Killcam
+  Round --> RoundTimer
+  RoundTimer --> RoundEnd
+  RoundEnd --> EconomyUpdate (CS)
+  RoundEnd --> NextRound
+  Match --> ServerTick[Server Tick (64-128Hz)]
+  ServerTick --> ClientPrediction
+  ServerTick --> Snapshot --> ClientInterp
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Match | `Match`, `Team`, `Round`, `Score`, `Phase` |
+| Player | `Player`, `Loadout`, `Health`, `Armor`, `EconomicState` |
+| Weapon | `WeaponDef`, `WeaponInstance`, `Magazine`, `RecoilPattern` |
+| World | `Map`, `Spawn`, `BombSite`, `NavMesh`, `Physics` |
+| Net | `ServerTick`, `Snapshot`, `Prediction`, `LagComp`, `Reconcile` |
+| Audio | `Footstep`, `WeaponSFX`, `Occlusion`, `SpatialMixer` |
+| Service | `Matchmaker`, `Anticheat`, `Scoreboard`, `KillCam` |
+
+## 対応するコード設計
+
+サーバ権威 + クライアント予測 + ラグ補正が三本柱:
+
+```rust
+// crates/game-fps-server/src/tick.rs
+//
+// サーバが 64-128Hz で動く。 全プレイヤーの input は時刻スタンプ付きで届く。
+// shoot を判定する時は、 撃った側の input frame の "敵の位置" まで遡る (lag comp)。
+pub struct ServerTick {
+    pub tick: u64,
+    pub state: WorldState,
+    pub history: VecDeque<WorldState>,    // 最近 N=64 tick (= 0.5-1 秒) 保持
+}
+
+pub fn process_input(server: &mut ServerTick, peer: PeerId, frame: InputFrame) {
+    let player = server.state.player_mut(peer);
+    player.apply_movement(frame.move_input);
+    if frame.shoot {
+        let shoot_tick = frame.tick;                            // クライアントが撃った時刻
+        let snap = server.history.iter().find(|s| s.tick == shoot_tick).unwrap_or(&server.state);
+        let result = lag_compensated_hitscan(snap, peer, frame.aim);
+        match result {
+            HitResult::Hit { target, part, distance } => {
+                let dmg = damage_for(player.weapon, part, distance);
+                server.state.player_mut(target).health -= dmg;
+                server.broadcast(Event::Hit { by: peer, target, part, dmg });
+            }
+            HitResult::Miss => {}
+        }
+    }
+}
+
+// crates/game-fps-client/src/predict.rs
+//
+// クライアント側はサーバ確定までの間、 自分の入力を「予測」 して動かしておく。
+// サーバ確定値が違っていたら、 reconcile (差分修正) する。
+pub struct Predictor {
+    pub last_confirmed_tick: u64,
+    pub local_state_history: VecDeque<LocalSnapshot>,
+}
+
+impl Predictor {
+    pub fn on_server_snapshot(&mut self, snap: ServerSnapshot, local_inputs: &[InputFrame]) {
+        if let Some(local) = self.local_state_history.iter().find(|s| s.tick == snap.tick) {
+            if local.matches(snap) { return; }       // 一致 → 予測当たり
+        }
+        // 不一致 → 確定スナップを起点に未確認入力を再シミュレートして現在へ
+        let mut state = snap.into_local();
+        for f in local_inputs.iter().filter(|f| f.tick > snap.tick) {
+            state.tick(f);
+        }
+        self.local_state_history.replace_to(state);
+    }
+}
+
+// crates/game-fps-core/src/recoil.rs
+pub struct RecoilPattern {
+    pub vertical:    Vec<f32>,    // 0..N: 各発の垂直キック (deg)
+    pub horizontal:  Vec<f32>,    // 横ぶれ
+    pub recovery_per_sec: f32,    // 自動戻り
+}
+
+impl RecoilPattern {
+    pub fn apply(&self, shot_index: usize, dt_since_last: f32, current: &mut Vec2) {
+        let v = self.vertical.get(shot_index).copied().unwrap_or(*self.vertical.last().unwrap());
+        let h = self.horizontal.get(shot_index).copied().unwrap_or(0.0);
+        current.y += v;
+        current.x += h;
+        // (recovery は別途毎フレーム適用)
+    }
+}
+```
+
+```text
+crates/
+  game-fps-core/      WorldState + Player + Weapon + Recoil
+  game-fps-server/    ServerTick + LagComp + Anticheat
+  game-fps-client/    Prediction + Reconcile + Render hook
+  game-fps-net/       Snapshot + Delta + Compress
+  game-fps-audio/     Spatial + Occlusion + Footstep
+  game-fps-data/      Weapon / Map / Loadout (TOML)
+  game-fps-match/     Matchmaking + Lobby + Loadout select
+  game-fps-replay/    KillCam + Match replay
+  game-fps-ui/        HUD + ScoreBoard + ChatVoice
+```
+
+依存:
+- `ergo_health`
+- ネットワーク基盤は WebRTC / UDP + 独自プロトコル (Synergos 流用も可)
+- audio は WASAPI / OpenAL / Steam Audio などプラットフォーム依存
+- アンチチート + サーバ権威 + ラグ補正 がそろわないと商用にならない

--- a/spec/game-template/hack_and_slash.md
+++ b/spec/game-template/hack_and_slash.md
@@ -1,0 +1,145 @@
+# ハクスラ (Hack & Slash ARPG) テンプレート
+
+## 概要
+
+俯瞰視点の **Loot 駆動アクション RPG**。 代表作は **Diablo 1/2/3/4**, **Path of Exile**, **Grim Dawn**, **Last Epoch**, **Torchlight**。
+
+コアループ:
+
+> 進入 → モブ大量虐殺 → アイテムドロップ → 装備更新 → ボス → 次の難度 / 次のマップ → 倒した敵から良いアイテム → endless
+
+特徴:
+
+- **ランダム化アイテム** (rarity, prefix/suffix mod, ilvl) が中心動機
+- **クラス + ビルド** (スキルツリー / ジェム / クラフト)
+- マップは**毎回プロシージャル**生成 (PoE は「マップアイテム」 = 1 マップ単位)
+- 「**画面外まで埋まる敵**」 + AOE スキル + パーティクル爆発
+- 装備の **比較 UI** + ストレージ 管理 が重要 (大量に拾うため)
+
+## 必要不可欠な機能実装
+
+- `[character-class]` (新規) Barbarian / Sorceress / ... + 専用ステ + スキルツリー
+- `[skill-tree]` (新規) パッシブ + アクティブのノード DAG
+- `[stat-system]` HP / mana / armor / damage + 多数の secondary (resist / fr / cr / ...)
+- `[loot-table]` (新規) 敵 ID + 場所 + ilvl からのドロップ確率表
+- `[item-mods]` (新規) prefix / suffix / implicit + 階層 (rarity)
+- `[item-rarity]` (新規) Normal / Magic / Rare / Unique / Legendary / Set
+- `[stash]` (新規) 大容量ストレージ (タブ / 検索)
+- `[inventory]` グリッド型 (Diablo 2 系) または重量型
+- `[crafting]` (新規) リロール / 強化 / アップグレード
+- `[skill-bar]` (新規) アクティブスキル N 個割当 (左右クリック + 1-9)
+- `[ground-loot]` (新規) ドロップアイテムが地面に表示 (label) / ピックアップ
+- `[procgen-map]` (新規) マップタイル / 装飾 / 敵パック / ボス位置の手続き生成
+- `[difficulty-tiers]` (新規) Normal / Nightmare / Hell / Torment ...
+- `[currency]` ゴールド + 専用通貨 (Orb of Alchemy 等)
+- `[party-coop]` (新規 / 任意) 4 人マルチ (ホスト / クライアント)
+- `[seasons]` (新規 / 任意) 期間制リーダーボード / 専用ビルド
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Character --> Stats
+  Character --> SkillTree
+  Character --> Inventory
+  Character --> SkillBar
+  Inventory --> EquippedItems --> StatBag[Total Stats]
+  StatBag --> Damage
+  Damage --> EnemyHP
+  EnemyHP -->|0| Loot[Loot Table Roll]
+  Loot --> ItemMods[prefix + suffix]
+  ItemMods --> GroundDrop
+  GroundDrop -->|pickup| Inventory
+  Map --> ProcgenSeed
+  ProcgenSeed --> TileLayout
+  ProcgenSeed --> EnemyPacks
+  ProcgenSeed --> BossPosition
+  Difficulty --> LootTable
+  Difficulty --> EnemyHP
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Character | `Character`, `Class`, `SkillTree`, `Stats`, `SkillBar`, `Inventory`, `Stash` |
+| Skill | `SkillDef`, `Active vs Passive`, `Rank`, `JewelSlot` |
+| Item | `ItemBase`, `ModRoll`, `Affix`, `Rarity`, `ImplicitMod`, `Sockets` |
+| Loot | `LootTable`, `MonsterFamily`, `Rarity weights`, `MagicFind` |
+| Map | `MapDef`, `ProcgenSeed`, `Tile`, `EnemyPack`, `Boss` |
+| Crafting | `Currency`, `CraftRecipe`, `Modifier` |
+| Run / Difficulty | `Difficulty`, `Tier`, `MapModifiers` |
+
+## 対応するコード設計
+
+```rust
+// crates/game-hns/src/item.rs
+pub struct ItemRoll {
+    pub base: ItemBase,
+    pub ilvl: u16,
+    pub rarity: Rarity,
+    pub prefixes: Vec<ModRoll>,    // up to 3
+    pub suffixes: Vec<ModRoll>,    // up to 3
+    pub implicit: Option<ModRoll>,
+    pub sockets:  Vec<Socket>,
+}
+
+pub fn roll_item(rng: &mut Rng, base: ItemBase, ilvl: u16, rarity: Rarity, modpool: &ModPool) -> ItemRoll {
+    let mut item = ItemRoll {
+        base, ilvl, rarity,
+        prefixes: vec![], suffixes: vec![],
+        implicit: base.implicit_mod.clone(),
+        sockets: roll_sockets(rng, base, ilvl),
+    };
+    let (n_prefix, n_suffix) = match rarity {
+        Rarity::Normal => (0, 0),
+        Rarity::Magic  => (rng.range(0..=1), rng.range(0..=1)),
+        Rarity::Rare   => (rng.range(1..=3), rng.range(1..=3)),
+        Rarity::Unique => return roll_unique(rng, base, ilvl),
+    };
+    for _ in 0..n_prefix {
+        let m = modpool.pick(rng, ModSlot::Prefix, base.tags(), ilvl);
+        item.prefixes.push(m.roll(rng));
+    }
+    for _ in 0..n_suffix {
+        let m = modpool.pick(rng, ModSlot::Suffix, base.tags(), ilvl);
+        item.suffixes.push(m.roll(rng));
+    }
+    item
+}
+
+// crates/game-hns/src/stats.rs
+//
+// 装備 + パッシブ + バフを集計して「現在の合計ステ」 を出す。
+// 計算は乗算・加算の順序ルールを厳密に定義する (PoE 流の "more / increased / added")。
+pub struct ComputedStats {
+    pub max_hp: i64,
+    pub damage_per_hit: f64,
+    pub crit_chance: f32,
+    // ...
+}
+
+pub fn compute_stats(c: &Character, eq: &EquippedSet, buffs: &[Buff]) -> ComputedStats {
+    ...
+}
+```
+
+```text
+src/
+  character/     Character + Class + SkillTree + Stats compute
+  skill/         SkillDef + Active / Passive + JewelSlot
+  item/          ItemBase + ModRoll + Roller + Affix DB
+  loot/          LootTable + MagicFind
+  inventory/     Grid layout + Stash tabs + Search
+  craft/         Currency + Recipe
+  map/           MapDef + ProcgenSeed + Tile + Pack
+  enemy/         Family + Pack + Boss + ElitePacks
+  difficulty/    DifficultyTier + MapModifier
+  party/         CoopHost + ClientSync
+  ui/            ItemTooltip + Comparator + StashUI + SkillTreeUI
+```
+
+依存:
+- `ergo_health`
+- アイテム mod プールは **TOML 管理** + バランスシートから生成
+- 装備変更時の stats 再計算は dirty フラグでバッチ化

--- a/spec/game-template/jrpg.md
+++ b/spec/game-template/jrpg.md
@@ -1,0 +1,180 @@
+# JRPG (ストーリードリブン) テンプレート
+
+## 概要
+
+ターン制 / ATB / CTB のコマンドバトル + 物語進行。 代表作は **Dragon Quest**, **Final Fantasy IV-IX**, **Persona 4/5**, **Octopath Traveler**, **Bravely Default**。
+
+コアループ:
+
+> 街 / イベント → ダンジョン探索 (エンカウント) → 戦闘 (コマンド選択) → 経験値 + アイテム → レベルアップ + 装備 → 次のイベントへ
+
+特徴:
+
+- **シナリオが主役**。 イベント (会話 + 演出 + 選択肢) のスクリプティングが中心
+- **パーティ** (3-4 人) を切り替えて戦う。 役割分担 (タンク / DPS / ヒーラー / バッファー)
+- **戦闘は別画面** (背景がフェードして戦闘 BG に切替) もあり、 シームレス (Tales 系) もあり
+- **装備** + **スキル習得** (経験値 / SP / ジョブシステム)
+- **クラフト / 合成** + **裏ボス** + **ミニゲーム** で長尺化
+
+## 必要不可欠な機能実装
+
+- `[command-battle]` ATB / Turn / CTB の戦闘ループ
+- `[stat-system]` HP / MP / 攻 / 防 / 速 / 知 / 運 + 属性耐性 + 状態耐性
+- `[party-system]` (新規) 3-4 名のパーティ + リザーブ
+- `[skill-learning]` (新規) Lv up / SP / ジョブで習得
+- `[equipment-slots]` (新規) 武器 / 防具 / 装飾品 + 個別ステ補正
+- `[status-effect]` (新規) 毒 / 麻痺 / 沈黙 / 混乱 / バフ + ターン経過減衰
+- `[elemental-affinity]` (新規) 弱点 / 耐性 / 無効 / 吸収
+- `[encounter]` (新規) ランダム / シンボルエンカウント
+- `[dialogue-system]` 会話 + 選択肢 + 分岐
+- `[event-script]` (新規) イベントシーンの演出スクリプト (テキスト / カメラ / SE)
+- `[quest-system]` メイン + サイドクエスト
+- `[inventory]` アイテム + 装備 + キーアイテム
+- `[shop]` (新規) 売買 + 在庫
+- `[crafting]` (新規 / 任意) 合成 / 強化
+- `[save-load]` 任意セーブ + オートセーブ
+- `[level-up-screen]` レベルアップ + 習得スキル表示
+- `[overworld]` (新規) 街 / 世界マップ / ダンジョン
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Overworld --> Town & Dungeon & WorldMap
+  Town --> Shop & Inn & NPC
+  Dungeon --> Encounter --> Battle
+  Battle --> Party
+  Battle --> Enemies
+  Party -->|select| Command
+  Command -->|act| BattleResolve
+  BattleResolve --> Damage
+  BattleResolve --> StatusApply
+  BattleResolve --> NextATB[ATB / Turn 進行]
+  BattleEnd --> XP & Gold & Loot
+  XP --> LevelUp
+  Loot --> Inventory
+  EventScript --> Dialogue
+  Dialogue --> Choice
+  Choice --> StoryFlag
+  StoryFlag --> NextScene
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Party | `Character`, `Job`, `Stats`, `Equipment`, `SkillSet`, `Reserve` |
+| Battle | `BattleState`, `Combatant`, `Command`, `ATBClock`, `BattleRng` |
+| Effect | `Status`, `Buff`, `Element`, `DamageFormula` |
+| World | `Town`, `Dungeon`, `WorldMap`, `EncounterTable` |
+| Script | `Event`, `Choice`, `Flag`, `Cutscene` |
+| Inventory | `Item`, `Equipment`, `KeyItem`, `Stack` |
+| Quest | `Quest`, `QuestStep`, `Tracker` |
+| Save | `SaveSlot`, `Snapshot`, `AutoSave` |
+
+## 対応するコード設計
+
+戦闘とフィールドは独立したシステムにする (が同じ Character を参照):
+
+```rust
+// crates/game-jrpg/src/character.rs
+pub struct Character {
+    pub id: CharId,
+    pub name: String,
+    pub level: u16,
+    pub xp: u64,
+    pub stats: Stats,                // ベース値
+    pub equipment: Equipment,
+    pub skills: Vec<SkillId>,        // 習得済み
+    pub statuses: StatusBag,
+    pub current_hp: i32,
+    pub current_mp: i32,
+}
+
+impl Character {
+    pub fn effective_stats(&self) -> Stats {
+        let mut s = self.stats.clone();
+        s.add(self.equipment.modifiers());
+        s.add(self.statuses.modifiers());
+        s
+    }
+}
+
+// crates/game-jrpg/src/battle.rs
+//
+// ATB: 各キャラに 0..1000 の ATB ゲージがあり、 速さに応じて貯まり、
+// 1000 に達したら命令選択画面が出る、 が古典 ATB のモデル。
+pub struct BattleState {
+    pub party:   Vec<CombatantId>,
+    pub enemies: Vec<CombatantId>,
+    pub combat:  HashMap<CombatantId, Combatant>,
+    pub atb:     HashMap<CombatantId, u16>,     // 0..1000
+    pub turn_queue: VecDeque<CombatantId>,
+    pub log: Vec<BattleEvent>,
+    pub rng: SeededRng,
+}
+
+pub fn tick_atb(state: &mut BattleState, dt_ms: u32) {
+    for (id, c) in &state.combat {
+        if !c.alive() { continue; }
+        let speed = c.character.effective_stats().speed;
+        let inc = ((speed as u32 * dt_ms) / 100) as u16;
+        let v = state.atb.entry(*id).or_insert(0);
+        *v = (*v + inc).min(1000);
+        if *v >= 1000 && !state.turn_queue.contains(id) {
+            state.turn_queue.push_back(*id);
+        }
+    }
+}
+
+pub fn execute_command(state: &mut BattleState, by: CombatantId, cmd: Command) {
+    let actor = state.combat.get(&by).unwrap();
+    match cmd {
+        Command::Attack(target) => {
+            let dmg = damage_formula(&state, by, target);
+            state.combat.get_mut(&target).unwrap().character.current_hp -= dmg;
+            state.log.push(BattleEvent::Damage { by, target, dmg });
+        }
+        Command::Skill(skill_id, target) => skill::resolve(state, by, skill_id, target),
+        Command::Item(item_id, target) => item::use_in_battle(state, by, item_id, target),
+        Command::Defend => state.combat.get_mut(&by).unwrap().defending = true,
+        Command::Run => try_escape(state, by),
+    }
+    state.atb.insert(by, 0);
+}
+
+// crates/game-jrpg/src/script.rs
+//
+// イベントスクリプトは外部 DSL (Lua / Rhai / 独自 YAML) が無難。
+// 進行は state machine + 各 Step を駆動する Director に任せる。
+pub enum EventStep {
+    Show { speaker: String, line: String },
+    Choose { options: Vec<String> },
+    Camera { ... },
+    Wait { ms: u32 },
+    SetFlag { name: String, value: bool },
+    SpawnBattle { enemies: Vec<EnemyId> },
+    Move { actor: ActorRef, to: Coord },
+}
+```
+
+```text
+src/
+  character/     Character + Job + Stats + Equipment
+  party/         Party + Reserve + Formation
+  battle/        BattleState + ATB + Command + Resolver
+  skill/         Skill DB + Resolver
+  status/        StatusEffect + StatusBag
+  field/         Town + Dungeon + WorldMap + Encounter
+  script/        EventScript runner (Lua / 独自)
+  dialogue/      Window + Choice + AutoText
+  inventory/     Item + Equipment + KeyItem
+  quest/         Quest + Step + Tracker
+  shop/          Inventory + Pricing
+  save/          Snapshot + AutoSave
+  ui/            BattleUI / FieldUI / MenuUI
+```
+
+依存:
+- `ergo_health` `ergo_input`
+- スクリプトは Lua / Rhai が現実解 — でも独自 YAML DSL で 80% カバー可

--- a/spec/game-template/metroidvania.md
+++ b/spec/game-template/metroidvania.md
@@ -1,0 +1,127 @@
+# メトロイドヴァニア テンプレート
+
+## 概要
+
+「能力解放で行ける場所が広がる」 探索型 2D アクション。 代表作は **Super Metroid**, **Castlevania: Symphony of the Night**, **Hollow Knight**, **Ori and the Will of the Wisps**, **Blasphemous**。
+
+コアループ:
+
+> 探索 → 行き止まり (能力不足) → ボス / 隠し部屋 → 新能力 (二段ジャンプ / ダッシュ / 壁張り付き) → 既存ステージで通れなかった場所が解放 → さらに探索
+
+特徴:
+
+- **シームレス相互接続マップ** (loading 無しのエリア遷移、 部屋単位の遅延 load も可)
+- **能力ロックゲート** が中心: 物理的に通れない壁・床・ピット
+- **ボス戦** + **隠し** の連鎖。 探索の動機 = 報酬 (能力 / 体力タンク / マナ)
+- 100% コンプを目指す上級層と、 メイン進行で十分な層、 両方を満たす設計
+- **マップ画面** (ミニマップ) が UX の半分
+
+## 必要不可欠な機能実装
+
+- `[player-controller-2d]` プラットフォーマー基礎 + 拡張能力
+- `[ability-system]` (新規) 取得済み能力フラグ (二段 / ダッシュ / 壁ジャンプ / 反射弾 ...)
+- `[gate-trigger]` (新規) 「特定能力を要求」 する地形ゲート
+- `[interconnected-rooms]` (新規) 部屋単位ロード + 相互シームレス遷移
+- `[minimap-system]` (新規) 探索済 / 未探索 / セーブポイント / アイテムを表示
+- `[save-room]` (新規) 限定地点でのセーブ + 全快
+- `[boss-fight]` (新規) ボスごとのフェーズ移行 + 専用 BGM + アリーナ閉鎖
+- `[health-system]` HP コンテナ + ハート / タンク 拡張
+- `[mp-resource]` (新規 / 任意) 魔法 / 能力使用に消費する追加リソース
+- `[secret-detect]` (新規) 偽壁 / 隠し床のフラグ管理
+- `[item-pickup]` (新規) 永続効果アイテム (ダブルジャンプ取得 etc)
+- `[lore-collectible]` (新規) ロアテキスト断片 (Hollow Knight の Hunter's Journal 等)
+- `[fast-travel]` 任意 — 能力アンロック後に解放されるテレポーター
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Player --> AbilityFlags[Ability Set]
+  Map --> Rooms
+  Rooms --> Gates[Gates]
+  Gates -->|require| AbilityFlags
+  Player -->|enter| Rooms
+  Rooms -->|on enter| RoomLoader
+  Player -->|defeats| Boss
+  Boss -->|drops| Ability
+  Ability --> AbilityFlags
+  Player -->|reaches| SaveRoom
+  SaveRoom --> SaveSlot
+  Player -->|maps| Minimap
+  Minimap --> ExploredFlags
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Player | `PlayerActor`, `AbilityFlags`, `HealthTanks`, `Mana` |
+| World | `WorldMap`, `Room`, `RoomTransition`, `Gate`, `SaveRoom` |
+| Combat | `EnemyDef`, `EnemyInstance`, `Boss`, `Phase`, `Aggro` |
+| Progression | `AbilityDef`, `Pickup`, `Secret`, `LoreEntry` |
+| UI | `Minimap`, `AbilityListUI`, `BossHUD` |
+
+## 対応するコード設計
+
+```rust
+// crates/game-mvania/src/ability.rs
+bitflags! {
+    pub struct AbilityFlags: u64 {
+        const DOUBLE_JUMP    = 1 << 0;
+        const DASH           = 1 << 1;
+        const WALL_JUMP      = 1 << 2;
+        const SUPER_MISSILE  = 1 << 3;
+        const SHINESPARK     = 1 << 4;
+        const FAST_TRAVEL    = 1 << 5;
+        // ...
+    }
+}
+
+// crates/game-mvania/src/gate.rs
+pub struct Gate {
+    pub pos: Coord,
+    pub kind: GateKind,            // ColorBlock / IceWall / VineGrowth ...
+    pub require: AbilityFlags,
+}
+
+impl Gate {
+    pub fn can_pass(&self, abilities: AbilityFlags) -> bool {
+        abilities.contains(self.require)
+    }
+}
+
+// crates/game-mvania/src/world.rs
+pub struct WorldMap {
+    pub rooms: HashMap<RoomId, RoomDef>,
+    pub edges: Vec<RoomEdge>,       // 部屋接続 (ドア / トランジション)
+    pub gates: Vec<Gate>,
+    pub current_room: RoomId,
+    pub explored: HashSet<RoomId>,
+}
+
+pub fn enter_room(world: &mut World, dest: RoomId, from_edge: EdgeId) {
+    let prev = world.map.current_room;
+    world.unload_room(prev);
+    world.load_room(dest);
+    world.map.current_room = dest;
+    world.map.explored.insert(dest);
+    world.minimap.mark_explored(dest);
+}
+```
+
+```text
+src/
+  player/        Controller (extends platformer) + Ability use
+  ability/       AbilityFlags + AbilityUnlocks
+  world/         WorldMap + Room + RoomEdge + Gate
+  enemy/         Enemy / Boss / Phase
+  saveroom/      SavePoint + Restoration
+  minimap/       Minimap state + render
+  pickup/        AbilityPickup / HealthTank / Lore
+  ui/            BossHUD + InventoryUI + LoreReader
+```
+
+依存:
+- `[platformer]` 基礎を使い回す
+- `ergo_health` `ergo_input`
+- 部屋ロード戦略は **room-streaming** (現在 + 隣接 N 部屋を常駐) が安定する

--- a/spec/game-template/moba.md
+++ b/spec/game-template/moba.md
@@ -1,0 +1,146 @@
+# MOBA テンプレート
+
+## 概要
+
+5v5 アリーナ制対戦ゲーム。 代表作は **League of Legends**, **Dota 2**, **Smite**, **Mobile Legends**, **Wild Rift**。
+
+コアループ:
+
+> ピックバン → 5v5 で各々レーンに配置 → 経験値 / 金で成長 → タワー破壊 → ジャングル / オブジェクト争奪 → ベース陥落 → 勝敗
+
+特徴:
+
+- **対戦ネットコード** (低遅延, ロールバック / クライアント予測) が品質の半分
+- **ヒーロー (チャンピオン)** ごとの **能動スキルセット** (Q/W/E/R) + **パッシブ**
+- **ミニオンウェーブ** + **タワー** + **オブジェクト** (ドラゴン / バロン) の経済設計
+- **アイテム** (300 種前後) の組合せ
+- **試合 25-40 分**、 試合外メタは **ランクポイント** + **シーズン**
+
+## 必要不可欠な機能実装
+
+- `[hero-skill]` ヒーローごとの Q/W/E/R + パッシブ + ulti unlock level
+- `[stat-system]` HP / MP / AD / AP / armor / MR / move speed / attack speed / ...
+- `[leveling]` 経験値 → レベル up でスキル強化
+- `[minion-wave]` 一定間隔のレーンウェーブ
+- `[tower-objective]` タワー (range 攻撃) + ベース (Inhibitor)
+- `[neutral-camp]` (新規) ジャングルキャンプ (リスポーンタイマー)
+- `[item-shop]` (新規) ベース内 shop で購入 / 売却
+- `[item-database]` (新規) アイテム + パッシブ + コンポーネント階層
+- `[hitbox-system]` スキルショット / AOE / DOT
+- `[rollback-netcode]` ロールバックネットコード (frame-perfect 同期)
+- `[client-prediction]` (新規) 入力予測 + reconcile
+- `[matchmaking]` (新規) MMR / Elo + キュー時間
+- `[ban-pick]` (新規) 試合前のバンピックフェーズ
+- `[chat-ping]` (新規) ボイス / テキスト / マップピン
+- `[replay]` (新規) 入力ログから完全再現
+- `[anti-cheat]` (新規) クライアント整合性検証
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Match[Match] --> Map
+  Match --> Teams[2 Teams x 5 Players]
+  Teams --> Heroes
+  Heroes --> StatBag[Stats (level + items)]
+  Heroes --> Cooldowns
+  Heroes -->|cast| Skill
+  Skill --> SkillProjectile[Hitbox / AOE]
+  SkillProjectile --> Damage --> Health
+  Map --> MinionWaves
+  MinionWaves --> Towers
+  Map --> JungleCamps
+  Map --> Objectives[Drake / Baron]
+  Items[Item Shop] --> Heroes
+  Damage --> Gold
+  Gold --> Items
+  XP --> LevelUp --> SkillUnlock
+  MatchEnd --> MMR
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Match | `Match`, `Team`, `Score`, `MatchClock`, `MatchPhase` |
+| Hero | `HeroDef`, `HeroInstance`, `Stats`, `Cooldowns`, `Buffs` |
+| Skill | `SkillDef`, `SkillCast`, `Hitbox`, `Effect` |
+| Items | `Item`, `ItemTree`, `ShopInventory` |
+| Map | `Lane`, `JungleCamp`, `Tower`, `Objective` |
+| Minion | `MinionWave`, `MinionInstance`, `WaveSpawner` |
+| Net | `RollbackEngine`, `Snapshot`, `Input`, `Reconcile` |
+| Match Service | `Matchmaker`, `BanPick`, `Replay`, `Anticheat` |
+
+## 対応するコード設計
+
+決定論的シミュレーションが必須 (= ロールバック前提):
+
+```rust
+// crates/game-moba/src/sim.rs
+//
+// シミュレーションは整数 / 固定小数点で書く (浮動小数の機種依存をなくす)
+pub struct Sim {
+    pub tick: u32,                      // 30 tick/s が標準
+    pub players: [Player; 10],
+    pub minions: Vec<Minion>,
+    pub projectiles: Vec<Projectile>,
+    pub jungle: Vec<JungleCamp>,
+    pub towers: Vec<Tower>,
+    pub rng: DeterministicRng,
+}
+
+impl Sim {
+    pub fn step(&mut self, inputs: &[InputFrame; 10]) {
+        // 1. 入力 → ヒーロー命令
+        for (i, p) in self.players.iter_mut().enumerate() {
+            p.consume(inputs[i]);
+        }
+        // 2. スキル発動 / 移動 / 自動攻撃
+        for p in &mut self.players { p.tick(); }
+        // 3. プロジェクタイル / ヒットボックス
+        Projectile::tick_all(self);
+        // 4. ミニオン / ジャングル / タワー
+        Minion::tick_all(self);
+        Tower::tick_all(self);
+        // 5. ステータス更新 / 戦闘解決
+        // 6. tick++
+        self.tick += 1;
+    }
+}
+
+// crates/game-moba/src/net.rs
+pub struct RollbackEngine {
+    sim: Sim,
+    history: VecDeque<Snapshot>,        // 最近 N=120 frames を保存
+    confirmed: u32,                      // 全プレイヤー確定済 frame
+}
+
+impl RollbackEngine {
+    pub fn on_remote_input(&mut self, peer: PeerId, frame: u32, input: Input) {
+        let prediction_was_wrong = ...;
+        if prediction_was_wrong {
+            // confirmed まで巻き戻し → 既知入力で再 step → 現在 tick まで進める
+            let snap = self.history.iter().find(|s| s.tick == frame).unwrap();
+            self.sim = snap.restore();
+            for f in frame..self.sim.tick {
+                let inputs = self.collect_inputs(f);
+                self.sim.step(&inputs);
+            }
+        }
+    }
+}
+```
+
+```text
+crates/
+  game-moba-sim/        # 決定論シミュレーション (整数演算)
+  game-moba-net/        # ロールバック + 予測
+  game-moba-data/       # ヒーロー / アイテム / ミニオン定義 (TOML)
+  game-moba-server/     # マッチメイキング / アンチチート / リプレイ
+  game-moba-client/     # 描画 + UI + チャット
+```
+
+依存:
+- `ergo_health` `ergo_input` `ergo_log`
+- ネットワーク基盤は **Synergos** や **WebRTC + データチャネル** を利用
+- 描画とシミュレーションは厳密に分離 (シムは固定 tick 30Hz、 描画は 60+ Hz で補間)

--- a/spec/game-template/open_world.md
+++ b/spec/game-template/open_world.md
@@ -1,0 +1,175 @@
+# オープンワールド テンプレート
+
+## 概要
+
+シームレスな大規模 3D 世界を自由に探索する RPG / ARPG。 代表作は **The Legend of Zelda: Breath of the Wild / Tears of the Kingdom**, **The Elder Scrolls V: Skyrim**, **Witcher 3**, **Red Dead Redemption 2**, **Genshin Impact**, **Elden Ring**。
+
+コアループ:
+
+> 「気になるもの」 を見つける → 移動 → アクティビティ (敵 / 採集 / クエスト / シリーズ) → 報酬 → 別の 「気になるもの」 へ
+
+特徴:
+
+- **シームレスストリーミング**: 地形 / 敵 / 草木を **動的にロード / アンロード**
+- **動的システム** (天候 / 時間帯 / NPC スケジュール / 物理) による創発
+- **クエストとサンドボックス** の二層: メインクエスト + 道草が同等に楽しい設計
+- **巨大なデータ管理** (アイテム数千、 NPC 数千、 セリフ数十万行)
+- **クエスト変数 / フラグ管理** が複雑化しがち → 中央 KV ストア + イベント
+- **セーブデータ** が巨大 (場合により MB 級)
+
+## 必要不可欠な機能実装
+
+- `[world-streaming]` プレイヤー位置に応じたタイル / アセット動的 load / unload
+- `[day-night-cycle]` 時間 / 太陽位置 / ライティング
+- `[fast-travel]` 発見済み地点へのテレポート
+- `[mount-system]` 騎乗 / 乗り物 (馬 / グライダー / 船)
+- `[quest-system]` メイン + サイド + ワールドイベント (条件発火型)
+- `[dialogue-system]` 分岐 + ボイス + 顔 + 唇同期
+- `[inventory]` + `[equipment-slots]` + `[stash]`
+- `[stat-system]` HP / スタミナ / 攻防 + 状態
+- `[combat-melee]` 近接 + 弓 / 魔法
+- `[ai-schedule]` (新規) NPC の時間ごとの位置 / 行動 (Skyrim Radiant AI 系)
+- `[weather-system]` (新規) 天候変化 + ゲームへの影響 (雷 / 雨 / 寒さ)
+- `[stamina-system]` (新規) 走り / 滑空 / 登攀の制限
+- `[climb-glide]` (新規 / 任意) BotW 由来の登攀 + パラセール
+- `[poi-system]` (新規) Point of Interest のマーカ + 自動発見
+- `[loot-table]` 戦闘 / 宝箱 / 採集
+- `[crafting]` 料理 / 武器修理 / 鍛冶
+- `[reputation]` (新規 / 任意) 派閥評判
+- `[save-load]` 巨大 state の効率的シリアライズ + 圧縮
+- `[autosave]` 区切り (ファストトラベル / 起床 / 主要イベント) の自動セーブ
+- `[chunked-asset-pipeline]` (新規) 街 / 地域単位の asset bundle
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  WorldMap[World Map (大)] --> Tiles
+  Tiles -->|near player| Streaming[Streaming Loader]
+  Streaming --> ActiveScene
+  ActiveScene --> NPCs
+  ActiveScene --> Wildlife
+  ActiveScene --> Vegetation
+  Player --> Inventory & Equipment
+  Player --> Stamina
+  Player --> Quest[Active Quests]
+  Quest --> Trigger[Conditional Triggers]
+  Trigger -->|var change| Quest
+  WorldClock --> DayNight & WeatherSystem
+  WeatherSystem --> NPCs
+  WeatherSystem --> ActiveScene
+  PlayerAction --> EventBus
+  EventBus --> Quest
+  EventBus --> AI_Schedule
+  Save --> SaveSlot
+  Save -->|delta encode| OnDisk
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| World | `WorldMap`, `Region`, `Tile`, `StreamingLoader`, `Cell` |
+| Player | `PlayerActor`, `Stats`, `Inventory`, `Equipment`, `Stamina`, `Reputation` |
+| NPC | `NpcDef`, `NpcInstance`, `Schedule`, `Faction`, `MoodState` |
+| World System | `WorldClock`, `DayNight`, `Weather`, `Season`, `Temperature` |
+| Quest | `QuestDef`, `QuestState`, `Trigger`, `Flag`, `Tracker` |
+| Combat | `MeleeResolver`, `RangedResolver`, `Status` |
+| Service | `SaveSerializer`, `SaveCompressor`, `AssetBundle` |
+| UI | `Map`, `Menu`, `Dialogue`, `HUD` |
+
+## 対応するコード設計
+
+巨大プロジェクトなので **データ駆動 + ECS 寄り** + **多モジュール分離** が現実解:
+
+```rust
+// crates/game-ow-streaming/src/lib.rs
+pub struct StreamingLoader {
+    pub tile_size_m: f32,           // 例: 256
+    pub load_radius: i32,           // 例: 3 (= 9x9 タイル)
+    pub loaded: HashMap<TileCoord, LoadedTile>,
+    pub queued_load: VecDeque<TileCoord>,
+    pub queued_unload: VecDeque<TileCoord>,
+    pub asset_db: Arc<AssetDb>,
+}
+
+impl StreamingLoader {
+    pub fn update(&mut self, player_pos: Vec3) {
+        let center = self.tile_for(player_pos);
+        let mut keep = HashSet::new();
+        for dx in -self.load_radius..=self.load_radius {
+            for dy in -self.load_radius..=self.load_radius {
+                keep.insert(TileCoord(center.0 + dx, center.1 + dy));
+            }
+        }
+        // 新規ロード
+        for c in &keep {
+            if !self.loaded.contains_key(c) { self.queued_load.push_back(*c); }
+        }
+        // アンロード
+        let to_unload: Vec<_> = self.loaded.keys()
+            .filter(|c| !keep.contains(c)).cloned().collect();
+        for c in to_unload { self.queued_unload.push_back(c); }
+    }
+}
+
+// crates/game-ow-quest/src/lib.rs
+//
+// クエストは「フラグ駆動」 + 「イベントバスをサブスクライブ」 で動かす。
+// 直接ハードコード (== if statements all over) は破綻するため、 Trigger DSL に集約。
+pub struct QuestDef {
+    pub id: QuestId,
+    pub steps: Vec<QuestStep>,
+}
+
+pub struct QuestStep {
+    pub id: StepId,
+    pub triggers: Vec<Trigger>,         // 条件 (Flag == X / KillCount >= N / EnterRegion)
+    pub on_complete: Vec<Action>,        // 次ステップ進行 / フラグセット
+}
+
+impl QuestSystem {
+    pub fn on_event(&mut self, ev: &WorldEvent, world: &mut World) {
+        for q in self.active_quests() {
+            for trigger in q.current_step().triggers {
+                if trigger.matches(ev, world) {
+                    self.advance(q.id);
+                }
+            }
+        }
+    }
+}
+
+// crates/game-ow-save/src/lib.rs
+//
+// 巨大セーブは「ベースライン + 差分」 (delta encoding) で書く。
+// テクスチャ等は除外、 dynamic state (NPC 位置 / Quest フラグ / Inventory) のみ。
+pub fn save_to(slot: SaveSlot, world: &World) -> Result<()> {
+    let snap = world.snapshot();
+    let bytes = postcard::to_allocvec(&snap)?;
+    let zstd = zstd::stream::encode_all(&bytes[..], 3)?;
+    fs::write(slot.path(), zstd)?;
+    Ok(())
+}
+```
+
+```text
+crates/
+  game-ow-streaming/   タイル / アセット動的ロード
+  game-ow-world/       時刻 / 天候 / 季節
+  game-ow-player/      Actor + Stats + Stamina + Movement
+  game-ow-combat/      Melee + Ranged + Magic
+  game-ow-npc/         NPC + Schedule + Faction
+  game-ow-quest/       Quest + Trigger + Flag
+  game-ow-dialogue/    Branch + Voice + Lipsync
+  game-ow-inventory/   Item + Equipment + Stash
+  game-ow-craft/       Recipe + Cooking + Smith
+  game-ow-save/        Snapshot + Delta + Compress
+  game-ow-asset/       AssetDb + Bundle + Cache
+  game-ow-ui/          Map + HUD + Menu
+```
+
+依存:
+- `ergo_health` (プレイヤー / ボス)
+- 大量モブ HP は ECS で SoA
+- アセットパイプライン + メモリプロファイリング無しでは破綻するので、 早期から計測ツール連携を作る (Pictor / 自作 profiler)

--- a/spec/game-template/platformer.md
+++ b/spec/game-template/platformer.md
@@ -1,0 +1,124 @@
+# プラットフォーマー テンプレート
+
+## 概要
+
+スーパーマリオ系の **2D / 2.5D 横スクロールプラットフォーマー**。 代表作は **Super Mario Bros**, **Celeste**, **Hollow Knight (横移動部分)**, **Super Meat Boy**。
+
+コアループ:
+
+> 移動 → ジャンプ → 着地 → ギミック (敵 / 障害 / 取得物) → 次のセクション
+
+技術的な注意:
+
+- **ジャンプの曲線** が遊び味を決める。 上昇加速度・落下加速度・短押しキャンセル・"coyote time" (足場を踏み外しても 100ms はジャンプ可) の調整が肝
+- 床 / 壁 / 天井の **タイル衝突解像** (sweep + slide) を 1px 精度で
+- 敵接触は普通の hitbox、 ギミック (バネ・敵を踏む) は別パスで判定
+- スクロール / カメラは **デッドゾーン + look-ahead** が定番
+
+## 必要不可欠な機能実装
+
+- `[player-controller-2d]` (新規) 加速度ベースの 2D 移動 + 着地判定
+- `[jump-physics]` (新規) 可変高さジャンプ + coyote time + jump buffer
+- `[tile-collision]` (新規) AABB vs タイルマップ sweep & slide
+- `[hitbox-system]` 敵接触判定
+- `[stomp-detect]` (新規) 上から踏んだか横から触れたかの判定 (上下方向の相対速度 + Y 距離)
+- `[health-system]` HP (3 機制 / ハート制)
+- `[respawn-system]` (新規) チェックポイント / 即時リスポーン
+- `[camera-2d-follow]` (新規) デッドゾーン + look-ahead カメラ
+- `[parallax-bg]` (新規) 多層スクロール背景
+- `[pickup-system]` コイン / アイテム取得
+- `[level-loader]` (新規) Tiled / Aseprite / 独自フォーマットのステージロード
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Input --> Controller[Player Controller]
+  Controller -->|sets| Velocity
+  Velocity -->|integrate| TileCollide[Tile Collision]
+  TileCollide -->|resolve| Position
+  Position --> CameraRig
+  Position --> EntityOverlap[Entity Overlap]
+  EntityOverlap -->|enemy| Stomp{Y vel down?}
+  Stomp -->|yes| EnemyDie
+  Stomp -->|no| PlayerDamage
+  EntityOverlap -->|pickup| Pickup
+  EntityOverlap -->|hazard| PlayerDamage
+  PlayerDamage --> Respawn{HP=0?}
+  Respawn -->|yes| Checkpoint
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Player | `PlayerActor`, `PlayerState (Idle/Run/Jump/Fall)`, `JumpBuffer`, `CoyoteTimer` |
+| World | `TileMap`, `Layer`, `Checkpoint`, `Spawner` |
+| Entity | `Enemy`, `Pickup`, `Hazard`, `MovingPlatform` |
+| Camera | `Camera2D`, `DeadZone`, `LookAhead` |
+
+## 対応するコード設計
+
+```rust
+// crates/game-platformer/src/player.rs
+pub struct PlayerActor {
+    state: PlayerState,
+    pos: Vec2,
+    vel: Vec2,
+    grounded: bool,
+    coyote: f32,            // 残り coyote time (秒)
+    jump_buffer: f32,       // 残り入力先行受付 (秒)
+    health: ergo_health::Health,
+}
+
+impl Actor for PlayerActor {
+    fn tick(&mut self, dt: f32, ctx: &mut TickCtx) {
+        // 1. 入力読み込み
+        let i = ctx.input;
+        let want_jump = i.pressed(Btn::A);
+        let xaxis = i.axis(Axis::Hori);
+
+        // 2. 横移動 (加速度 + 摩擦)
+        let target_vx = xaxis * MOVE_SPEED;
+        self.vel.x = approach(self.vel.x, target_vx, ACCEL * dt);
+
+        // 3. ジャンプ
+        if want_jump { self.jump_buffer = 0.1; }
+        if self.jump_buffer > 0.0 && (self.grounded || self.coyote > 0.0) {
+            self.vel.y = JUMP_VEL;
+            self.jump_buffer = 0.0;
+            self.coyote = 0.0;
+        }
+        // 短押しキャンセル
+        if !i.held(Btn::A) && self.vel.y > JUMP_VEL * 0.4 {
+            self.vel.y *= 0.5;
+        }
+
+        // 4. 重力
+        self.vel.y += GRAVITY * dt;
+
+        // 5. 衝突解像 — sweep + slide
+        let (new_pos, hit) = ctx.tilemap.sweep(self.pos, self.vel * dt, AABB_SIZE);
+        self.pos = new_pos;
+        self.grounded = hit.bottom;
+        if hit.bottom { self.vel.y = 0.0; self.coyote = 0.1; }
+        else { self.coyote -= dt; }
+        if hit.top    { self.vel.y = 0.0; }
+
+        // 6. 取得 / 接触判定はオーバーラップフェーズで別途
+    }
+}
+```
+
+```text
+src/
+  player/        Controller + State + Animation
+  world/         TileMap + Checkpoint + Spawner
+  entity/        Enemy / Pickup / Hazard / MovingPlatform
+  camera/        Camera2D + DeadZone + Lookahead
+  level/         Loader (Tiled JSON or 独自)
+```
+
+依存:
+- `ergo_health` `ergo_input` `ergo_frame`
+- 物理は自前 (`tile-collision` モジュール) — 重い物理エンジンは要らない

--- a/spec/game-template/puzzle_casual.md
+++ b/spec/game-template/puzzle_casual.md
@@ -1,0 +1,124 @@
+# パズル / カジュアル テンプレート
+
+## 概要
+
+3-match / blast 系のステージ制カジュアルパズル。 代表作は **Royal Match**, **Candy Crush Saga**, **Toon Blast**, **Gardenscapes**。
+
+コアループ:
+
+> ステージ開始 → 限定手数 / 時間 → グリッドで連結消去 → 連鎖カスケード → 目標達成 / 失敗 → メタ画面 (家リフォーム / ライフ / コイン)
+
+特徴:
+
+- **手数制 + 目標条件**: 「氷をすべて割る」 「ジェムを N 個集める」 など
+- **連鎖カスケード**: 消去 → 落下 → 補充 → 再連結チェック の繰り返しで気持ち良さを作る
+- **特殊ピース** (ロケット / バクダン / 虹) の生成ルールが戦略の中心
+- **ライフ / コイン / ブースター** の **メタゲーム** + **広告 / IAP** が事業として必須
+- 1 ステージ = 数十秒〜数分。 **数千ステージ** の大規模手作り
+
+## 必要不可欠な機能実装
+
+- `[grid-puzzle]` (新規) NxM グリッドにピース配置
+- `[match-detect]` (新規) 同色 3+ 連結検出 (横 / 縦 / L / T 形)
+- `[cascade-resolve]` (新規) 消去 → 重力落下 → 補充 → 再検査の駆動
+- `[booster-piece]` (新規) ロケット / 爆弾 / 虹 / 縞 の生成 + 効果伝播
+- `[move-counter]` (新規) 残り手数 + ボーナス判定
+- `[goal-tracker]` (新規) ステージ目標 (氷 N / ジェム N / アイテム持ち出し)
+- `[stage-loader]` (新規) 数千ステージ定義の効率的ロード (LRU)
+- `[life-system]` (新規) ライフ (5 個 / 30 分回復) + 友人ギフト
+- `[currency]` (新規) コイン + 課金通貨
+- `[booster-inventory]` (新規) ステージ前 / 中に使う消費アイテム
+- `[meta-progression]` 家 / 庭のリフォーム進行 (Gardenscapes 系)
+- `[ads-iap]` (新規) リワード広告 / IAP 統合
+- `[push-retention]` (新規) ライフ満タン / 友人プレイ時のプッシュ通知
+- `[analytics]` (新規) ステージ離脱率 / 平均試行回数 (チューニング必須)
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  StageDef --> Grid[Grid State]
+  Player -->|swap| Grid
+  Grid --> MatchDetect
+  MatchDetect -->|matched| Cascade
+  Cascade --> Booster[Booster spawn / trigger]
+  Booster --> Cascade
+  Cascade --> GoalTracker
+  GoalTracker --> WinLose{条件達成?}
+  WinLose -->|win| Reward
+  WinLose -->|手数 0| Lose --> LifeMinus
+  Reward --> Currency
+  Currency --> Meta[家リフォーム]
+  StageDef -->|手数| MoveCounter
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Stage | `StageDef`, `GoalSet`, `MoveBudget`, `Grid<Piece>` |
+| Match | `MatchDetector`, `MatchGroup`, `BoosterRule` |
+| Cascade | `CascadeStep`, `Gravity`, `Refill`, `EffectQueue` |
+| Meta | `LifePool`, `Currency`, `BoosterInventory`, `RenovationProgress` |
+| Service | `IAP`, `Ads`, `PushScheduler`, `Analytics` |
+
+## 対応するコード設計
+
+```rust
+// crates/game-puzzle/src/grid.rs
+pub struct Grid {
+    pub w: u8,
+    pub h: u8,
+    pub cells: Vec<Cell>,    // length = w*h, row-major
+}
+
+#[derive(Clone, Copy)]
+pub struct Cell {
+    pub piece: Piece,
+    pub blocker: Option<Blocker>,   // 氷 / ゼリー / 鎖
+}
+
+impl Grid {
+    /// 隣接スワップ後に match があるか? (= valid swap か)
+    pub fn try_swap(&mut self, a: Coord, b: Coord) -> bool {
+        self.swap(a, b);
+        let m = self.find_matches();
+        if m.is_empty() { self.swap(a, b); false } else { true }
+    }
+
+    /// 一連のカスケードを progressing-step で返す (アニメ駆動用)
+    pub fn cascade(&mut self) -> impl Iterator<Item = CascadeStep> + '_ {
+        std::iter::from_fn(move || {
+            let m = self.find_matches();
+            if m.is_empty() { return None; }
+            let step = self.apply_matches(m);
+            self.gravity();
+            self.refill();
+            Some(step)
+        })
+    }
+}
+
+// crates/game-puzzle/src/booster.rs
+pub fn trigger_rocket(g: &mut Grid, at: Coord, dir: Dir) -> Vec<Coord> {
+    // 横 / 縦に並んだセルをすべて消す。 巻き込みで他 booster も発火
+    ...
+}
+```
+
+```text
+src/
+  grid/          Grid + Cell + Coord
+  match/         MatchDetector + MatchGroup
+  cascade/       Gravity + Refill + Effect resolution
+  booster/       Rocket / Bomb / Rainbow / Stripe rules
+  stage/         StageDef + GoalSet + Loader (lazy chunks)
+  meta/          Life + Currency + Renovation
+  ui/            BoardRenderer + ParticleEffects + ResultPanel
+  services/      IAP / Ads / Push / Analytics
+```
+
+依存:
+- `ergo_score` (任意 — 一般的にステージ内スコアは固有)
+- `ergo_io` (大量ステージファイル管理)
+- 連鎖アニメは「論理 step → 描画 step」 の二段プレイバックが定石

--- a/spec/game-template/rhythm.md
+++ b/spec/game-template/rhythm.md
@@ -1,0 +1,144 @@
+# 音ゲー (リズム) テンプレート
+
+## 概要
+
+音楽に合わせてノーツを叩く。 代表作は **Beatmania IIDX**, **Dance Dance Revolution**, **Project DIVA**, **osu!**, **Cytus**, **Project Sekai**。
+
+コアループ:
+
+> 楽曲選択 → 譜面プレイ → タイミング判定 (PERFECT/GREAT/GOOD/MISS) → コンボ → スコア → リザルト → 次曲
+
+特徴:
+
+- **オーディオとビジュアルの厳密同期** (ms 単位)
+- **ローレイテンシ入力** (タッチ / ボタン → 判定まで 16ms 以内が理想)
+- **譜面エディタ** がコンテンツの命綱 (内製 + コミュニティ)
+- **キャリブレーション** (ユーザー環境ごとのオフセット調整) 必須
+- **判定窓** の数値が体感を決める (PERFECT 25ms / GREAT 60ms / GOOD 120ms 等)
+- 1 曲 1.5-3 分。 セッションは 5-30 曲
+
+## 必要不可欠な機能実装
+
+- `[song-database]` (新規) 楽曲メタ + 譜面 + 音源 + ジャケット
+- `[note-chart]` 譜面ファイル (json / toml / osu / bms / sm)
+- `[chart-loader]` (新規) 各種フォーマットからの読込
+- `[audio-engine]` (新規) 低遅延再生 (ASIO / WASAPI / Core Audio / OpenSL ES)
+- `[audio-sync]` 音声同期 + ユーザーオフセット (audio offset / video offset)
+- `[timing-judge]` ms 窓判定 (PERFECT/GREAT/GOOD/MISS)
+- `[input-lowlatency]` (新規) OS native ホットパス (キーボード / タッチ / 専用デバイス)
+- `[combo-counter]` コンボ + フルコンボ判定
+- `[score-system]` 加点 + 倍率 + ランク (S/A/B/C/D)
+- `[note-renderer]` (新規) 高精度描画 (4ms 単位以下のジッタ許容しない)
+- `[lane-system]` (新規) レーン (4 / 5 / 6 / 7 / 16 など) + キーマップ
+- `[note-types]` (新規) Tap / Hold / Slide / Flick / Bomb / Mash etc
+- `[bpm-changes]` (新規) 譜面途中の BPM / オフセット変化
+- `[result-screen]` (新規) スコア / 判定数 / コンボ / グラフ
+- `[chart-editor]` (新規 / 任意) 内製エディタ
+- `[song-select-ui]` (新規) ジャンル / 難易度 / レベル別ソート + プレビュー再生
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Song[Song + Chart] --> AudioPlay
+  Song --> NoteScheduler
+  AudioPlay -->|time| Clock[Audio Clock]
+  Clock --> NoteScheduler
+  NoteScheduler --> NoteRenderer
+  Input -->|press| TimingJudge
+  Clock --> TimingJudge
+  TimingJudge --> Judgement
+  Judgement --> ComboCounter
+  Judgement --> Score
+  Judgement --> ComboCounter
+  ComboCounter --> Score
+  SongEnd --> Result
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Song | `SongDef`, `ChartDef`, `Difficulty`, `BpmChanges` |
+| Audio | `AudioEngine`, `Clock`, `Track`, `OffsetConfig` |
+| Note | `Note`, `NoteKind`, `NoteScheduler` |
+| Input | `LowLatencyInput`, `LaneMapping` |
+| Judge | `TimingWindows`, `JudgeResult`, `JudgeStream` |
+| Score | `Score`, `RankCurve`, `Combo`, `FullCombo` |
+| Library | `SongDatabase`, `Filter`, `Sort`, `Preview` |
+
+## 対応するコード設計
+
+オーディオクロックを source of truth に:
+
+```rust
+// crates/game-rhythm/src/clock.rs
+//
+// 描画フレームには依存しない。 オーディオデバイスから取った再生位置を
+// 「ゲーム時刻」 とする。 これに user_offset (ms) を加算した値を判定 / 描画
+// 双方が参照する。
+pub struct AudioClock {
+    pub now_ms_raw: i64,         // オーディオデバイス由来
+    pub user_offset_ms: i32,     // 設定で調整
+    pub video_offset_ms: i32,    // モニタ遅延補正
+}
+
+impl AudioClock {
+    pub fn now_for_judge(&self) -> i64 { self.now_ms_raw + self.user_offset_ms as i64 }
+    pub fn now_for_render(&self) -> i64 { self.now_ms_raw + self.video_offset_ms as i64 }
+}
+
+// crates/game-rhythm/src/judge.rs
+// (ergo_timing_judge をそのまま使える — 判定窓 + breaks_combo)
+
+// crates/game-rhythm/src/scheduler.rs
+//
+// 譜面ノートを「いま判定圏内」 「いま描画圏内」 に分けて Vec で持つ。
+pub struct NoteScheduler {
+    pub all: Vec<Note>,           // 譜面 ID 順 (時刻昇順)
+    pub head_judge: usize,        // 判定窓 in/out 用カーソル
+    pub head_render: usize,       // 描画窓 (look-ahead) 用カーソル
+}
+
+impl NoteScheduler {
+    pub fn judge_window(&self, now_ms: i64, win_ms: i64) -> &[Note] {
+        // self.all[head_judge ..] のうち now_ms - win_ms ~ now_ms + win_ms を返す
+        ...
+    }
+}
+
+// crates/game-rhythm/src/play.rs
+pub fn on_input(state: &mut PlayState, lane: u8) {
+    let now = state.clock.now_for_judge();
+    let candidates = state.scheduler.judge_window(now, state.windows.good_ms as i64);
+    // この lane で「最も近い」未判定ノートを 1 件選ぶ
+    let target = pick_closest(candidates, lane);
+    let Some(note) = target else { return };
+    let j = ergo_timing_judge::judge(note.target_ms, now, &state.windows);
+    state.score.add(score_for(j));
+    if breaks_combo(j, state.combo_break_threshold) {
+        state.combo.break_();
+    } else {
+        state.combo.hit();
+    }
+    note.judged = Some(j);
+}
+```
+
+```text
+crates/
+  game-rhythm-core/    Clock + NoteScheduler + Play
+  game-rhythm-audio/   低遅延 audio engine + ASIO/WASAPI bind
+  game-rhythm-chart/   ChartDef + Loader (osu/bms/sm/独自)
+  game-rhythm-data/    SongDatabase + Library
+  game-rhythm-input/   LowLatencyInput
+  game-rhythm-render/  Note 描画 (高精度)
+  game-rhythm-edit/    エディタ (任意)
+```
+
+依存:
+- `ergo_timing_judge` (このまま使える)
+- `ergo_combo_counter` (フルコンボ判定込み)
+- `ergo_score`
+- `ergo_input` (ただしホットパスは OS native の方が遅延低い)
+- 音声バックエンドだけは外部依存 (FMOD / ASIO / etc)

--- a/spec/game-template/roguelike_berlin.md
+++ b/spec/game-template/roguelike_berlin.md
@@ -1,0 +1,140 @@
+# ローグライク (ベルリン解釈) テンプレート
+
+## 概要
+
+**ベルリン解釈** に従う「真の」ローグライク。 代表作は **NetHack**, **Dungeon Crawl Stone Soup**, **Caves of Qud**, **Brogue**, **ToME**。
+
+ベルリン解釈の主要素 (高基準):
+
+1. **手続き的生成** — ステージは毎回違う
+2. **永続死** (パーマデス) — 死ねば 1 周終了
+3. **ターン制 + グリッドベース**
+4. **複雑性** (アイテム / モンスターの多様な相互作用)
+5. **資源管理** (HP / MP / 食料 / 巻物 ...)
+6. **ハック&スラッシュ的戦闘** (近接 + 魔法)
+7. **探索 / 発見** (アイテム識別、 マップ open)
+8. **シングルプレイヤー / シングルキャラクター**
+
+低基準 (任意): ASCII 表示 / 単一キャラ / 視認システム / 床数枚分の階層 / 数値演算ベース
+
+コアループ:
+
+> 1 ターン分の入力 → プレイヤー行動 → モンスター AI ターン → ステータス効果適用 → 死亡判定 → 次ターン
+
+## 必要不可欠な機能実装
+
+- `[turn-engine]` (新規) energy cost 制 (全アクションが「重さ」を持ち、 速さでターン頻度が変わる)
+- `[procgen-dungeon]` (新規) 部屋 + 通路生成 (BSP / cellular automata / 独自)
+- `[fov]` (新規) 視界計算 (シャドウキャスト / RPS)
+- `[grid-actor]` (新規) セルに乗る Actor (player / monster / item)
+- `[health-system]` HP + 状態異常 (毒 / 麻痺 / 混乱 ...)
+- `[hunger]` (新規) 食料カウンタ (満腹 / 空腹 / 飢餓 / 餓死)
+- `[inventory]` インベントリ (重量 / スロット / スタック)
+- `[item-identify]` (新規) 巻物 / 薬の正体未確定状態 (使うか試行で確定)
+- `[combat-melee]` (新規) 近接攻撃 (命中 / 回避 / クリ + 武器付加効果)
+- `[magic-spells]` (新規) 詠唱 / MP 消費 / 範囲効果 / 状態異常付与
+- `[monster-ai]` (新規) FoV ベース行動 (見えてないと idle、 見えたら chase / cast)
+- `[trap-system]` (新規) 床 / 壁 / 落とし穴
+- `[stair-descent]` (新規) 階層降下 + map clear
+- `[permadeath]` (新規) 死亡 → セーブ削除 + 死因記録 (memorial)
+- `[seeded-rng]` (新規) RNG seed 公開 (再現可能ラン)
+- `[message-log]` (新規) 行動ログを画面下に保持
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Schedule[Action Scheduler] -->|next| Actor
+  Actor -->|player| Input
+  Actor -->|monster| AI
+  Input --> Action
+  AI --> Action
+  Action --> CostEnergy
+  Action --> Effect[World Mutation]
+  Effect --> Map
+  Effect --> Inventory
+  Effect --> Health
+  Effect --> Status
+  Effect --> Log[Message Log]
+  Schedule --> NextActor
+  Health -->|0| Death --> Memorial
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| World | `Dungeon`, `Floor`, `Tile`, `FloorGenerator`, `Stair` |
+| Actor | `Actor`, `Stats`, `Energy`, `StatusList`, `Inventory` |
+| Action | `Action`, `Cost`, `Effect[]`, `ActionResolver` |
+| Item | `Item`, `Identify`, `Stack`, `Slot`, `EnchantTable` |
+| Magic | `Spell`, `SpellEffect`, `Element` |
+| Vision | `FieldOfView`, `Memory (mapped tiles)` |
+| Run | `RunRecord`, `Memorial`, `RNG`, `Seed` |
+
+## 対応するコード設計
+
+エネルギーベースのターンエンジンが核:
+
+```rust
+// crates/game-roguelike/src/schedule.rs
+pub struct Scheduler {
+    queue: BinaryHeap<Reverse<(i64 /*time*/, ActorId)>>,
+    now:   i64,
+}
+
+impl Scheduler {
+    pub fn next(&mut self) -> ActorId {
+        let Reverse((t, id)) = self.queue.pop().unwrap();
+        self.now = t;
+        id
+    }
+    pub fn reschedule(&mut self, id: ActorId, cost: i64) {
+        self.queue.push(Reverse((self.now + cost, id)));
+    }
+}
+
+// crates/game-roguelike/src/action.rs
+pub enum Action {
+    Move(Direction),
+    Attack(ActorId),
+    Quaff(ItemId),
+    Cast(SpellId, Target),
+    Descend,
+    ...
+}
+
+pub struct Effect {
+    pub mutates: Vec<Mutation>,   // World への変更を後でまとめて適用
+    pub log: Vec<String>,
+}
+
+pub fn apply(action: Action, by: ActorId, world: &World) -> Effect {
+    match action {
+        Action::Move(d) => move_action::resolve(by, d, world),
+        Action::Attack(t) => combat::resolve(by, t, world),
+        Action::Quaff(i) => potion::resolve(by, i, world),
+        ...
+    }
+}
+```
+
+```text
+src/
+  world/         Dungeon + Floor + Tile + Generator
+  actor/         Actor + Stats + Inventory
+  action/        Action enum + resolvers
+  combat/        Melee + ToHit + Dmg
+  magic/         Spell + Element + Effect
+  item/          Item + Stack + Identify table
+  vision/        ShadowCast FOV + Memory
+  ai/            Patrol / Hunt / Flee
+  schedule/      Energy-based scheduler
+  run/           Memorial + Seeded RNG
+  ui/            Map + Log + Inventory + Spellbook
+  generator/     BSP / Cellular automata / Vault placement
+```
+
+依存:
+- `ergo_health` `ergo_input` `ergo_log`
+- 描画は ASCII でも GUI でもいいが、 **同じロジックレイヤを差し替える** べき (テスト容易性)

--- a/spec/game-template/shmup.md
+++ b/spec/game-template/shmup.md
@@ -1,0 +1,171 @@
+# シューティング (STG / SHMUP) テンプレート
+
+## 概要
+
+2D 縦 / 横スクロール固定弾幕シューター。 代表作は **Gradius**, **R-Type**, **Ikaruga**, **東方 Project**, **Cave (DoDonPachi 等)**, **斑鳩**。
+
+コアループ:
+
+> 自機が常に前進 → 敵 + 弾幕を撃破 / 回避 → アイテム取得 → 強化 → ボス → クリア / 死亡
+
+特徴:
+
+- **避ける** ことが楽しさの本体。 弾幕の **パターン設計** が中心
+- 命中判定は **小さな自機 hitbox + 大きな見た目** が定石 (グレイズ判定)
+- **パワーアップ** (オプション / レーザー / ホーミング / 子機) が個性
+- **スコアアタック文化**: ノーミス / フルチェイン / 1cc クリア
+- 1 ステージ 3-5 分 × 5-7 ステージ
+- **STG 弾幕** はオブジェクト数が多い (数百-数千) ので SoA + プールが必須
+
+## 必要不可欠な機能実装
+
+- `[player-ship]` (新規) 自機制御 (固定速 + 入力で減速 / 集中モード)
+- `[bullet-pattern]` 弾幕パターン (扇 / 円 / 螺旋 / ホーミング / 反射)
+- `[bullet-pool]` (新規) 弾オブジェクトプール (数千)
+- `[hitbox-system]` 自機の極小 hitbox (1-2px) + 弾の hitbox
+- `[graze-system]` (新規) ニアミス判定 (スコア / ボム回復)
+- `[enemy-pattern]` (新規) 敵の出現パターン (時刻 + 種別 + 経路)
+- `[scrolling-stage]` (新規) ステージ強制スクロール + 背景多層
+- `[powerup-system]` (新規) アイテムドロップ + 武器階位
+- `[bomb-system]` (新規) 残機 / ボム消費の画面クリア
+- `[score-system]` 撃破 + チェイン + グレイズ + アイテム取得
+- `[life-extend]` (新規) スコアごとの残機追加
+- `[boss-fight]` 多段フェーズ + 専用パターン
+- `[continue-system]` (新規) クレジット制 (アーケード由来)
+- `[seed-replay]` (新規) RNG 固定 → リプレイ可能
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Stage[Stage Script] -->|時刻| EnemySpawn
+  EnemySpawn --> Enemies[Enemy Pool]
+  Enemies -->|射撃| EnemyBulletPattern
+  EnemyBulletPattern --> EnemyBullets[Bullet Pool]
+  Player -->|入力| PlayerControl
+  PlayerControl --> PlayerShip
+  PlayerShip -->|射撃| PlayerBullets
+  PlayerBullets -->|hit| Enemies
+  Enemies -->|drop| Powerup
+  Powerup --> PlayerShip
+  EnemyBullets -->|hit player hitbox| PlayerDeath
+  EnemyBullets -->|graze player| GrazeScore
+  Player -->|bomb| ClearBullets[全弾消去]
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Stage | `StageScript`, `EnemyTimeline`, `BackgroundLayers` |
+| Ship | `PlayerShip`, `WeaponLevel`, `OptionPattern`, `FocusMode` |
+| Bullet | `BulletPool` (SoA), `BulletPattern`, `Emitter` |
+| Enemy | `EnemyDef`, `EnemyInstance`, `MovementCurve` |
+| Score | `Score`, `Chain`, `GrazeCount`, `Extend` |
+| Boss | `Boss`, `Phase`, `Spell` (東方系) |
+| Replay | `Seed`, `InputLog`, `Verifier` |
+
+## 対応するコード設計
+
+```rust
+// crates/game-shmup/src/bullet.rs — SoA + プール
+pub struct BulletPool {
+    pub alive: Vec<bool>,      // 8000 個など
+    pub pos:   Vec<Vec2>,
+    pub vel:   Vec<Vec2>,
+    pub kind:  Vec<BulletKind>,
+    pub team:  Vec<Team>,      // Player / Enemy
+}
+
+impl BulletPool {
+    pub fn tick(&mut self, dt: f32, world: &mut World) {
+        for i in 0..self.alive.len() {
+            if !self.alive[i] { continue; }
+            self.pos[i] += self.vel[i] * dt;
+            // 画面外で kill
+            if !world.bounds.contains(self.pos[i]) {
+                self.alive[i] = false;
+                continue;
+            }
+        }
+    }
+
+    pub fn spawn(&mut self, pos: Vec2, vel: Vec2, kind: BulletKind, team: Team) -> Option<usize> {
+        // 空きスロットを探して再利用 (free list 推奨)
+        ...
+    }
+}
+
+// crates/game-shmup/src/pattern.rs
+//
+// 弾幕パターンは「emitter」 を時間進行で動かす単純なステートマシン。
+// (派手な東方系は Lua スクリプトで書くことが多い)
+pub enum Emitter {
+    Spread { center: Vec2, dir: f32, count: u32, spread_rad: f32, speed: f32, fired: bool },
+    Ring   { center: Vec2, count: u32, speed: f32, fired: bool },
+    Spiral { center: Vec2, base_angle: f32, step: f32, period: f32, until: f32, t: f32 },
+    Homing { center: Vec2, target: Target, speed: f32, fired: bool },
+}
+
+impl Emitter {
+    pub fn tick(&mut self, dt: f32, pool: &mut BulletPool, team: Team) {
+        match self {
+            Emitter::Spread { center, dir, count, spread_rad, speed, fired } => {
+                if *fired { return; }
+                let half = *spread_rad * 0.5;
+                let step = if *count > 1 { *spread_rad / (*count - 1) as f32 } else { 0.0 };
+                for i in 0..*count {
+                    let theta = *dir - half + step * i as f32;
+                    pool.spawn(*center, Vec2::from_angle(theta) * *speed, BulletKind::Round, team);
+                }
+                *fired = true;
+            }
+            Emitter::Spiral { center, base_angle, step, period, until, t } => {
+                *t += dt;
+                if *t > *until { return; }
+                if *t > *period {
+                    *t -= *period;
+                    *base_angle += *step;
+                    pool.spawn(*center, Vec2::from_angle(*base_angle) * 80.0, BulletKind::Round, team);
+                }
+            }
+            ...
+        }
+    }
+}
+
+// crates/game-shmup/src/hit.rs
+//
+// 自機 hitbox は 1-2px 想定 (グレイズは別)。
+pub fn check_player_hit(player: &PlayerShip, bullets: &BulletPool) -> Option<usize> {
+    for i in 0..bullets.alive.len() {
+        if !bullets.alive[i] || bullets.team[i] != Team::Enemy { continue; }
+        let d = (bullets.pos[i] - player.pos).length();
+        if d < player.hitbox_r + bullet_radius(bullets.kind[i]) {
+            return Some(i);
+        }
+        if d < player.graze_r {
+            // グレイズスコア + ボム回復
+        }
+    }
+    None
+}
+```
+
+```text
+src/
+  ship/          PlayerShip + WeaponLevel + Option
+  bullet/        BulletPool + Emitter (Pattern DSL)
+  enemy/         EnemyPool + Movement curve + Drop
+  stage/         StageScript + Background layers + Spawn timeline
+  boss/          Boss + Phase + Spell
+  score/         Score + Chain + Graze + Extend
+  bomb/          Bomb + ScreenClear + Invuln
+  replay/        InputLog + ReplayPlayer
+  ui/            HUD + Continue + ResultScreen
+```
+
+依存:
+- `ergo_score`
+- `ergo_input` (固定 60 fps + リプレイ前提なので入力サンプリングは決定論)
+- 描画は GPU instancing (Pictor)

--- a/spec/game-template/slg_grid.md
+++ b/spec/game-template/slg_grid.md
@@ -1,0 +1,126 @@
+# グリッド SLG テンプレート
+
+## 概要
+
+ターン制 + ヘックス / 四角グリッドのストラテジー RPG。 代表作は **Fire Emblem**, **Final Fantasy Tactics**, **Tactics Ogre**, **Triangle Strategy**, **Advance Wars**。
+
+コアループ:
+
+> 自軍ターン (各ユニット 1 行動) → 敵ターン (AI 行動) → 戦闘発生 → ステータス更新 → 全滅 / 勝利条件チェック → 次ターン
+
+特徴:
+
+- **盤面 (グリッド)** が中心。 距離 / 高低差 / 地形効果 / 移動コストがすべてセル単位
+- 1 戦闘 = 1 ステージ、 ステージ間に**会話シーン** + **拠点メニュー** (FE) または **隊列メニュー** (FFT) を挟む
+- ユニットの **クラス + 装備 + スキル** が組合せの肝
+- 戦闘予測 (ダメージ % / 命中 % / クリ %) を「攻撃前にプレイヤーに見せる」 のがジャンル定石
+
+## 必要不可欠な機能実装
+
+- `[hex-grid]` 盤面 (hex / square 切替可)
+- `[unit-action]` ユニットの 1 ターン行動 (移動 + 攻撃 / スキル / 待機)
+- `[movement-range]` (新規) 移動可能セル計算 (ダイクストラ + 地形コスト)
+- `[attack-range]` (新規) 攻撃 / スキルの射程セル計算
+- `[battle-forecast]` (新規) 戦闘前のダメージ / 命中 / クリ予測表示
+- `[stat-system]` HP / 攻 / 防 / 速 / 技 / 運 / 移動力
+- `[class-system]` (新規) クラス → ステータス成長補正 + スキル
+- `[turn-manager]` (新規) Player/Enemy/Allied/Other フェーズ管理
+- `[unit-ai]` (新規) 敵ターンの行動選択 (移動先 + ターゲット選び)
+- `[victory-defeat]` (新規) ステージ勝利 / 敗北条件 (全滅 / リーダー撃破 / N ターン以内 / 占領)
+- `[map-loader]` (新規) ステージマップ + ユニット配置 + 勝敗条件のロード
+- `[dialogue-system]` ステージ前後のイベント会話
+- `[save-load]` 章ごと / ターンごとの中断セーブ
+- `[level-up-screen]` (新規) ランダム成長率での Lv up 表示
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  TurnMgr[Turn Manager] -->|cycles| Phase{Phase}
+  Phase -->|Player| Cursor[Player Cursor]
+  Cursor --> SelectUnit
+  SelectUnit --> MoveRange[Move Range Calc]
+  MoveRange --> ChooseAction
+  ChooseAction --> Attack
+  Attack --> Forecast[Battle Forecast]
+  Forecast --> Resolve[Battle Resolver]
+  Resolve --> ApplyDamage
+  ApplyDamage --> CheckVictory
+  Phase -->|Enemy| EnemyAI
+  EnemyAI --> SelectUnit
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Map | `Grid`, `Cell (terrain, height, occupant)`, `Path`, `MapDef` |
+| Unit | `Unit`, `Class`, `Stats`, `Skill`, `Equipment`, `Inventory` |
+| Turn | `TurnManager`, `Phase`, `ActionUsed[]` |
+| Battle | `BattleEvent`, `Forecast`, `DamageResolver`, `HitRng` |
+| Campaign | `Chapter`, `MapLoader`, `EventScript`, `SaveSlot` |
+
+## 対応するコード設計
+
+```rust
+// crates/game-slg/src/grid.rs
+pub struct Grid {
+    pub w: u16,
+    pub h: u16,
+    pub kind: GridKind,         // Hex | Square
+    pub cells: Vec<Cell>,       // length = w*h
+}
+
+#[derive(Clone)]
+pub struct Cell {
+    pub terrain: TerrainId,
+    pub height: i16,
+    pub occupant: Option<UnitId>,
+}
+
+impl Grid {
+    pub fn move_range(&self, from: Coord, mp: u16, unit: &Unit, ctx: &TerrainTable) -> Vec<(Coord, u16)> {
+        // ダイクストラ。 cost = ctx.cost(terrain, unit.class)
+        // 戻り値: 到達可能セル + 残 MP
+        ...
+    }
+    pub fn attack_range(&self, from: Coord, weapon: &Weapon) -> Vec<Coord> { ... }
+}
+
+// crates/game-slg/src/turn.rs
+pub struct TurnManager {
+    pub turn:  u32,
+    pub phase: Phase,
+    pub used:  HashSet<UnitId>,
+}
+
+impl TurnManager {
+    pub fn end_action(&mut self, u: UnitId) {
+        self.used.insert(u);
+        if self.all_used_for_phase() { self.advance_phase(); }
+    }
+}
+
+// crates/game-slg/src/battle.rs
+pub fn forecast(att: &Unit, def: &Unit, terrain: TerrainEffect) -> Forecast {
+    let dmg = (att.stats.atk - def.stats.def + att.equip.might).max(0);
+    let hit = (att.stats.skl * 2 + att.equip.hit) - def.stats.spd - terrain.evasion;
+    let crit = att.stats.skl / 2 + att.equip.crit;
+    Forecast { dmg, hit: hit.clamp(0, 100), crit: crit.clamp(0, 100) }
+}
+```
+
+```text
+src/
+  grid/          Grid + Cell + Pathfinding (Dijkstra)
+  unit/          Unit + Class + Stats + Skill
+  turn/          TurnManager + Phase
+  battle/        Forecast + Resolver + RNG
+  ai/            EnemyAI (heuristic / utility)
+  campaign/      Chapter + Map loader + Events
+  ui/            Cursor + RangeOverlay + ForecastUI + UnitInfo
+```
+
+依存:
+- `ergo_health` `ergo_input` `ergo_frame`
+- 戦闘 RNG は seed 固定可能にする (ロード後の再現性)

--- a/spec/game-template/strategy_4x.md
+++ b/spec/game-template/strategy_4x.md
@@ -1,0 +1,139 @@
+# 4X / グランドストラテジー テンプレート
+
+## 概要
+
+eXplore / eXpand / eXploit / eXterminate の **4X** ストラテジー。 代表作は **Sid Meier's Civilization**, **Endless Legend**, **Stellaris**, **Crusader Kings**。
+
+コアループ:
+
+> ターン (年) 進行 → 都市 / ユニット 1 つずつ操作 → 研究進行 → 外交イベント → AI ターン → 勝利条件チェック → 翌ターン
+
+特徴:
+
+- **長尺セッション** (1 試合 6-20 時間)。 セーブ・ロード品質が UX を決める
+- **マルチテック軸** (科学・文化・宗教・経済・軍事) が独立に進む
+- **AI が同等のルールで動く** ことが大事 (チートで強くしすぎない)
+- 「**前のターンに何が起きたか**」 をプレイヤーに通知する **アラートキュー** が必須
+
+## 必要不可欠な機能実装
+
+- `[hex-grid]` 大規模六角マップ (1000+ タイル)
+- `[fog-of-war]` (新規) 自勢力 / 同盟ごとの可視範囲管理
+- `[city]` (新規) 都市オブジェクト (人口 / 食料 / 生産 / 文化 / 信仰 / 区画)
+- `[unit-types]` (新規) ユニット系統 (戦士 / 弓 / 騎兵 / ...) + Tier
+- `[resource-economy]` 資源 (食料 / 生産 / 金 / 科学 / 文化 / 信仰)
+- `[tech-tree]` 科学ツリー (前提付きノード DAG)
+- `[civic-tree]` (新規) 文化ツリー (科学とは別軸)
+- `[diplomacy]` (新規) 国家関係 (同盟 / 戦争 / 通商 / 抗議)
+- `[trade-route]` (新規) 都市間 / 国家間の貿易路
+- `[turn-manager]` 年次ターン + AI 同時行動 (orders queue)
+- `[event-system]` (新規) ランダム + 連鎖イベント (CK 系)
+- `[victory-condition]` (新規) 科学 / 文化 / 制覇 / 外交 / 信仰 ...
+- `[save-load]` 巨大 state を圧縮シリアライズ (zstd など)
+- `[notification-queue]` (新規) ターン頭にプレイヤー通知一覧
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Map[Hex Map] -->|owned by| Civ[Civilization]
+  Civ --> Cities
+  Civ --> Units
+  Civ --> Treasury[Treasury & Yields]
+  Cities --> CityYield
+  CityYield --> Treasury
+  Treasury -->|科学| TechTree
+  Treasury -->|文化| CivicTree
+  TechTree -->|unlocks| Buildings & Units & Wonders
+  Civ --> Diplomacy
+  Diplomacy -->|war/peace| OtherCiv[Other Civ]
+  TurnEnd --> AI_Order[AI Orders]
+  AI_Order -->|move| Units
+  AI_Order -->|build| Cities
+  AI_Order -->|research| TechTree
+  TurnEnd --> Notification
+  Notification --> NextTurn
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Map | `Grid`, `Tile (terrain, feature, resource, owner)`, `FogOfWar` |
+| Civ | `Civilization`, `Treasury`, `Government`, `Religion`, `Researcher` |
+| City | `City`, `Population`, `District`, `Building`, `BuildQueue` |
+| Unit | `UnitType`, `UnitInstance`, `MovementOrder`, `Promotion` |
+| Tech | `TechNode`, `CivicNode`, `Prerequisites`, `Unlocks` |
+| Diplomacy | `Relation`, `Treaty`, `War`, `Trade` |
+| World | `TurnManager`, `EventDeck`, `NotificationQueue`, `VictoryCheck` |
+
+## 対応するコード設計
+
+巨大 state なので **イミュータブル更新** + **オーダーキュー** が安定する:
+
+```rust
+// crates/game-strat4x/src/state.rs
+pub struct WorldState {
+    pub turn: u32,
+    pub map:  Grid,
+    pub civs: Vec<Civilization>,        // インデックス安定 (削除しない)
+    pub fog:  HashMap<CivId, FogOfWar>,
+    pub events: EventDeck,
+    pub notifs: HashMap<CivId, Vec<Notification>>,
+}
+
+// crates/game-strat4x/src/orders.rs
+pub enum Order {
+    MoveUnit  { civ: CivId, unit: UnitId, path: Vec<Coord> },
+    BuildItem { civ: CivId, city: CityId, item: BuildItem },
+    SetResearch { civ: CivId, tech: TechId },
+    Diplomacy { from: CivId, to: CivId, action: DiploAction },
+    EndTurn   { civ: CivId },
+}
+
+// crates/game-strat4x/src/turn.rs
+pub fn advance_turn(world: &mut WorldState, orders: Vec<Order>) -> Vec<Notification> {
+    // 1. プレイヤーの orders を適用
+    for o in orders { apply_order(world, o); }
+    // 2. AI 各勢力の orders を生成 + 適用
+    let ai_orders = world.civs.iter()
+        .filter(|c| c.is_ai)
+        .flat_map(|c| ai::propose(world, c.id))
+        .collect::<Vec<_>>();
+    for o in ai_orders { apply_order(world, o); }
+    // 3. 都市生産・科学進行・税収
+    economy::tick(world);
+    // 4. ランダムイベント
+    let events = world.events.draw(world.turn);
+    for ev in events { event::apply(world, ev); }
+    // 5. 勝利条件チェック
+    if let Some(v) = victory::check(world) {
+        return vec![Notification::Victory(v)];
+    }
+    world.turn += 1;
+    // 6. notifications を返す
+    drain_notifs(world)
+}
+```
+
+```text
+src/
+  state.rs       WorldState aggregate
+  map/           Grid + Tile + FogOfWar
+  civ/           Civilization + Treasury + Government
+  city/          City + Population + Buildings
+  unit/          UnitType + UnitInstance + Promotion
+  tech/          TechTree + CivicTree
+  diplomacy/     Relations + Treaties
+  orders/        Order + applier
+  turn/          TurnManager + advance_turn
+  ai/            Strategic + Operational + Tactical layers
+  event/         EventDeck + chains
+  victory/       VictoryCondition checks
+  save/          serde + zstd
+  ui/            CityScreen, TechTreeUI, DiploScreen, Minimap
+```
+
+依存:
+- 純粋ロジックが大半なので **ユニットテストでターン進行を検証** できる作り
+- 描画は別 crate (大きすぎるため `game-strat4x-render` に分離推奨)

--- a/spec/game-template/vampire_survivors_like.md
+++ b/spec/game-template/vampire_survivors_like.md
@@ -1,0 +1,145 @@
+# バンサバライク テンプレート
+
+## 概要
+
+**Vampire Survivors** が確立した「自動攻撃 + 大量湧き敵 + 短時間ラン + ロード」 ゲームジャンル。
+代表作は **Vampire Survivors**, **Brotato**, **Halls of Torment**, **Soulstone Survivors**。
+
+コアループ:
+
+> 移動だけ手動 → 武器が自動発射 → 大量敵を倒す → 経験値 → レベルアップで武器/パッシブ追加 → 数百体規模の同時画面 → 30 分耐久 / 死亡
+
+設計上の特徴:
+
+- **大量エンティティ** (敵 1000+ / 弾 数百) を 60 fps で動かすため、 描画 + sim とも data-oriented (SoA) が事実上必須
+- **武器の組合せシナジー** がリプレイ性を担う
+- 移動以外プレイヤー操作なし → AI と弾道は完全に自走
+- セッションは 20-30 分の使い切り、 メタ進行 (お金 / 永久パッシブ) で長期動機
+
+## 必要不可欠な機能実装
+
+- `[entity-pool]` (新規) 敵 / 弾 / pickup の事前確保プール (毎フレーム alloc 回避)
+- `[spatial-hash]` (新規) 大量エンティティの近傍検索 (固定セル化)
+- `[health-system]` プレイヤー HP + 敵 HP (大量同時)
+- `[xp-pickup]` (新規) 撃破 → 経験値ジェム → 自動吸引 (磁石半径)
+- `[leveling]` レベルアップ → 武器 / パッシブ選択画面
+- `[weapon-auto-fire]` (新規) クールダウン駆動の自動武器
+- `[weapon-evolution]` (新規) 武器 + 必須パッシブ → 進化武器
+- `[wave-spawner]` (新規) 時間軸スクリプトに沿った敵スポーン (経過分単位)
+- `[damage-numbers]` (新規 / 任意) ダメージポップアップ
+- `[meta-progression]` (新規) ラン横断のお金 / 永久強化 / アンロック
+- `[score-system]` 撃破数 / 残り時間 / コイン
+
+## コアドメイン設計
+
+```mermaid
+flowchart LR
+  Time[Run Clock] --> Spawner[Wave Spawner]
+  Spawner --> EnemyPool
+  Player -->|emits| Movement
+  Movement --> Position
+  Position --> Camera
+  WeaponSlot[Weapon Slots] -->|每 cooldown| ProjectilePool
+  ProjectilePool -->|spatial hash| EnemyPool
+  EnemyPool -->|hit| Damage --> EnemyHP
+  EnemyHP -->|0| Drop[Drop XP / Gold]
+  Drop --> XPPool
+  XPPool -->|magnet| Player
+  Player --> XPLevel[XP Total]
+  XPLevel -->|threshold| LevelUpUI[Level-up Picker]
+  LevelUpUI --> WeaponSlot
+  RunEnd --> Meta[Meta Progression]
+```
+
+**境界づけられたコンテキスト**:
+
+| Context | 主な型 |
+|---------|--------|
+| Run | `RunClock`, `Score`, `Difficulty`, `WaveSpawner` |
+| Player | `PlayerActor`, `XPPool`, `WeaponSlots`, `PassiveSlots` |
+| Entity | `EnemyPool`, `ProjectilePool`, `XpGemPool`, `PickupPool` |
+| Spatial | `SpatialHash` (cell size 64-128 units) |
+| Meta | `Currency`, `Unlock`, `MetaUpgrade` |
+
+## 対応するコード設計
+
+データ指向で書く (Vec ベースの SoA):
+
+```rust
+// crates/game-vampsurv/src/enemies.rs — SoA pool
+pub struct EnemyPool {
+    pub alive:  Vec<bool>,        // 1000+
+    pub pos:    Vec<Vec2>,
+    pub vel:    Vec<Vec2>,
+    pub hp:     Vec<i32>,
+    pub kind:   Vec<EnemyKind>,
+}
+
+impl EnemyPool {
+    pub fn tick(&mut self, dt: f32, player: Vec2) {
+        for i in 0..self.alive.len() {
+            if !self.alive[i] { continue; }
+            let dir = (player - self.pos[i]).normalize_or_zero();
+            self.vel[i] = dir * speed_for(self.kind[i]);
+            self.pos[i] += self.vel[i] * dt;
+        }
+    }
+
+    pub fn kill(&mut self, i: usize) {
+        self.alive[i] = false;
+        // free index goes back into the pool's free-list
+    }
+}
+
+// crates/game-vampsurv/src/spatial_hash.rs
+pub struct SpatialHash {
+    cell: f32,
+    map: HashMap<(i32, i32), Vec<u32>>, // cell -> indices
+}
+
+impl SpatialHash {
+    pub fn rebuild(&mut self, pos: &[Vec2], alive: &[bool]) {
+        self.map.clear();
+        for (i, &p) in pos.iter().enumerate() {
+            if !alive[i] { continue; }
+            let key = (
+                (p.x / self.cell) as i32,
+                (p.y / self.cell) as i32,
+            );
+            self.map.entry(key).or_default().push(i as u32);
+        }
+    }
+    pub fn query(&self, c: Vec2, r: f32, mut visit: impl FnMut(u32)) {
+        let cmin = ((c.x - r) / self.cell) as i32;
+        let cmax = ((c.x + r) / self.cell) as i32;
+        let rmin = ((c.y - r) / self.cell) as i32;
+        let rmax = ((c.y + r) / self.cell) as i32;
+        for x in cmin..=cmax {
+            for y in rmin..=rmax {
+                if let Some(v) = self.map.get(&(x, y)) {
+                    for &i in v { visit(i); }
+                }
+            }
+        }
+    }
+}
+```
+
+```text
+src/
+  run/           RunClock + WaveSpawner + Difficulty
+  player/        Controller + XP + Slots
+  enemy/         EnemyPool (SoA)
+  projectile/    ProjectilePool (SoA)
+  pickup/        XpGem / Coin / Magnet
+  weapon/        Definitions + Cooldown + Evolution rules
+  spatial/       SpatialHash
+  meta/          Currency + Unlock + MetaUpgrade
+  ui/            LevelUpPicker + RunHUD + DamageText
+```
+
+依存:
+- `ergo_health` (プレイヤー HP は ergo、 敵は SoA で自前)
+- `ergo_score`
+- `ergo_input` (移動のみ)
+- 描画は GPU instancing (Pictor 側) が望ましい

--- a/spec/modules/overview.md
+++ b/spec/modules/overview.md
@@ -64,6 +64,10 @@ App版（Tauri Desktop）とWeb版（Axum Server）の**両方で同一ビジネ
 | ars-resource-depot | `resource-depot` | アセット管理 | 設計のみ |
 | ars-data-organizer | `data-organizer` | Blackboard変数、ゲーム設定値 | 設計のみ |
 | **ars-game-lexicon** | `game-lexicon` | ゲーム辞書 (Genre / Feature / Preset / Term)、 仕様駆動の seed データ + ローダ | **v0.1 (フレーム + 9 ジャンル seed)** |
+
+> 関連ドキュメント:
+> - [`spec/game-lexicon/`](../game-lexicon/) — Feature 単体の辞書 (TOML)
+> - [`spec/game-template/`](../game-template/) — 17 ジャンル分の実装ガイド (アクション / プラットフォーマー / バンサバライク / SLG / 4X / パズル / ローグライク / デッキビルド / MOBA / メトロイドヴァニア / ハクスラ / 格ゲー / 音ゲー / JRPG / OW / STG / FPS)
 | ars-auth | `auth` | 認証、セッション管理 | 設計のみ |
 | ars-collab | `collab` | WebSocket同期、プレゼンス、ロック | 設計のみ |
 | ars-secrets | `secrets` | シークレット管理（Keychain + TOML） | 設計のみ |


### PR DESCRIPTION
## 目的
\`spec/game-template/\` を新設し、 17 ジャンル分の「骨格ガイド」 を 1 ジャンル 1 md で整備する。 既存の \`spec/game-lexicon/\` (Feature 単体辞書) を補完し、 ウィザードや AI コード生成が「ジャンル → Feature セット」 の判断材料に使える。

## 17 ジャンル
action / platformer / vampire_survivors_like / slg_grid / strategy_4x / puzzle_casual / roguelike_berlin / deckbuilder_roguelike / moba / metroidvania / hack_and_slash / fighting / rhythm / jrpg / open_world / shmup / fps

代表作はそれぞれ SEKIRO / Mario / Vampire Survivors / Fire Emblem / Civ / Royal Match / NetHack / Slay the Spire / LoL / Hollow Knight / Diablo / Street Fighter / Beatmania / Dragon Quest / BotW / Gradius / Apex。

## 各テンプレの構成
1. 概要 (代表作 + コアループ + 特徴)
2. 必要不可欠な機能実装 (game-lexicon の Feature ID と相互参照)
3. コアドメイン設計 (Mermaid 図 + 境界づけられたコンテキスト)
4. 対応するコード設計 (Ars アクター + Ergo モジュール想定の疑似 Rust)

## game-lexicon との関係
- game-lexicon = 「Feature 単体の辞書」
- game-template = 「ジャンルごとに Feature をどう束ねるか」

\`spec/modules/overview.md\` から両方をリンク。

🤖 Generated with [Claude Code](https://claude.com/claude-code)