### PR TITLE
chore: prevent script injection in workflow_dispatch inputs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,12 +59,15 @@ jobs:
       # ── タグ・プラットフォームを計算 ──
       - name: Compute build parameters
         id: params
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
         run: |
           $sha     = "${{ github.sha }}".Substring(0, 7)
           $ref     = "${{ github.ref }}"
           $refName = "${{ github.ref_name }}"
-          $input   = "${{ inputs.version }}"
-          $plat    = "${{ inputs.platform }}"
+          $input   = "$env:INPUT_VERSION"
+          $plat    = "$env:INPUT_PLATFORM"
 
           # Tags
           $tags = [System.Collections.Generic.List[string]]::new()

--- a/.github/workflows/update-web-version.yml
+++ b/.github/workflows/update-web-version.yml
@@ -37,15 +37,18 @@ jobs:
 
       - name: Calculate new version
         id: version
+        env:
+          CUSTOM_VERSION: ${{ inputs.custom_version }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
-          if [ -n "${{ inputs.custom_version }}" ]; then
-            NEW_VERSION="${{ inputs.custom_version }}"
+          if [ -n "$CUSTOM_VERSION" ]; then
+            NEW_VERSION="$CUSTOM_VERSION"
           else
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-            case "${{ inputs.bump_type }}" in
+            case "$BUMP_TYPE" in
               major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
               minor) NEW_VERSION="$MAJOR.$((MINOR + 1)).0" ;;
               patch) NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))" ;;
@@ -56,19 +59,25 @@ jobs:
           echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
 
       - name: Update package.json version
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
-          npm version "${{ steps.version.outputs.new }}" --no-git-tag-version
+          npm version "$NEW_VERSION" --no-git-tag-version
 
       - name: Update Cargo.toml version
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
-          sed -i "0,/^version = /s/^version = \".*\"/version = \"${{ steps.version.outputs.new }}\"/" src-tauri/Cargo.toml
+          sed -i "0,/^version = /s/^version = \".*\"/version = \"$NEW_VERSION\"/" src-tauri/Cargo.toml
 
       - name: Update tauri.conf.json version
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
           node -e "
             const fs = require('fs');
             const conf = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json', 'utf8'));
-            conf.version = '${{ steps.version.outputs.new }}';
+            conf.version = process.env.NEW_VERSION;
             fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(conf, null, 2) + '\n');
           "
 
@@ -85,11 +94,13 @@ jobs:
           path: ars-editor/dist/
 
       - name: Commit version update
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
           cd ..
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ars-editor/package.json ars-editor/src-tauri/Cargo.toml ars-editor/src-tauri/tauri.conf.json
-          git commit -m "chore: bump web version to v${{ steps.version.outputs.new }}"
-          git tag "v${{ steps.version.outputs.new }}"
+          git commit -m "chore: bump web version to v$NEW_VERSION"
+          git tag "v$NEW_VERSION"
           git push origin HEAD --tags


### PR DESCRIPTION
`workflow_dispatch` の `inputs.*` を run スクリプトへ直接展開していた箇所を `env:` 経由に変更し script injection を防止 (docker-publish / update-web-version)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)