### PR TITLE
fix(pages): drop pip cache

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Install MkDocs + plugins
         run: |


### PR DESCRIPTION
Pages workflow が pip cache のため requirements.txt を要求して落ちていたので、 cache 設定を外す。